### PR TITLE
Feature/issue advi lp

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -7,7 +7,7 @@ GTEST_MAIN = $(GTEST)/src/gtest_main.cc
 CFLAGS_GTEST += -I $(GTEST)/include -I $(GTEST)
 
 ##
-# target path_separator for use in some tests that need to 
+# target path_separator for use in some tests that need to
 # call executables.
 ##
 .PHONY: path_separator
@@ -25,8 +25,8 @@ TEST_MODELS := $(shell find src/test/test-models -name '*.stan' -type f)
 ##
 # Target to verify header files are coherent
 ##
-HEADER_TESTS := $(addsuffix -test,$(shell find src/cmdstan -name '*.hpp' -type f)) 
-ifeq ($(OS),win) 
+HEADER_TESTS := $(addsuffix -test,$(shell find src/cmdstan -name '*.hpp' -type f))
+ifeq ($(OS),win)
   DEV_NULL = nul
 else
   DEV_NULL = /dev/null
@@ -42,7 +42,7 @@ test/dummy.cpp:
 
 ##
 # Build the google test library.
-## 
+##
 $(LIBGTEST): $(LIBGTEST)(test/gtest.o)
 
 test/gtest.o: $(GTEST)/src/gtest-all.cc
@@ -77,7 +77,7 @@ endif
 ####
 ## These make rules apply if SECONDEXPANSION is available
 ## in make.
-#### 
+####
 ifneq ($(filter second-expansion,$(.FEATURES)),)
 ##
 # Defining the test target implicit static rule.
@@ -100,9 +100,9 @@ $(TEST_TARGETS): src/test/%: $$(filter $$(patsubst src/$$(PERCENT),$$(PERCENT),$
 	@echo 'Ran '$(words $(filter test/%,$^))' tests for '$@
 else
 ####
-## Warning for developers that don't have a 
+## Warning for developers that don't have a
 ## current enough version of make (3.81 or higher).
-#### 
+####
 .PHONY: $(TEST_TARGETS)
 $(TEST_TARGETS):
 	@echo ''
@@ -120,6 +120,7 @@ test/interface/command_test.o: $(addsuffix $(EXE),$(addprefix src/test/test-mode
 test/interface/csv_header_consistency_test.o: src/test/test-models/csv_header_consistency$(EXE)
 test/interface/fixed_param_sampler_test.o: $(addsuffix $(EXE),$(addprefix src/test/test-models/, empty proper))
 test/interface/optimization_output_test.o: src/test/test-models/optimization_output$(EXE)
+test/interface/variational_output_test.o: src/test/test-models/variational_output$(EXE)
 test/interface/print_test.o: src/test/interface/matrix_output.csv bin/print$(EXE)
 test/interface/print_uninitialized_test.o: src/test/test-models/print_uninitialized$(EXE)
 test/interface/services/argument_configuration_test.o: src/test/test-models/test_model$(EXE)

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -818,7 +818,7 @@ namespace stan {
         if (algo->value() == "fullrank") {
           if (output_stream) {
             std::vector<std::string> names;
-            names.push_back("lp");
+            names.push_back("lp__");
             model.constrained_param_names(names, true, true);
 
             (*output_stream) << names.at(0);
@@ -848,7 +848,7 @@ namespace stan {
         if (algo->value() == "meanfield") {
           if (output_stream) {
             std::vector<std::string> names;
-            names.push_back("lp");
+            names.push_back("lp__");
             model.constrained_param_names(names, true, true);
 
             (*output_stream) << names.at(0);

--- a/src/docs/cmdstan-guide/getting-started.tex
+++ b/src/docs/cmdstan-guide/getting-started.tex
@@ -697,20 +697,20 @@ output for sampling, first dumping the entire set of parameters used.
 #   file = output.csv (Default)
 #   diagnostic_file =  (Default)
 #   refresh = 100 (Default)
-lp,theta
-0,0.221171
-0,0.166458
-0,0.297987
-0,...
-0,...
-0,...
+lp__,theta
+-6.77173,0.223462
+-6.74816,0.252055
+-6.92751,0.180521
+-7.25717,0.13987
+-6.91783,0.182266
+...
 \end{Verbatim}
 \end{quote}
 %
 Note that everything is a comment other than a line for the header,
-and a line for the values.  Here, the header indicates the
-unnormalized log probability with \code{lp\_\_}, which is not evaluated
-in the variational algorithm. The ELBO is also not stored unless a diagnostic
+and a line for the values. The header indicates the
+unnormalized log probability with \code{lp\_\_} based on the variational
+parameters. The ELBO is not stored unless a diagnostic
 option is given. See \refsection{stan-command-line-options} for more details.
 The first line is special: it is the mean of the variational approximation.
 The rest of the output contains \code{output\_samples} number of samples

--- a/src/test/interface/variational_output_test.cpp
+++ b/src/test/interface/variational_output_test.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include <test/utility.hpp>
+#include <stan/mcmc/chains.hpp>
+#include <fstream>
+
+using cmdstan::test::convert_model_path;
+using cmdstan::test::run_command;
+using cmdstan::test::run_command_output;
+
+class CmdStan : public testing::Test {
+ public:
+  void SetUp() {
+    std::vector<std::string> model_path;
+    model_path.push_back("src");
+    model_path.push_back("test");
+    model_path.push_back("test-models");
+    model_path.push_back("variational_output");
+
+    output_file = "test/output.csv";
+
+    base_command = convert_model_path(model_path)
+      + " output file=" + output_file;
+
+    y11 = "y[1,1]";
+    y12 = "y[1,2]";
+    y21 = "y[2,1]";
+    y22 = "y[2,2]";
+  }
+
+  stan::mcmc::chains<> parse_output_file() {
+    std::ifstream output_stream;
+    output_stream.open(output_file.data());
+
+    stan::io::stan_csv parsed_output = stan::io::stan_csv_reader::parse(output_stream, 0);
+    stan::mcmc::chains<> chains(parsed_output);
+    output_stream.close();
+    return chains;
+  }
+
+  std::string base_command;
+  std::string output_file;
+  std::string y11, y12, y21, y22;
+};
+
+
+TEST_F(CmdStan, variational_default) {
+  run_command_output out = run_command(base_command + " variational");
+
+  ASSERT_EQ(0, out.err_code);
+
+  stan::mcmc::chains<> chains = parse_output_file();
+  ASSERT_EQ(1, chains.num_chains());
+  ASSERT_EQ(1001, chains.num_samples());
+}
+
+TEST_F(CmdStan, variational_meanfield) {
+  run_command_output out = run_command(base_command + " variational algorithm=meanfield");
+
+  ASSERT_EQ(0, out.err_code);
+
+  stan::mcmc::chains<> chains = parse_output_file();
+  ASSERT_EQ(1, chains.num_chains());
+  ASSERT_EQ(1001, chains.num_samples());
+}
+
+TEST_F(CmdStan, variational_fullrank) {
+  run_command_output out = run_command(base_command + " variational algorithm=fullrank");
+
+  ASSERT_EQ(0, out.err_code);
+
+  stan::mcmc::chains<> chains = parse_output_file();
+  ASSERT_EQ(1, chains.num_chains());
+  ASSERT_EQ(1001, chains.num_samples());
+}

--- a/src/test/test-models/variational_output.stan
+++ b/src/test/test-models/variational_output.stan
@@ -1,0 +1,9 @@
+parameters {
+  real y[2,2];
+}
+model {
+  y[1,1] ~ normal(1,1);
+  y[2,1] ~ normal(100,1);
+  y[1,2] ~ normal(10000,1);
+  y[2,2] ~ normal(1000000,1);
+}


### PR DESCRIPTION
#### Summary:
Renames `lp` to `lp__` in output of variational inference.

#### Intended Effect:
N/A

#### How to Verify:
Run models by building them, then running them, e.g. `make examples/bernoulli/bernoulli && cd examples/bernoulli && ./bernoulli variational data file=bernoulli.data.R`.

#### Side Effects:
N/A

#### Documentation:
Changed variational inference documentation to reflect that `lp__` is actually calculated now. See [stan pull request](https://github.com/stan-dev/stan/pull/1539)

#### Reviewer Suggestions:
N/A