### PR TITLE
Puts argument output back into the output file

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -245,8 +245,8 @@ namespace stan {
       if (output_stream) {
         io::write_stan(output_stream, "#");
         io::write_model(output_stream, model.model_name(), "#");
-        parser.print(info);
-        info();
+        interface_callbacks::writer::stream_writer sample_writer(*output_stream, "# ");
+        parser.print(sample_writer);
       }
 
       if (diagnostic_stream) {

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -242,10 +242,13 @@ namespace stan {
 
       Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(model.num_params_r());
 
+      parser.print(info);
+      info();
+      
       if (output_stream) {
         io::write_stan(output_stream, "#");
         io::write_model(output_stream, model.model_name(), "#");
-        interface_callbacks::writer::stream_writer sample_writer(*output_stream, "# ");
+        interface_callbacks::writer::stream_writer sample_writer(*output_stream, "#");
         parser.print(sample_writer);
       }
 

--- a/src/test/interface/command_test.cpp
+++ b/src/test/interface/command_test.cpp
@@ -286,6 +286,30 @@ TEST(StanUiCommand, timing_info) {
   EXPECT_EQ(1, count_matches(" seconds (Total)", output));
 }
 
+TEST(StanUiCommand, run_info) {
+  std::vector<std::string> model_path;
+  model_path.push_back("src");
+  model_path.push_back("test");
+  model_path.push_back("test-models");
+  model_path.push_back("proper");
+  
+  std::string command = convert_model_path(model_path) + " sample num_samples=10 num_warmup=10 init=0 output refresh=0 file=test/output.csv";
+  run_command_output out = run_command(command);
+  EXPECT_EQ(int(stan::services::error_codes::OK), out.err_code);
+  
+  std::fstream output_csv_stream("test/output.csv");
+  std::stringstream output_sstream;
+  output_sstream << output_csv_stream.rdbuf();
+  output_csv_stream.close();
+  std::string output = output_sstream.str();
+  
+  EXPECT_EQ(1, count_matches("# method = sample", output));
+  EXPECT_EQ(1, count_matches(" num_samples = 10", output));
+  EXPECT_EQ(1, count_matches(" num_warmup = 10", output));
+  EXPECT_EQ(1, count_matches(" init = 0", output));
+}
+
+
 // 
 struct dummy_stepsize_adaptation {
   void set_mu(const double) {}


### PR DESCRIPTION
#### Summary:

Puts argument output back into the output file. This was accidentally taken out between 2.8.0 and now.

#### Intended Effect:

Makes CmdStan behave as it did in the past.

#### How to Verify:

Run the tests. Verify output.

The test should catch some of the issues in the future.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions: 

@akucukelbir, can you verify?