### PR TITLE
Updating makefile

### DIFF
--- a/make/command
+++ b/make/command
@@ -1,7 +1,7 @@
 .PRECIOUS: bin/stanc$(EXE)
 bin/stanc$(EXE) : bin/cmdstan/stanc.o bin/libstanc.a
 	@mkdir -p $(dir $@)
-	$(LINK.c) -O$(O_STANC) $(OUTPUT_OPTION) $< $(LDLIBS_STANC)
+	$(LINK.c) -O$(O_STANC) $(OUTPUT_OPTION) $< $(LDLIBS) $(LDLIBS_STANC)
 
 .PRECIOUS: bin/print$(EXE)
 bin/print$(EXE) : bin/cmdstan/print.o


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Fixes makefile.

#### Intended Effect:
This forces the `LDLIBS` variable to be used when building `bin/stanc`.

#### How to Verify:
Change `make/local`.

#### Side Effects:
None.

#### Documentation:
None. This should have already worked.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

