### PR TITLE
updated build system to CVODES

### DIFF
--- a/make/models
+++ b/make/models
@@ -5,10 +5,10 @@ MODEL_HEADER := $(STAN)src/stan/model/model_header.hpp
 CMDSTAN_MAIN := src/cmdstan/main.cpp
 
 .PRECIOUS: %.hpp %.o
-$(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE) : %.hpp %.stan bin/stanc$(EXE) bin/print$(EXE) $(LIBCVODE)
+$(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE) : %.hpp %.stan bin/stanc$(EXE) bin/print$(EXE) $(LIBCVODES)
 	@echo ''
 	@echo '--- Linking C++ model ---'
-	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< $(LIBCVODE) $(LDLIBS)
+	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< $(LIBCVODES) $(LDLIBS)
 
 .PRECIOUS: %.hpp
 %.hpp : %.stan $(MODEL_HEADER) bin/stanc$(EXE)

--- a/make/models
+++ b/make/models
@@ -5,7 +5,7 @@ MODEL_HEADER := $(STAN)src/stan/model/model_header.hpp
 CMDSTAN_MAIN := src/cmdstan/main.cpp
 
 .PRECIOUS: %.hpp %.o
-$(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE) : %.hpp %.stan bin/stanc$(EXE) bin/print$(EXE) $(LIBCVODES)
+$(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE) : %.hpp %.stan bin/stanc$(EXE) bin/stansummary$(EXE) $(LIBCVODES)
 	@echo ''
 	@echo '--- Linking C++ model ---'
 	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< $(LIBCVODES) $(LDLIBS)

--- a/make/tests
+++ b/make/tests
@@ -67,9 +67,9 @@ ALL_TESTS = $(shell find src/test -type f -name '*_test.cpp')
 ALL_TEST_EXECUTABLES = $(patsubst src/%.cpp,%$(EXE),$(ALL_TESTS))
 
 .PRECIOUS: test/%.o
-test/%$(EXE) : test/%.o $(LIBGTEST) $(LIBCVODE)
+test/%$(EXE) : test/%.o $(LIBGTEST) $(LIBCVODES)
 	@mkdir -p $(dir $@)
-	$(LINK.c) -O$O $(GTEST_MAIN) $< $(CFLAGS_GTEST) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS) $(LIBCVODE)
+	$(LINK.c) -O$O $(GTEST_MAIN) $< $(CFLAGS_GTEST) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS) $(LIBCVODES)
 ifeq ($(strip $(findstring src/test/,$(MAKECMDGOALS))), )
 	$(WINE) $@ --gtest_output="xml:$(basename $@).xml"
 endif

--- a/makefile
+++ b/makefile
@@ -68,11 +68,6 @@ CMDSTAN_VERSION := 2.9.0
 %.o : %.cpp
 	$(COMPILE.c) -O$O $(OUTPUT_OPTION) $<
 
-%$(EXE) : %.hpp %.stan 
-	@echo ''
-	@echo '--- Linking C++ model ---'
-	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< $(LDLIBS)
-
 ##
 # Tell make the default way to compile a .o file.
 ##

--- a/makefile
+++ b/makefile
@@ -31,7 +31,7 @@ MATH ?= $(STAN)lib/stan_math/
 ##
 # Set default compiler options.
 ## 
-CFLAGS = -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -I src -I $(STAN)src -isystem $(MATH) -isystem $(EIGEN) -isystem $(BOOST) -Wall -pipe -DEIGEN_NO_DEBUG -I$(CVODE)/include
+CFLAGS = -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -I src -I $(STAN)src -isystem $(MATH) -isystem $(EIGEN) -isystem $(BOOST) -Wall -pipe -DEIGEN_NO_DEBUG -I$(CVODES)/include
 CFLAGS_GTEST = -DGTEST_USE_OWN_TR1_TUPLE
 LDLIBS = 
 LDLIBS_STANC = -Lbin -lstanc
@@ -213,7 +213,7 @@ endif
 -include $(STAN)make/manual
 
 .PHONY: build
-build: bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) $(LIBCVODE)
+build: bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) $(LIBCVODES)
 	@echo ''
 	@echo '--- CmdStan v$(CMDSTAN_VERSION) built ---'
 


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
swap cvode for cvodes library

#### Intended Effect:
only change library, not any ode stan functions

#### How to Verify:
check source

#### Side Effects:
none

#### Documentation:
none

#### Reviewer Suggestions: 
Anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Sebastian Weber

By submitting this pull request, the copyright holder is requiring to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

cvode tests still work