### PR TITLE
Adding a test script that tests CmdStan, Stan, and the Stan Math Library

### DIFF
--- a/test-all.sh
+++ b/test-all.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+echo 'Running:'
+echo '  - CmdStan tests'
+echo '  - Stan tests'
+echo '  - Stan Math Library tests'
+echo ''
+echo '------------------------------------------------------------'
+echo 'CmdStan tests'
+./runCmdStanTests.py src/test/interface
+
+
+echo ''
+echo '------------------------------------------------------------'
+echo 'Stan tests'
+pushd stan
+./runTests.py src/test
+popd
+
+
+echo ''
+echo '------------------------------------------------------------'
+echo 'Stan Math Library tests'
+pushd stan/lib/stan_math_2.7.0
+./runTests.py test/unit
+./runTests.py test/prob
+popd


### PR DESCRIPTION
#### Summary:

Adds a test script called `test-all.sh` at the top level that tests CmdStan, Stan, and the Stan Math Library.

#### Intended Effect:

Hopefully this set of tests will pass on Novartis, but we can't verify on our systems.

#### How to Verify:

`> ./test-all.sh`

#### Side Effects:

None.

#### Documentation:

Script is self-explanatory.


N/A.