### PR TITLE
Feature/allow undefined

### DIFF
--- a/make/models
+++ b/make/models
@@ -8,7 +8,8 @@ CMDSTAN_MAIN := src/cmdstan/main.cpp
 $(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE) : %.hpp %.stan bin/stanc$(EXE) bin/stansummary$(EXE) $(LIBCVODES)
 	@echo ''
 	@echo '--- Linking C++ model ---'
-	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< $(LIBCVODES) $(LDLIBS)
+	@test -f $(dir $<)USER_HEADER.hpp || touch $(dir $<)USER_HEADER.hpp
+	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< -include $(dir $<)USER_HEADER.hpp $(LIBCVODES) $(LDLIBS)
 
 .PRECIOUS: %.hpp
 %.hpp : %.stan $(MODEL_HEADER) bin/stanc$(EXE)

--- a/make/models
+++ b/make/models
@@ -14,5 +14,5 @@ $(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE) : 
 %.hpp : %.stan $(MODEL_HEADER) bin/stanc$(EXE)
 	@echo ''
 	@echo '--- Translating Stan model to C++ code ---'
-	$(WINE) bin$(PATH_SEPARATOR)stanc$(EXE) $< --o=$@
+	$(WINE) bin$(PATH_SEPARATOR)stanc$(EXE) $(ALLOW_UNDEFINED) $< --o=$@
 

--- a/make/models
+++ b/make/models
@@ -4,16 +4,20 @@
 MODEL_HEADER := $(STAN)src/stan/model/model_header.hpp
 CMDSTAN_MAIN := src/cmdstan/main.cpp
 
+
 .PRECIOUS: %.hpp %.o
 $(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE) : %.hpp %.stan bin/stanc$(EXE) bin/stansummary$(EXE) $(LIBCVODES)
 	@echo ''
 	@echo '--- Linking C++ model ---'
-	@test -f $(dir $<)USER_HEADER.hpp || touch $(dir $<)USER_HEADER.hpp
-	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< -include $(dir $<)USER_HEADER.hpp $(LIBCVODES) $(LDLIBS)
+ifneq (,$(findstring allow_undefined,$(STANCFLAGS)))
+	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< -include $(USER_HEADER) $(LIBCVODES) $(LDLIBS)
+else
+	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< $(LIBCVODES) $(LDLIBS)
+endif
 
 .PRECIOUS: %.hpp
 %.hpp : %.stan $(MODEL_HEADER) bin/stanc$(EXE)
 	@echo ''
 	@echo '--- Translating Stan model to C++ code ---'
-	$(WINE) bin$(PATH_SEPARATOR)stanc$(EXE) $(ALLOW_UNDEFINED) $< --o=$@
+	$(WINE) bin$(PATH_SEPARATOR)stanc$(EXE) $(STANCFLAGS) $< --o=$@
 

--- a/makefile
+++ b/makefile
@@ -66,12 +66,13 @@ CMDSTAN_VERSION := 2.12.0
 # Tell make the default way to compile a .o file.
 ##
 %.o : %.cpp
-	$(COMPILE.c) -O$O $(OUTPUT_OPTION) $<
+	$(COMPILE.c) -O$O -include $(dir $<)USER_HEADER.hpp  $(OUTPUT_OPTION) $<
 
 %$(EXE) : %.hpp %.stan 
 	@echo ''
 	@echo '--- Linking C++ model ---'
-	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< $(LIBCVODES) $(LDLIBS)
+	@test -f $(dir $<)USER_HEADER.hpp || touch $(dir $<)USER_HEADER.hpp
+	$(LINK.c) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< -include $(dir $<)USER_HEADER.hpp $(LIBCVODES) $(LDLIBS)
 
 
 ##

--- a/makefile
+++ b/makefile
@@ -35,6 +35,8 @@ CFLAGS = -I src -I $(STAN)src -isystem $(MATH) -isystem $(EIGEN) -isystem $(BOOS
 CFLAGS_GTEST = -DGTEST_USE_OWN_TR1_TUPLE
 LDLIBS = 
 LDLIBS_STANC = -Lbin -lstanc
+STANCFLAGS ?=
+USER_HEADER ?= $(dir $<)user_header.hpp
 EXE = 
 PATH_SEPARATOR = /
 CMDSTAN_VERSION := 2.12.0
@@ -142,6 +144,15 @@ help:
 	@echo '    1. Build the Stan compiler and the print utility if not built.'
 	@echo '    2. Use the Stan compiler to generate C++ code, foo/bar.hpp.'
 	@echo '    3. Compile the C++ code using $(CC) $(CC_MAJOR).$(CC_MINOR) to generate foo/bar$(EXE)'
+	@echo ''
+	@echo '  Additional make options:'
+	@echo '    STANCFLAGS: defaults to "". These are extra options passed to bin/stanc$(EXE)'
+	@echo '      when generating C++ code. If you want to allow undefined functions in the'
+	@echo '      Stan program, either add this to make/local or the command line:'
+	@echo '          STANCFLAGS = --allow_undefined'
+	@echo '    USER_HEADER: when STANCFLAGS has --allow_undefined, this is the name of the'
+	@echo '      header file that is included. This defaults to "user_header.hpp" in the'
+	@echo '      directory of the Stan program.'
 	@echo ''
 	@echo ''
 	@echo '  Example - bernoulli model: examples/bernoulli/bernoulli.stan'

--- a/src/docs/cmdstan-guide/installation.tex
+++ b/src/docs/cmdstan-guide/installation.tex
@@ -482,6 +482,24 @@ The most common options to set are the compiler options:
     \Verb|s|.
 \end{itemize}
 
+\subsubsection{{\tt stanc} Options}
+
+There are two options for controlling \stanc:
+%
+\begin{itemize}
+\item \Verb|STANCFLAGS|. These flags are passed to \stanc.  To allow
+  functions in Stan programs that are declared, but undefined, use
+  \Verb|STANCFLAGS = --allow_undefined| and update \Verb|USER_HEADER|
+  appropriately.
+\item \Verb|USER_HEADER|. If \Verb|--allow_undefined| is passed to
+  \stanc, the value of this variable is the additional include that is
+  passed to the \Cpp linker when compiling the program. The file in
+  \Verb|USER_HEADER| must have a definition of the function if the function
+  is used and not defined in the Stan program. This defaults to
+  \Verb|user_header.hpp| in the directory of the Stan program being compiled.
+\end{itemize}
+%
+
 \subsubsection{Changing Library Locations}
 
 The next set of variables allow for easy replacement of dependent

--- a/src/docs/cmdstan-guide/stanc.tex
+++ b/src/docs/cmdstan-guide/stanc.tex
@@ -108,5 +108,107 @@ Specify the name of the file into which the generated \Cpp is written.
 \\[2pt]
 Default: {\tt {\slshape cpp\_file\_name} = {\slshape class\_name}.hpp}
 %
+\item[\tt {-}-{\slshape allow\_undefined}]
+\mbox{ } \\ 
+Do not throw a parser error if there is a function in the Stan program
+that is declared but not defined in the functions block.
+%
 \end{description}
 
+\section{Using External \Cpp Code}
+
+If the {\tt allow\_undefined} flag is specified in the call to \stanc, 
+either directly or indirectly by defining 
+{\tt ALLOW\_UNDEFINED=--allow\_undefined} in the {\tt make/local} file,
+then you can declare a function signature in the functions block of
+your Stan program without defining it. In that case, \stanc will 
+generate a \Cpp header file that will not compile unless you edit the 
+generated \Cpp header file to add a {\tt \#include} statement pointing
+to another \Cpp header file that defines a function with the same name
+and signature in the same namespace. This namespace is the same as the
+{\tt class\_name} argument to \stanc documented above but with
+{\tt \_namespace} postfixed to the end of the {\tt class\_name}. After
+making that change, you do not need to run \stanc again; you merely 
+need to compile the \Cpp by calling {\tt make} followed by the path
+to the Stan program with the {\tt .stan} extension omitted.
+
+For more details about how to write \Cpp code using the Stan Math
+Library, see \url{https://arxiv.org/abs/1509.07164}. As an example,
+consider the following variant of the Bernoulli example
+%
+\begin{quote}
+\begin{Verbatim}
+functions {
+  real make_odds(real theta);
+}
+data {
+  int<lower=0> N;
+  int<lower=0,upper=1> y[N];
+}
+parameters {
+  real<lower=0,upper=1> theta;
+}
+model {
+  theta ~ beta(1,1);
+  for (n in 1:N)
+    y[n] ~ bernoulli(theta);
+}
+generated quantities {
+  real odds;
+  odds = make_odds(theta);
+}
+\end{Verbatim}
+\end{quote}
+%
+Here the {\tt make\_odds} function is declared but not defined,
+which would ordinarily result in a parser error. However, if you
+put {\tt ALLOW\_UNDEFINED=--allow\_undefined} into the
+{\tt make/local} file, then the above Stan program will parse
+successfully but would not compile when you call
+%
+\begin{quote}
+\begin{Verbatim}[fontshape=sl]
+> make examples/bernoulli/bernoulli # on Windows postfix .exe 
+\end{Verbatim}
+\end{quote}
+%
+To compile, you need to write a file such as 
+{\tt examples/bernoulli/make\_odds.hpp} with the following lines
+%
+\begin{quote}
+\begin{Verbatim}
+namespace bernoulli_model_namespace {
+
+  template <typename T0__>
+  inline
+  typename boost::math::tools::promote_args<T0__>::type
+  make_odds(const T0__& theta, std::ostream* pstream__) {
+    return theta / (1 - theta);
+  }
+
+}
+\end{Verbatim}
+\end{quote}
+%
+If the function were more complicated and involved functions
+in the Stan Math Library, then you would need to prefix the
+function calls with {\tt stan::math::}. The {\tt pstream\_\_}
+argument is mandatory in the signature but need not be used
+if your function does not print any output. To see the 
+necessary boilerplate look at the generated lines in the
+generated \Cpp file.
+
+Next, you need to edit {\tt examples/bernoulli/bernoulli.hpp}
+and add a line that says {\tt \#include 'make\_odds.hpp'} at
+the very top. If your header file were in a different directory
+than {\tt examples/bernoulli/}, then you would need to specify
+{\tt \#include 'full/path/to/make\_odds.hpp'}. Finally, call
+%
+\begin{quote}
+\begin{Verbatim}[fontshape=sl]
+> make examples/bernoulli/bernoulli # on Windows postfix .exe 
+\end{Verbatim}
+\end{quote}
+%
+and your \Cpp program should compile without reparsing your
+Stan program.

--- a/src/docs/cmdstan-guide/stanc.tex
+++ b/src/docs/cmdstan-guide/stanc.tex
@@ -160,8 +160,9 @@ generated quantities {
 Here the {\tt make\_odds} function is declared but not defined,
 which would ordinarily result in a parser error. However, if you
 put \Verb|STANCFLAGS = --allow_undefined| into the
-{\tt make/local} file, then the above Stan program will parse
-successfully but would not compile when you call
+{\tt make/local} file or into the {\tt stanc} call, then the above 
+Stan program will parse successfully but would not compile when you 
+call
 %
 \begin{quote}
 \begin{Verbatim}[fontshape=sl]
@@ -169,9 +170,8 @@ successfully but would not compile when you call
 \end{Verbatim}
 \end{quote}
 %
-To compile, you need to write a file such as {\tt
-  examples/bernoulli/user\_header.hpp} (the default) with the
-following lines
+To compile successfully, you need to write a file such as {\tt
+examples/bernoulli/make\_odds.hpp} with the following lines
 %
 \begin{quote}
 \begin{Verbatim}
@@ -188,6 +188,20 @@ namespace bernoulli_model_namespace {
 \end{Verbatim}
 \end{quote}
 %
+Thus, the following {\tt make} invocation should work
+%
+\begin{quote}
+\begin{Verbatim}[fontshape=sl]
+> STANCFLAGS=--allow_undefined \
+USER_HEADER=examples/bernoulli/make_odds.hpp \
+make examples/bernoulli/bernoulli # on Windows add .exe 
+\end{Verbatim}
+\end{quote}
+%
+or you could put \Verb|STANCFLAGS| and \Verb|USER_HEADER|
+into the {\tt make/local} file instead of specifying them
+on the command-line.
+
 If the function were more complicated and involved functions
 in the Stan Math Library, then you would need to prefix the
 function calls with {\tt stan::math::}. The {\tt pstream\_\_}

--- a/src/docs/cmdstan-guide/stanc.tex
+++ b/src/docs/cmdstan-guide/stanc.tex
@@ -117,15 +117,16 @@ that is declared but not defined in the functions block.
 
 \section{Using External \Cpp Code}
 
-If the {\tt allow\_undefined} flag is specified in the call to \stanc, 
-either directly or indirectly by defining 
-{\tt ALLOW\_UNDEFINED=--allow\_undefined} in the {\tt make/local} file,
-then you can declare a function signature in the functions block of
-your Stan program without defining it. In that case, \stanc will 
-generate a \Cpp file that will not compile unless you write a
-{\tt USER\_HEADER.hpp} file in the same directory as the Stan program
-that defines a function with the same name and signature in a namespace
-that is formed by concatenating the {\tt class\_name} argument to 
+The {\tt --allow\_undefined} flag can be passed to the call to \stanc,
+which will allow undefined functions in the Stan language to be parsed
+without an error. We can then include a definition of the function in
+a \Cpp header file. We typically control these options with two {\tt
+  make} variables: \Verb|STANCFLAGS| and \Verb|USER_HEADER|. See
+\refappendix{make-options} for more details.
+
+The \Cpp file will not compile unless there is a header file that
+defines a function with the same name and signature in a namespace
+that is formed by concatenating the {\tt class\_name} argument to
 \stanc documented above to the string {\tt \_namespace}.
 
 For more details about how to write \Cpp code using the Stan Math
@@ -158,7 +159,7 @@ generated quantities {
 %
 Here the {\tt make\_odds} function is declared but not defined,
 which would ordinarily result in a parser error. However, if you
-put {\tt ALLOW\_UNDEFINED=--allow\_undefined} into the
+put \Verb|STANCFLAGS = --allow_undefined| into the
 {\tt make/local} file, then the above Stan program will parse
 successfully but would not compile when you call
 %
@@ -168,8 +169,9 @@ successfully but would not compile when you call
 \end{Verbatim}
 \end{quote}
 %
-To compile, you need to write a file such as 
-{\tt examples/bernoulli/USER\_HEADER.hpp} with the following lines
+To compile, you need to write a file such as {\tt
+  examples/bernoulli/user\_header.hpp} (the default) with the
+following lines
 %
 \begin{quote}
 \begin{Verbatim}

--- a/src/docs/cmdstan-guide/stanc.tex
+++ b/src/docs/cmdstan-guide/stanc.tex
@@ -122,15 +122,11 @@ either directly or indirectly by defining
 {\tt ALLOW\_UNDEFINED=--allow\_undefined} in the {\tt make/local} file,
 then you can declare a function signature in the functions block of
 your Stan program without defining it. In that case, \stanc will 
-generate a \Cpp header file that will not compile unless you edit the 
-generated \Cpp header file to add a {\tt \#include} statement pointing
-to another \Cpp header file that defines a function with the same name
-and signature in the same namespace. This namespace is the same as the
-{\tt class\_name} argument to \stanc documented above but with
-{\tt \_namespace} postfixed to the end of the {\tt class\_name}. After
-making that change, you do not need to run \stanc again; you merely 
-need to compile the \Cpp by calling {\tt make} followed by the path
-to the Stan program with the {\tt .stan} extension omitted.
+generate a \Cpp file that will not compile unless you write a
+{\tt USER\_HEADER.hpp} file in the same directory as the Stan program
+that defines a function with the same name and signature in a namespace
+that is formed by concatenating the {\tt class\_name} argument to 
+\stanc documented above to the string {\tt \_namespace}.
 
 For more details about how to write \Cpp code using the Stan Math
 Library, see \url{https://arxiv.org/abs/1509.07164}. As an example,
@@ -168,12 +164,12 @@ successfully but would not compile when you call
 %
 \begin{quote}
 \begin{Verbatim}[fontshape=sl]
-> make examples/bernoulli/bernoulli # on Windows postfix .exe 
+> make examples/bernoulli/bernoulli # on Windows add .exe 
 \end{Verbatim}
 \end{quote}
 %
 To compile, you need to write a file such as 
-{\tt examples/bernoulli/make\_odds.hpp} with the following lines
+{\tt examples/bernoulli/USER\_HEADER.hpp} with the following lines
 %
 \begin{quote}
 \begin{Verbatim}
@@ -195,20 +191,5 @@ in the Stan Math Library, then you would need to prefix the
 function calls with {\tt stan::math::}. The {\tt pstream\_\_}
 argument is mandatory in the signature but need not be used
 if your function does not print any output. To see the 
-necessary boilerplate look at the generated lines in the
+necessary boilerplate look at the corresponding lines in the
 generated \Cpp file.
-
-Next, you need to edit {\tt examples/bernoulli/bernoulli.hpp}
-and add a line that says {\tt \#include 'make\_odds.hpp'} at
-the very top. If your header file were in a different directory
-than {\tt examples/bernoulli/}, then you would need to specify
-{\tt \#include 'full/path/to/make\_odds.hpp'}. Finally, call
-%
-\begin{quote}
-\begin{Verbatim}[fontshape=sl]
-> make examples/bernoulli/bernoulli # on Windows postfix .exe 
-\end{Verbatim}
-\end{quote}
-%
-and your \Cpp program should compile without reparsing your
-Stan program.


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run tests: `./runCmdStanTests.py src/test`
- [X] Declare copyright holder and open-source license: see below

#### Summary:

Pass the environmental variable `ALLOW_UNDEFINED` to `stanc`. 
Also, pass `-include path/to/USER_HEADER.hpp` to the compiler.

#### Intended Effect:

If the user has `ALLOW_UNDEFINED=--allow_undefined` in `make/local` then models will parse with functions that are declared but not defined.
If USER_HEADER.hpp is written correctly, then when the Stan program executes, it will use the functions defined therein.

#### How to Verify:

Put `ALLOW_UNDEFINED=--allow_undefined` in `make/local` and do `./runCmdStanTests.py src/test` but that doesn't actually do much because there are no test files in cmdstan that have undefined functions (there is a parser test in the Stan library already). 

#### Side Effects:

Linker errors. At the moment, models with functions that are declared but not defined will parse and compile but not link. The user either needs to edit a USER_HEADER.hpp file or specify `LDLIBS = -Lmy_lib_dir -lmy_lib` in `make/local` to link to a shared object called `my_lib.o`. Then it should compile. 

#### Documentation:

In section 4.4 of cmdstan-guide.pdf

#### Reviewer Suggestions: 

@syclik 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

