### PR TITLE
make clean-all now removes built CVODES binaries

### DIFF
--- a/makefile
+++ b/makefile
@@ -221,7 +221,7 @@ build: bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) $(LIBCVODES)
 ##
 # Clean up.
 ##
-.PHONY: clean clean-manual clean-all clean-cvodes
+.PHONY: clean clean-manual clean-all
 
 clean: clean-manual
 	$(RM) -r test
@@ -231,11 +231,7 @@ clean: clean-manual
 clean-manual:
 	cd src/docs/cmdstan-guide; $(RM) *.brf *.aux *.bbl *.blg *.log *.toc *.pdf *.out *.idx *.ilg *.ind *.cb *.cb2 *.upa
 
-clean-cvodes:
-	$(RM) $(wildcard $(CVODES)/lib/*)
-	$(RM) $(wildcard $(CVODES)/src/*/*.o)
-
-clean-all: clean clean-cvodes
+clean-all: clean clean-libraries
 	$(RM) -r bin
 
 ##

--- a/makefile
+++ b/makefile
@@ -221,7 +221,7 @@ build: bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) $(LIBCVODES)
 ##
 # Clean up.
 ##
-.PHONY: clean clean-manual clean-all
+.PHONY: clean clean-manual clean-all clean-cvodes
 
 clean: clean-manual
 	$(RM) -r test
@@ -231,8 +231,11 @@ clean: clean-manual
 clean-manual:
 	cd src/docs/cmdstan-guide; $(RM) *.brf *.aux *.bbl *.blg *.log *.toc *.pdf *.out *.idx *.ilg *.ind *.cb *.cb2 *.upa
 
+clean-cvodes:
+	$(RM) $(wildcard $(CVODES)/lib/*)
+	$(RM) $(wildcard $(CVODES)/src/*/*.o)
 
-clean-all: clean
+clean-all: clean clean-cvodes
 	$(RM) -r bin
 
 ##


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
`make clean-all` now removes all built CVODES binaries.

#### Side Effects:
None.

#### Documentation:
None.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

