### PR TITLE
add doc about integer(x) for dump format

### DIFF
--- a/src/docs/cmdstan-guide/dump-format.tex
+++ b/src/docs/cmdstan-guide/dump-format.tex
@@ -15,10 +15,10 @@ Dump files can be created from R using RStan.  The function is
 \code{stan\_rdump} in package \code{rstan}.
 
 Using R's native \code{dump()} function can produce dump files which
-Stan cannot read in.  The underlying cause is that R gets creative in
-the format it uses for output, only being constrained to something
-that can be executed in R.  So it will write the array containing the
-values 1, 2, 3, 4 as \code{1:4} rather than as \code{c(1,2,3,4)}.
+Stan cannot read in.  The underlying cause is that R supports
+complicated data structures, some of which are not used in \CmdStan.
+For example, R's \code{dump()} can write a numerical vector with names
+for each element.
 
 \section{Scalar Variables}
 
@@ -74,6 +74,25 @@ the second.
 \begin{Verbatim}
 n <- 2:-2
 n <- c(2,1,0,-1,-2)
+\end{Verbatim}
+\end{quote}
+%
+
+As a special case, a sequence of zeros can also be
+represented in the dump format by \code{integer(x)} and
+\code{double(x)}, for type int and double, respectively.
+Here \code{x} is a non-negative integer to specify the
+length. If \code{x} is \code{0}, it can be ommitted. The
+following are some examples.
+%
+\begin{quote}
+\begin{Verbatim}
+x1 <- integer()
+x2 <- integer(0)
+x3 <- integer(2)
+y1 <- double()
+y2 <- double(0)
+y3 <- double(2)
 \end{Verbatim}
 \end{quote}
 %
@@ -146,6 +165,19 @@ z[1,1,4] = 19   z[1,2,4] = 21   z[1,3,4] = 23
 z[2,1,4] = 20   z[2,2,4] = 22   z[2,3,4] = 24
 \end{verbatim}
 \end{quote}
+
+The sequence of values inside \code{structure} can also be
+\code{integer(x)} or \code{double(x)}. In particular, if one
+or more dimensions is zero, \code{integer()} can be put inside
+\code{structure}.  For instance, the following example is supported
+by the dump format.
+
+\begin{quote}
+\begin{verbatim}
+y <- structure(integer(), .Dim = c(2, 0))
+\end{verbatim}
+\end{quote}
+
 
 \section{Matrix- and Vector-Valued Variables}
 
@@ -365,10 +397,16 @@ by the following (mildly templated) Backus-Naur form grammar.
 
  value<T> ::= T 
             | seq<T>
+            | zero_array<T>
             | 'structure' '(' seq<T> ',' ".Dim" '=' seq<int> ')'
+            | 'structure' '(' zero_array<T> ',' ".Dim" '=' seq<int> ')'
 
  seq<int> ::= int ':' int
             | cseq<int>
+
+ zero_array<int> ::= "integer" '(' <non-negative int>? ')'
+
+ zero_array<real> ::= "double" '(' <non-negative int>? ')'
 
  seq<real> ::= cseq<real>
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

The addresses issue #523.

Add a simple description including examples of sequence of zeros can be specified as `integer(x)` or `double(x)` in the dump format. 

#### Intended Effect:

Update the doc about dump format. 

#### How to Verify:

checkout out section c in the appendices under the new manual

#### Reviewer Suggestions: 
@bob-carpenter @syclik 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Jiqiang Guo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)


