### PR TITLE
Fixes stan#2049. Updating CmdStan to call individual headers instead of stan/model/util.hpp

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -88,7 +88,8 @@
 #include <stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp>
 #include <stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp>
 
-#include <stan/model/util.hpp>
+#include <stan/model/gradient.hpp>
+#include <stan/model/test_gradients.hpp>
 
 #include <stan/optimization/newton.hpp>
 #include <stan/optimization/bfgs.hpp>


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Deals with change to the Stan library.

#### Intended Effect:
Update includes.

#### Side Effects:
May make compiles quicker.
This must wait until stan#2062 has been merged.

#### Documentation:
None.

#### Reviewer Suggestions: 
Me.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

…of stan/model/util.hpp