### PR TITLE
Stan incompatibility: Boost version

### DIFF
--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ AR = ar
 ##
 STANAPI_HOME ?= stan/
 EIGEN ?= $(STANAPI_HOME)lib/eigen_3.2.2
-BOOST ?= $(STANAPI_HOME)lib/boost_1.54.0
+BOOST ?= $(STANAPI_HOME)lib/boost_1.55.0
 GTEST ?= $(STANAPI_HOME)lib/gtest_1.7.0
 
 ##


### PR DESCRIPTION
Fixes the incompatibility with the current Stan development version by updating the makefile.