### PR TITLE
Updates CmdStan to use the libraries included in the Stan Math Library

### DIFF
--- a/make/libstan
+++ b/make/libstan
@@ -1,11 +1,11 @@
-TEMPLATE_INSTANTIATION := $(shell find $(STANAPI_HOME)src/stan/lang -type f -name '*_inst.cpp')
-TEMPLATE_INSTANTIATION += $(shell find $(STANAPI_HOME)src/stan/lang -type f -name '*_def.cpp')
-TEMPLATE_INSTANTIATION := $(TEMPLATE_INSTANTIATION:$(STANAPI_HOME)src/%.cpp=bin/%.o)
+TEMPLATE_INSTANTIATION := $(shell find $(STAN)src/stan/lang -type f -name '*_inst.cpp')
+TEMPLATE_INSTANTIATION += $(shell find $(STAN)src/stan/lang -type f -name '*_def.cpp')
+TEMPLATE_INSTANTIATION := $(TEMPLATE_INSTANTIATION:$(STAN)src/%.cpp=bin/%.o)
 bin/libstanc.a : $(TEMPLATE_INSTANTIATION)
 	@mkdir -p $(dir $@)
 	$(AR) -rs bin/libstanc.a $(TEMPLATE_INSTANTIATION)
 
-$(TEMPLATE_INSTANTIATION) : bin/stan/%.o : $(STANAPI_HOME)src/stan/%.cpp
+$(TEMPLATE_INSTANTIATION) : bin/stan/%.o : $(STAN)src/stan/%.cpp
 	@mkdir -p $(dir $@)
 	$(COMPILE.c) -O$(O_STANC) $(OUTPUT_OPTION) $<
 

--- a/make/models
+++ b/make/models
@@ -1,7 +1,7 @@
 ##
 # Models (to be passed through stanc)
 ##
-MODEL_HEADER := $(STANAPI_HOME)src/stan/model/model_header.hpp
+MODEL_HEADER := $(STAN)src/stan/model/model_header.hpp
 CMDSTAN_MAIN := src/cmdstan/main.cpp
 
 .PRECIOUS: %.hpp %.o

--- a/makefile
+++ b/makefile
@@ -28,7 +28,7 @@ STANAPI_HOME ?= stan/
 EIGEN ?= $(STANAPI_HOME)lib/eigen_3.2.4
 BOOST ?= $(STANAPI_HOME)lib/boost_1.58.0
 GTEST ?= $(STANAPI_HOME)lib/gtest_1.7.0
-MATH  ?= $(STANAPI_HOME)lib/stan_math_2.7.0
+MATH  ?= $(STANAPI_HOME)lib/stan_math
 
 ##
 # Set default compiler options.

--- a/makefile
+++ b/makefile
@@ -24,16 +24,14 @@ AR = ar
 ##
 # Library locations
 ##
-STANAPI_HOME ?= stan/
-EIGEN ?= $(STANAPI_HOME)lib/eigen_3.2.4
-BOOST ?= $(STANAPI_HOME)lib/boost_1.58.0
-GTEST ?= $(STANAPI_HOME)lib/gtest_1.7.0
-MATH  ?= $(STANAPI_HOME)lib/stan_math
+STAN ?= stan/
+MATH ?= $(STAN)lib/stan_math/
+-include $(MATH)make/libraries
 
 ##
 # Set default compiler options.
 ## 
-CFLAGS = -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -I src -I $(STANAPI_HOME)src -isystem $(MATH) -isystem $(EIGEN) -isystem $(BOOST) -Wall -pipe -DEIGEN_NO_DEBUG
+CFLAGS = -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -I src -I $(STAN)src -isystem $(MATH) -isystem $(EIGEN) -isystem $(BOOST) -Wall -pipe -DEIGEN_NO_DEBUG
 CFLAGS_GTEST = -DGTEST_USE_OWN_TR1_TUPLE
 LDLIBS =
 LDLIBS_STANC = -Lbin -lstanc
@@ -47,7 +45,7 @@ CMDSTAN_VERSION := 2.7.0
 # - CC_MAJOR: major version of CC
 # - CC_MINOR: minor version of CC
 ##
--include $(STANAPI_HOME)make/detect_cc
+-include $(STAN)make/detect_cc
 
 # OS is set automatically by this script
 ##
@@ -57,12 +55,12 @@ CMDSTAN_VERSION := 2.7.0
 #   - CFLAGS_GTEST
 #   - EXE
 ##
--include $(STANAPI_HOME)make/detect_os
+-include $(STAN)make/detect_os
 
 ##
 # Get information about the version of make.
 ##
--include $(STANAPI_HOME)make/detect_make
+-include $(STAN)make/detect_make
 
 ##
 # Tell make the default way to compile a .o file.
@@ -85,7 +83,7 @@ bin/%.o : src/%.cpp
 ##
 # Tell make the default way to compile a .o file.
 ##
-bin/stan/%.o : $(STANAPI_HOME)src/stan/%.cpp
+bin/stan/%.o : $(STAN)src/stan/%.cpp
 	@mkdir -p $(dir $@)
 	$(COMPILE.c) -O$O $(OUTPUT_OPTION) $<
 
@@ -210,7 +208,7 @@ endif
 -include make/models   # models
 -include make/tests
 -include make/command  # bin/stanc, bin/print
--include $(STANAPI_HOME)make/manual
+-include $(STAN)make/manual
 
 .PHONY: build
 build: bin/stanc$(EXE) bin/print$(EXE)

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -114,15 +114,15 @@
 #include <stan/services/optimization/do_bfgs_optimize.hpp>
 
 // FIXME: These belong to the interfaces and should be templated out here
-#include <stan/interface/callback/noop_callback.hpp>
-#include <stan/interface/var_context_factory/dump_factory.hpp>
-#include <stan/interface/recorder/csv.hpp>
-#include <stan/interface/recorder/filtered_values.hpp>
-#include <stan/interface/recorder/messages.hpp>
-#include <stan/interface/recorder/noop.hpp>
-#include <stan/interface/recorder/recorder.hpp>
-#include <stan/interface/recorder/sum_values.hpp>
-#include <stan/interface/recorder/values.hpp>
+#include <stan/interface_callbacks/interrupt/noop.hpp>
+#include <stan/interface_callbacks/var_context_factory/dump_factory.hpp>
+#include <stan/interface_callbacks/writer/csv.hpp>
+#include <stan/interface_callbacks/writer/filtered_values.hpp>
+#include <stan/interface_callbacks/writer/messages.hpp>
+#include <stan/interface_callbacks/writer/noop.hpp>
+#include <stan/interface_callbacks/writer/base_writer.hpp>
+#include <stan/interface_callbacks/writer/sum_values.hpp>
+#include <stan/interface_callbacks/writer/values.hpp>
 
 #include <fstream>
 #include <iostream>
@@ -253,8 +253,8 @@ namespace stan {
       std::string init = dynamic_cast<stan::services::string_argument*>(
                          parser.arg("init"))->value();
 
-      interface::var_context_factory::dump_factory var_context_factory;
-      if (!init::initialize_state<interface::var_context_factory::dump_factory>
+      interface_callbacks::var_context_factory::dump_factory var_context_factory;
+      if (!init::initialize_state<interface_callbacks::var_context_factory::dump_factory>
           (init, cont_params, model, base_rng, &std::cout,
            var_context_factory))
         return stan::services::error_codes::SOFTWARE;
@@ -380,7 +380,7 @@ namespace stan {
           }
           return_code = stan::services::error_codes::OK;
         } else if (algo->value() == "bfgs") {
-          interface::callback::noop_callback callback;
+          interface_callbacks::interrupt::noop callback;
           typedef stan::optimization::BFGSLineSearch
             <Model,stan::optimization::BFGSUpdate_HInv<> > Optimizer;
           Optimizer bfgs(model, cont_vector, disc_vector, &std::cout);
@@ -405,7 +405,7 @@ namespace stan {
                                          save_iterations, refresh,
                                          callback);
         } else if (algo->value() == "lbfgs") {
-          interface::callback::noop_callback callback;
+          interface_callbacks::interrupt::noop callback;
           typedef stan::optimization::BFGSLineSearch
             <Model,stan::optimization::LBFGSUpdate<> > Optimizer;
 
@@ -473,14 +473,14 @@ namespace stan {
                   << std::endl << std::endl;
         std::cout << std::endl;
 
-        interface::recorder::csv sample_recorder(output_stream, "# ");
-        interface::recorder::csv diagnostic_recorder(diagnostic_stream, "# ");
-        interface::recorder::messages message_recorder(&std::cout, "# ");
+        interface_callbacks::writer::csv sample_writer(output_stream, "# ");
+        interface_callbacks::writer::csv diagnostic_writer(diagnostic_stream, "# ");
+        interface_callbacks::writer::messages message_writer(&std::cout, "# ");
 
         stan::io::mcmc_writer<Model,
-                              interface::recorder::csv, interface::recorder::csv,
-                              interface::recorder::messages>
-          writer(sample_recorder, diagnostic_recorder, message_recorder, &std::cout);
+                              interface_callbacks::writer::csv, interface_callbacks::writer::csv,
+                              interface_callbacks::writer::messages>
+          writer(sample_writer, diagnostic_writer, message_writer, &std::cout);
 
         // Sampling parameters
         int num_warmup = dynamic_cast<stan::services::int_argument*>(
@@ -704,7 +704,7 @@ namespace stan {
 
         std::string prefix = "";
         std::string suffix = "\n";
-        interface::callback::noop_callback startTransitionCallback;
+        interface_callbacks::interrupt::noop startTransitionCallback;
 
         // Warm-Up
         clock_t start = clock();

--- a/src/docs/cmdstan-guide/installation.tex
+++ b/src/docs/cmdstan-guide/installation.tex
@@ -491,21 +491,17 @@ these variables. That said, it is easy to point \CmdStan to other versions
 of these libraries in other directories.
 %
 \begin{itemize}
-  \item \Verb|STANAPI_HOME|. The location of the \Stan source
-    directory. The default is \Verb|STANAPI_HOME=stan/|. Note: the
+  \item \Verb|STAN|. The location of the \Stan source
+    directory. The default is \Verb|STAN=stan/|. Note: the
     trailing forward slash is necessary.
   \item \Verb|MATH|. The location of the Stan Math Library. The
-    default is \Verb|MATH=stan/lib/stan_math_2.7.0|. If
-    \Verb|STANAPI_HOME| is set, the default will be the
-    \Verb|lib/stan_math_2.7.0| folder within \Verb|STANAPI_HOME|.
-  \item \Verb|BOOST|. The location of the Boost library. The default
-    is \Verb|BOOST=stan/lib/boost_1.58.0|. If \Verb|STANAPI_HOME| is
-    set, the default will be the \Verb|lib/boost_1.58.0| folder within
-    \Verb|STANAPI_HOME|.
-  \item \Verb|EIGEN|. The location of the Eigen library. The default
-    is \Verb|EIGEN=stan/lib/eigen_3.4.0|. If \Verb|STANAPI_HOME| is
-    set, the default will be the \Verb|lib/eigen_3.4.0| folder within
-    \Verb|STANAPI_HOME|.
+    default is \Verb|MATH=stan/lib/stan_math_2.7.0|.
+  \item \Verb|BOOST|. The location of the Boost library. If
+    \Verb|BOOST| is not explicitly set, this will default to the
+    \Verb|lib/boost_1.58.0| folder within \Verb|MATH|.
+  \item \Verb|EIGEN|. The location of the Eigen library. If
+    \Verb|EIGEN| is not explicitly set, this will default to the
+    \Verb|lib/eigen_3.4.0| folder within \Verb|MATH|.
 \end{itemize}
 %
 


### PR DESCRIPTION
#### Summary:

Use the libraries in the Stan Math Library.

#### Intended Effect:

Updates builds.

#### How to Verify:

Type:
`> make build`

#### Side Effects:

Make variables have changed. Shouldn't affect the user. Just advanced developers that have been using `STANAPI_HOME` should use `STAN` instead.

#### Documentation:

None.

#### Reviewer Suggestions: 

Anyone.