### PR TITLE
updating stan-update make target

### DIFF
--- a/make/libstan
+++ b/make/libstan
@@ -1,11 +1,11 @@
-TEMPLATE_INSTANTIATION := $(shell find stan/src/stan/lang -type f -name '*_inst.cpp')
-TEMPLATE_INSTANTIATION += $(shell find stan/src/stan/lang -type f -name '*_def.cpp')
-TEMPLATE_INSTANTIATION := $(TEMPLATE_INSTANTIATION:stan/src/%.cpp=bin/%.o)
+TEMPLATE_INSTANTIATION := $(shell find $(STANAPI_HOME)src/stan/lang -type f -name '*_inst.cpp')
+TEMPLATE_INSTANTIATION += $(shell find $(STANAPI_HOME)src/stan/lang -type f -name '*_def.cpp')
+TEMPLATE_INSTANTIATION := $(TEMPLATE_INSTANTIATION:$(STANAPI_HOME)src/%.cpp=bin/%.o)
 bin/libstanc.a : $(TEMPLATE_INSTANTIATION)
 	@mkdir -p $(dir $@)
 	$(AR) -rs bin/libstanc.a $(TEMPLATE_INSTANTIATION)
 
-$(TEMPLATE_INSTANTIATION) : bin/stan/%.o : stan/src/stan/%.cpp
+$(TEMPLATE_INSTANTIATION) : bin/stan/%.o : $(STANAPI_HOME)src/stan/%.cpp
 	@mkdir -p $(dir $@)
 	$(COMPILE.c) -O$(O_STANC) $(OUTPUT_OPTION) $<
 

--- a/make/models
+++ b/make/models
@@ -1,7 +1,7 @@
 ##
 # Models (to be passed through stanc)
 ##
-MODEL_HEADER := stan/src/stan/model/model_header.hpp
+MODEL_HEADER := $(STANAPI_HOME)src/stan/model/model_header.hpp
 CMDSTAN_MAIN := src/cmdstan/main.cpp
 
 .PRECIOUS: %.hpp %.o

--- a/makefile
+++ b/makefile
@@ -219,8 +219,7 @@ clean-all: clean
 
 .PHONY: stan-update
 stan-update :
-	git submodule init
-	git submodule update --recursive
+	git submodule update --init --recursive
 
 stan-update/%: stan-update
 	cd stan && git fetch --all && git checkout $* && git pull


### PR DESCRIPTION
#### Summary:

Updates the `stan-update` make target to grab submodules.

#### Intended Effect:

The Stan Math Library is now a submodule of Stan and the make target needs to grab submodules recursively.

#### How to Verify:

Clone cmdstan fresh.

From within the cmdstan directory, type:
```
> make stan-update
```

This will set up Stan including the Math library.

#### Side Effects:

Whatever git does.

#### Documentation:

Already in the makefile help target.

