### PR TITLE
removed test reference from help target

### DIFF
--- a/makefile
+++ b/makefile
@@ -168,8 +168,6 @@ endif
 	@echo '                     branch or commit hash.'
 	@echo '  - stan-revert    : Reverts changes made to Stan library back to'
 	@echo '                     what is in the repository.'
-	@echo '  Test targets:'
-	@echo '  - src/test/interface: Runs tests on CmdStan interface.'
 	@echo ''
 	@echo 'Model related:'
 	@echo '- bin/stanc$(EXE): Build the Stan compiler.'


### PR DESCRIPTION
#### Summary:

Cleans up `help` make target.

#### How to Verify:

Run 
```
> make help
```

#### Side Effects:

None.

#### Documentation:

Updated.
