### PR TITLE
Update submodule for the Stan Library

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -355,7 +355,7 @@ namespace stan {
             lp = model.template log_prob<false, false>
               (cont_vector, disc_vector, &std::cout);
           } catch (const std::exception& e) {
-            io::write_error_msg(info, e);
+            io::write_error_msg(err, e);
             lp = -std::numeric_limits<double>::infinity();
           }
 
@@ -631,7 +631,7 @@ namespace stan {
                 return 0;
               if (!sample::init_adapt<sampler>(sampler_ptr,
                                                adapt, cont_params,
-                                               info))
+                                               info, err))
                 return 0;
               break;
             }
@@ -643,7 +643,7 @@ namespace stan {
                 return 0;
               if (!sample::init_adapt<sampler>(sampler_ptr,
                                                adapt, cont_params,
-                                               info))
+                                               info, err))
                 return 0;
               break;
             }
@@ -654,7 +654,7 @@ namespace stan {
               if (!sample::init_static_hmc<sampler>(sampler_ptr, algo))
                 return 0;
               if (!sample::init_windowed_adapt<sampler>(sampler_ptr, adapt, num_warmup,
-                                                        cont_params, info))
+                                                        cont_params, info, err))
                 return 0;
               break;
             }
@@ -665,7 +665,7 @@ namespace stan {
               if (!sample::init_nuts<sampler>(sampler_ptr, algo))
                 return 0;
               if (!sample::init_windowed_adapt<sampler>(sampler_ptr, adapt, num_warmup,
-                                                        cont_params, info))
+                                                        cont_params, info, err))
                 return 0;
               break;
             }
@@ -677,7 +677,7 @@ namespace stan {
               if (!sample::init_static_hmc<sampler>(sampler_ptr, algo))
                 return 0;
               if (!sample::init_windowed_adapt<sampler>(sampler_ptr, adapt, num_warmup,
-                                                        cont_params, info))
+                                                        cont_params, info, err))
                 return 0;
               break;
             }
@@ -688,7 +688,7 @@ namespace stan {
               if (!sample::init_nuts<sampler>(sampler_ptr, algo))
                 return 0;
               if (!sample::init_windowed_adapt<sampler>(sampler_ptr, adapt, num_warmup,
-                                                        cont_params, info))
+                                                        cont_params, info, err))
                 return 0;
               break;
             }
@@ -718,7 +718,7 @@ namespace stan {
                                    s, model, base_rng,
                                    prefix, suffix, std::cout,
                                    startTransitionCallback,
-                                   info);
+                                   info, err);
 
         clock_t end = clock();
         warmDeltaT = static_cast<double>(end - start) / CLOCKS_PER_SEC;
@@ -739,7 +739,7 @@ namespace stan {
            s, model, base_rng,
            prefix, suffix, std::cout,
            startTransitionCallback,
-           info);
+           info, err);
 
         end = clock();
         sampleDeltaT = static_cast<double>(end - start) / CLOCKS_PER_SEC;

--- a/src/test/interface/command_test.cpp
+++ b/src/test/interface/command_test.cpp
@@ -340,7 +340,9 @@ struct sampler {
     return _z;
   }
   
-  void init_stepsize(stan::interface_callbacks::writer::base_writer& writer) {
+  void
+  init_stepsize(stan::interface_callbacks::writer::base_writer& info_writer,
+                stan::interface_callbacks::writer::base_writer& error_writer) {
     throw ExceptionType("throwing exception");
   }
 };
@@ -356,10 +358,11 @@ TYPED_TEST_P(StanUiCommandException, init_adapt) {
   Eigen::VectorXd cont_params;
 
   stan::interface_callbacks::writer::stream_writer message_writer(std::cout);
+  stan::interface_callbacks::writer::stream_writer error_writer(std::cerr);
   
   EXPECT_FALSE(stan::services::sample::init_adapt(&throwing_sampler,
                                                   0, 0, 0, 0, cont_params,
-                                                  message_writer));
+                                                  message_writer, error_writer));
 }
 
 REGISTER_TYPED_TEST_CASE_P(StanUiCommandException,


### PR DESCRIPTION
#### Summary:

Updates the Stan submodule to the current develop version, 0a52247.

#### Intended Effect:

The Stan Library `develop` branch has been updated.
This pull request updates the submodule for the Stan Library submodule to 0a52247.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions: 

None.