### PR TITLE
Parser generates an hpp instead of cpp

### DIFF
--- a/make/models
+++ b/make/models
@@ -4,15 +4,15 @@
 MODEL_HEADER := stan/src/stan/model/model_header.hpp
 CMDSTAN_MAIN := src/cmdstan/main.cpp
 
-.PRECIOUS: %.cpp %.o
-$(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE) : %.cpp %.stan bin/stanc$(EXE) bin/print$(EXE)
+.PRECIOUS: %.hpp %.o
+$(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE) : %.hpp %.stan bin/stanc$(EXE) bin/print$(EXE)
 	@echo ''
 	@echo '--- Linking C++ model ---'
 	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< $(LDLIBS)
 
-.PRECIOUS: %.cpp
-%.cpp : %.stan $(MODEL_HEADER) bin/stanc$(EXE)
+.PRECIOUS: %.hpp
+%.hpp : %.stan $(MODEL_HEADER) bin/stanc$(EXE)
 	@echo ''
 	@echo '--- Translating Stan model to C++ code ---'
-	$(WINE) bin$(PATH_SEPARATOR)stanc$(EXE) $< --o=$@ --no_main
+	$(WINE) bin$(PATH_SEPARATOR)stanc$(EXE) $< --o=$@
 

--- a/makefile
+++ b/makefile
@@ -69,11 +69,10 @@ PATH_SEPARATOR = /
 %.o : %.cpp
 	$(COMPILE.c) -O$O $(OUTPUT_OPTION) $<
 
-%$(EXE) : %.cpp %.stan 
+%$(EXE) : %.hpp %.stan 
 	@echo ''
 	@echo '--- Linking C++ model ---'
 	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< $(LDLIBS)
-
 
 ##
 # Tell make the default way to compile a .o file.
@@ -139,7 +138,7 @@ endif
 	@echo ''
 	@echo '  This target will:'
 	@echo '  1. Build the Stan compiler: bin/stanc$(EXE).'
-	@echo '  2. Use the Stan compiler to generate C++ code, foo/bar.cpp.'
+	@echo '  2. Use the Stan compiler to generate C++ code, foo/bar.hpp.'
 	@echo '  3. Compile the C++ code using $(CC) to generate foo/bar$(EXE)'
 	@echo ''
 	@echo '  Example - Sample from a normal: stan/example-models/basic_distributions/normal.stan'
@@ -192,7 +191,7 @@ build: bin/stanc$(EXE) bin/print$(EXE)
 
 clean: clean-manual
 	$(RM) -r test
-	$(RM) $(wildcard $(patsubst %.stan,%.cpp,$(TEST_MODELS)))
+	$(RM) $(wildcard $(patsubst %.stan,%.hpp,$(TEST_MODELS)))
 	$(RM) $(wildcard $(patsubst %.stan,%$(EXE),$(TEST_MODELS)))
 
 clean-manual:

--- a/runCmdStanTests.py
+++ b/runCmdStanTests.py
@@ -41,7 +41,7 @@ def mungeName(name):
     if (name.startswith("src")):
         name = name.replace("src/","",1)
     if (name.endswith(testsfx)):
-        name = name.replace(testsfx,"")
+        name = name.replace(testsfx,"_test")
         if (isWin()):
             name += winsfx
             name = name.replace("\\","/")

--- a/runCmdStanTests.py
+++ b/runCmdStanTests.py
@@ -1,0 +1,181 @@
+#!/usr/bin/python
+
+"""
+replacement for runtest target in Makefile
+arg 1:  test dir or test file
+"""
+
+import os
+import os.path
+import platform
+import sys
+import subprocess
+import time
+
+winsfx = ".exe"
+testsfx = "_test.cpp"
+debug = False
+batchSize = 25
+
+def usage():
+    sys.stdout.write('usage: %s <path/test/dir(/files)>\n' % sys.argv[0])
+    sys.stdout.write('or\n')
+    sys.stdout.write('       %s -j<#cores> <path/test/dir(/files)>\n' % sys.argv[0])
+    sys.exit(0)
+
+def stopErr(msg, returncode):
+    sys.stderr.write('%s\n' % msg)
+    sys.stderr.write('exit now (%s)\n' % time.strftime('%x %X %Z'))
+    sys.exit(returncode)
+
+def isWin():
+    if (platform.system().lower().startswith("windows")
+        or os.name.lower().startswith("windows")):
+        return True
+    return False
+
+# set up good makefile target name    
+def mungeName(name):
+    if (debug):
+        print("munge input: %s" % name)
+    if (name.startswith("src")):
+        name = name.replace("src/","",1)
+    if (name.endswith(testsfx)):
+        name = name.replace(testsfx,"")
+        if (isWin()):
+            name += winsfx
+            name = name.replace("\\","/")
+
+    name = name.replace(" ", "\\ ").replace("(","\\(").replace(")","\\)")
+    if (debug):
+        print("munge return: %s" % name)
+    return name
+
+
+def doCommand(command):
+    print("------------------------------------------------------------")
+    print("%s" % command)
+    p1 = subprocess.Popen(command,shell=True)
+    p1.wait()
+    if (not(p1.returncode == None) and not(p1.returncode == 0)):
+        stopErr('%s failed' % command, p1.returncode)
+
+def makeTest(name, j):
+    target = mungeName(name)
+    if (j == None):
+        command = 'make %s' % target
+    else:
+        command = 'make -j%d %s' % (j,target)
+    doCommand(command)
+
+def makeBuild(j):
+    if (j == None):
+        command = 'make build'
+    else:
+        command = 'make -j%d build' % j
+    doCommand(command)
+
+
+def makeTestModel(target, j):
+    if (j == None):
+        command = 'make %s' % target
+    else:
+        command = 'make -j%d %s' % (j,target)
+    doCommand(command)
+
+    
+def makeTests(dirname, filenames, j):
+    targets = list()
+    for name in filenames:
+        if (not name.endswith(testsfx)):
+            continue
+        target = "/".join([dirname,name])
+        target = mungeName(target)
+        targets.append(target)
+    if (len(targets) > 0):
+        if (debug):
+            print('# targets: %d' % len(targets))
+        startIdx = 0
+        endIdx = batchSize
+        while (startIdx < len(targets)):
+            if (j == None):
+                command = 'make %s' % ' '.join(targets[startIdx:endIdx])
+            else:
+                command = 'make -j%d %s' % (j,' '.join(targets[startIdx:endIdx]))
+            if (debug):
+                print('start %d, end %d' % (startIdx,endIdx))
+                print(command)
+            doCommand(command)
+            startIdx = endIdx
+            endIdx = startIdx + batchSize
+            if (endIdx > len(targets)):
+                endIdx = len(targets)
+         
+
+def runTest(name):
+    executable = mungeName(name).replace("/",os.sep)
+    xml = mungeName(name).replace(winsfx, "")
+    command = '%s --gtest_output="xml:%s.xml"' % (executable, xml)
+    doCommand(command)
+
+def main():
+    if (len(sys.argv) < 2):
+        usage()
+
+    argsIdx = 1
+    j = None
+    if (sys.argv[1].startswith("-j")):
+        argsIdx = 2
+        if (len(sys.argv) < 3):
+            usage()
+        else:
+            j = sys.argv[1].replace("-j","")
+            try:
+                jprime = int(j)
+                if (jprime < 1 or jprime > 16):
+                    stopErr("bad value for -j flag",-1)                    
+                j = jprime
+            except ValueError:
+                stopErr("bad value for -j flag",-1)
+
+
+    # pass 0:  make build
+    makeBuild(j)
+
+    # pass 1:  call make to compile test targets
+    for i in range(argsIdx,len(sys.argv)):
+        testname = sys.argv[i]
+        if (debug):
+            print("testname: %s" % testname)
+        if (not(os.path.exists(testname))):
+            stopErr('%s: no such file or directory' % testname,-1)
+        if (not(os.path.isdir(testname))):
+            if (not(testname.endswith(testsfx))):
+                stopErr('%s: not a testfile' % testname,-1)
+            if (debug):
+                print("make single test: %s" % testname)
+            makeTest(testname,j)
+        else:
+            for root, dirs, files in os.walk(testname):
+                if (debug):
+                    print("make root: %s" % root)
+                makeTests(root,files,j)
+
+    # pass 2:  run test targets
+    for i in range(argsIdx,len(sys.argv)):
+        testname = sys.argv[i]
+        if (not(os.path.isdir(testname))):
+            if (debug):
+                print("run single test: %s" % testname)
+            runTest(testname)
+        else:
+            for root, dirs, files in os.walk(testname):
+                for name in files:
+                    if (name.endswith(testsfx)):
+                        if (debug):
+                            print("run dir,test: %s,%s" % (root,name))
+                        runTest(os.sep.join([root,name]))
+
+    
+if __name__ == "__main__":
+    main()

--- a/src/docs/cmdstan-guide/stanc.tex
+++ b/src/docs/cmdstan-guide/stanc.tex
@@ -39,7 +39,7 @@ For Linux and Mac:
 \begin{quote}
 \begin{Verbatim}[fontshape=sl]
 > cd <cmdstan-home>
-> bin/stanc --name=bernoulli --o=bernoulli.cpp \
+> bin/stanc --name=bernoulli --o=bernoulli.hpp \
   stan/example-models/basic_estimators/bernoulli.stan 
 \end{Verbatim}
 \end{quote}
@@ -51,7 +51,7 @@ For Windows:
 \begin{quote}
 \begin{Verbatim}[fontshape=sl]
 > cd <cmdstan-home>
-> bin\stanc.exe --name=bernoulli --o=bernoulli.cpp ^
+> bin\stanc.exe --name=bernoulli --o=bernoulli.hpp ^
     stan/example-models/basic_estimators/bernoulli.stan 
 \end{Verbatim}
 \end{quote}
@@ -67,7 +67,7 @@ contain only alphanumeric characters (\code{a--z}, \code{A--Z}, and
 any \Cpp reserved keyword.  
 
 The \Cpp code implementing the class is written to the file
-\code{bernoulli.cpp} in the current directory.  The final argument,
+\code{bernoulli.hpp} in the current directory.  The final argument,
 \code{bernoulli.stan}, is the file from which to read the \Stan
 program.
 
@@ -105,7 +105,7 @@ Default: {\tt {\slshape class\_name = model\_file}\_model}
 \mbox{ } \\ 
 Specify the name of the file into which the generated \Cpp is written.
 \\[2pt]
-Default: {\tt {\slshape cpp\_file\_name} = {\slshape class\_name}.cpp}
+Default: {\tt {\slshape cpp\_file\_name} = {\slshape class\_name}.hpp}
 %
 \end{description}
 


### PR DESCRIPTION
#### Summary:

Parser now generates a `.hpp` file instead of a `.cpp file` from a Stan program.

#### Intended Effect:

The Stan program has been generating a header file. Just changing the build process so it generates the right file name.

#### How to Verify:

Build a Stan program, you'll now see a `.hpp` file instead of a `.cpp` file that's been auto-generated.

#### Side Effects:

None.

#### Documentation:

Updated.

#### Reviewer Suggestions: 

Anyone.