### PR TITLE
Updates Stan to develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ os:
 compiler:
   - clang
 
+before_install:
+  - git submodule update --init --recursive
+
 before_script: echo "CC=$CXX" > make/local
 
 matrix:

--- a/makefile
+++ b/makefile
@@ -28,7 +28,7 @@ STANAPI_HOME ?= stan/
 EIGEN ?= $(STANAPI_HOME)lib/eigen_3.2.4
 BOOST ?= $(STANAPI_HOME)lib/boost_1.58.0
 GTEST ?= $(STANAPI_HOME)lib/gtest_1.7.0
-MATH  ?= $(STANAPI_HOME)lib/stan_math_2.6.3
+MATH  ?= $(STANAPI_HOME)lib/stan_math_2.7.0
 
 ##
 # Set default compiler options.


### PR DESCRIPTION
#### Summary:

Updating the Stan submodule to develop. It wasn't building due to the math library folder changing.


#### How to Verify:

Run tests.

#### Side Effects:

None.

#### Documentation:

None.
