### PR TITLE
Fix manual

### DIFF
--- a/src/docs/cmdstan-guide/cmdstan-guide.tex
+++ b/src/docs/cmdstan-guide/cmdstan-guide.tex
@@ -4,7 +4,6 @@
 
 \newcommand{\cmdstanversion}{2.15.0}
 \newcommand{\CmdStan}{CmdStan\xspace}
-\newcommand{\Stan}{Stan\xspace}
 
 \begin{document}
 

--- a/src/docs/cmdstan-guide/cmdstan-guide.tex
+++ b/src/docs/cmdstan-guide/cmdstan-guide.tex
@@ -4,6 +4,7 @@
 
 \newcommand{\cmdstanversion}{2.15.0}
 \newcommand{\CmdStan}{CmdStan\xspace}
+\newcommand{\Stan}{Stan\xspace}
 
 \begin{document}
 

--- a/src/docs/cmdstan-guide/compiling.tex
+++ b/src/docs/cmdstan-guide/compiling.tex
@@ -1,10 +1,10 @@
 \chapter{Compiling \CmdStan Exectuables}\label{compiling.chapter}
 
 \noindent
-Preparing a \Stan program to be run involves two steps,
+Preparing a Stan program to be run involves two steps,
 %
 \begin{enumerate}
-\item translating the \Stan program to \Cpp, and
+\item translating the Stan program to \Cpp, and
 \item compiling the resulting \Cpp to an executable.
 \end{enumerate}
 %
@@ -45,7 +45,7 @@ This will translate the model \code{bernoulli.stan} to a \Cpp file,
 generated \Cpp file, putting the executable in
 \nolinkurl{examples/bernoulli/bernoulli(.exe)}.
 
-\Stan programs do not need to be in the \code{<cmdstan-home>}
+Stan programs do not need to be in the \code{<cmdstan-home>}
 directory. The current limitation is that the target executable name
 can not have spaces -- this includes the path to the
 executable. Spaces in the full path can be avoided by using relative
@@ -61,7 +61,7 @@ If the \code{make} target to build the Bernoulli estimator is invoked
 a second time, it will see that it is up to date, and will not
 recompile the program.
 
-If the file containing the \Stan program is updated, the next call to
+If the file containing the Stan program is updated, the next call to
 \code{make} will rebuild the \CmdStan executable.
 
 

--- a/src/docs/cmdstan-guide/dump-format.tex
+++ b/src/docs/cmdstan-guide/dump-format.tex
@@ -242,11 +242,11 @@ row_vector[N] d[P,M];
 There is no declaration in a dump file that distinguishes integer
 versus continuous values.  If a value in a dump file's definition of a
 variable contains a decimal point (e.g., \code{132.3}) or uses
-scientific notation (e.g., \code{1.323e2}), \Stan assumes that the
+scientific notation (e.g., \code{1.323e2}), Stan assumes that the
 values are real.
 
 For a single value, if there is no decimal point, it may be assigned
-to an \code{int} or \code{real} variable in \Stan.  An array value may
+to an \code{int} or \code{real} variable in Stan.  An array value may
 only be assigned to an \code{int} array if there is no decimal point
 or scientific notation in any of the values.  This convention is
 compatible with the way \R writes data.
@@ -260,7 +260,7 @@ y <-
 \end{Verbatim}
 \end{quote}
 % 
-This definition can be used for a \Stan variable \code{y} declared as
+This definition can be used for a Stan variable \code{y} declared as
 \code{real} or as \code{int}.  Assigning an integer value to a real
 variable automatically promotes the integer value to a real value.
 
@@ -285,9 +285,9 @@ y <-
 \end{quote}
 %
 Even though this is a round value, the occurrence of the decimal
-point in the value, \code{2.0}, causes \Stan to infer that \code{y} is
+point in the value, \code{2.0}, causes Stan to infer that \code{y} is
 real valued.  This dump file may only be used for variables \code{y}
-declared as real in \Stan.
+declared as real in Stan.
 
 \subsection{Scientific Notation}
 
@@ -418,8 +418,8 @@ by the following (mildly templated) Backus-Naur form grammar.
 }
 \noindent
 The template parameters \code{T} will be set to either \code{int} or
-\code{real}.  Because \Stan allows promotion of integer values to real
+\code{real}.  Because Stan allows promotion of integer values to real
 values, an integer sequence specification in the dump data format may
-be assigned to either an integer- or real-based variable in \Stan.
+be assigned to either an integer- or real-based variable in Stan.
 
 

--- a/src/docs/cmdstan-guide/getting-started.tex
+++ b/src/docs/cmdstan-guide/getting-started.tex
@@ -4,7 +4,7 @@
 This chapter is designed to help users get acquainted with the
 \CmdStan interface. Later chapters are devoted to expanding on the
 material in this chapter with full reference documentation. See the
-\Stan user's manual for details about the \Stan language.
+Stan user's manual for details about the Stan language.
 
 \section{Installation}
 
@@ -34,7 +34,7 @@ instructions of the prerequisites, see
 Building \CmdStan involves building two executable programs:
 %
 \begin{itemize}
-\item \code{stanc}: the \Stan compiler (translates \Stan language to \Cpp)
+\item \code{stanc}: the Stan compiler (translates Stan language to \Cpp)
 \item \code{stansummary}: a basic posterior analysis tool
 \end{itemize}
 %
@@ -104,13 +104,13 @@ report (after other lines of output)
 and there will be two executables in the \code{<cmdstan-home>/bin/} folder:
 %
 \begin{itemize}
-  \item \code{stanc}, the \Stan compiler. The \Stan compiler
-    translates a \Stan program into \Cpp code. See \refchapter{stanc}
+  \item \code{stanc}, the Stan compiler. The Stan compiler
+    translates a Stan program into \Cpp code. See \refchapter{stanc}
     for details.
   \item \code{stansummary}, a posterior analysis tool. The \code{stansummary}
     command summarizes the comma-separated values files that are
-    generated from \Stan program runs. For each parameter within the
-    \Stan program, \code{stansummary} reports the mean, standard deviation,
+    generated from Stan program runs. For each parameter within the
+    Stan program, \code{stansummary} reports the mean, standard deviation,
     quantiles, $\hat{R}$, and other values. See \refchapter{stansummary} for
     details.
 \end{itemize}
@@ -178,17 +178,17 @@ using an R-like syntax (see \refchapter{dump} for more information).
 
 Before building any Stan program, change directories to \code{<cmdstan-home>}.
 
-\subsection{Compiling a \Stan Program}
+\subsection{Compiling a Stan Program}
 
 A single call to \code{make} is all that's necessary to translate a
-\Stan program to an executable for the command line. (This call will
-first translate the \Stan program to \Cpp, then compile the \Cpp code
+Stan program to an executable for the command line. (This call will
+first translate the Stan program to \Cpp, then compile the \Cpp code
 to an executable.)
 
-A \Stan program must be in a file with the file extension
-\code{.stan}. To create an executable from a \Stan program,
+A Stan program must be in a file with the file extension
+\code{.stan}. To create an executable from a Stan program,
 \code{make} will be called with the name of the executable as its
-argument. For Mac and Linux, it is the name of the \Stan program with
+argument. For Mac and Linux, it is the name of the Stan program with
 the \code{.stan} omitted. For Windows, replace \code{.stan} with
 \code{.exe}.
 
@@ -210,15 +210,15 @@ at the end of the target:
 \end{quote}
 
 The generated \Cpp code (\code{bernoulli.hpp}) and the compiled
-executable will be placed in the same directory as the \Stan program.
+executable will be placed in the same directory as the Stan program.
 
 \textbf{Note:} you must start in the \code{<cmdstan-home>}
-directory. The \Stan program can be in a different path, but the path
-to the \Stan program must not contain a space. (This is a limitation
+directory. The Stan program can be in a different path, but the path
+to the Stan program must not contain a space. (This is a limitation
 that's introduced by \code{make}.) Relative paths are ok; the relative
 path must not contain a space.
 
-\subsection{Sampling from the \Stan Program}
+\subsection{Sampling from the Stan Program}
 
 The program can be executed from the directory in which it resides.
 %
@@ -317,7 +317,7 @@ chain being written to a file in comma-separated value (CSV) format.
 The default name of the output file is \nolinkurl{output.csv}.
 
 The first part of the output file records the version of the
-underlying \Stan library and the configuration as comments (i.e.,
+underlying Stan library and the configuration as comments (i.e.,
 lines beginning with the pound sign (\Verb|#|)).
 %
 \begin{quote}
@@ -507,7 +507,7 @@ the draws (e.g., to make decisions or predictions for unseen data).
 from the posterior distribution. The executable does not need to be
 recompiled in order to switch from sampling to optimization, and the
 data input format is the same. The following is a minimal call to
-\Stan's optimizer using defaults for everything but the location of the
+Stan's optimizer using defaults for everything but the location of the
 data file. See \refsection{stan-command-line-options} for more
 details.
 %
@@ -627,7 +627,7 @@ that no uncertainty is reported.
 inference. The executable does not need to be
 recompiled in order to switch to variational inference, and the
 data input format is the same. The following is a minimal call to
-\Stan's variational inference algorithm using defaults for everything but the
+Stan's variational inference algorithm using defaults for everything but the
 location of the data file. See \refsection{stan-command-line-options} for more
 details.
 %
@@ -719,7 +719,7 @@ phase finds a good value for the step size scaling parameter $\eta$. The
 evidence
 lower bound (ELBO) is the variational objective function and is
 evaluated based on a Monte Carlo estimate. The variational inference
-algorithm in \Stan is stochastic, which makes it challenging to assess
+algorithm in Stan is stochastic, which makes it challenging to assess
 convergence. That is, while the algorithm appears to have converged in
 $\sim$100 iterations, the algorithm runs for another few thousand
 iterations until mean change in ELBO drops below the default
@@ -914,9 +914,9 @@ and on Windows with
 
 %% \subsection{Compile-time Errors}
 
-%% \Stan tries to report errors and warnings in order to help users
+%% Stan tries to report errors and warnings in order to help users
 %% correctly formulate and debug models. Compile-time errors occur when
-%% \Stan programs are not syntaxtically valid. These errors prevent \Cpp
+%% Stan programs are not syntaxtically valid. These errors prevent \Cpp
 %% code from being generated and must be addressed before proceeding. See
 %% the user's guide for more details.
 
@@ -956,7 +956,7 @@ and on Windows with
 
 %% If this message occurs repeatedly, the model may have a poorly
 %% conditioned constraint (typically with covariance or correlation
-%% matrices) or may be misformulated.  In a future version of \Stan, we
+%% matrices) or may be misformulated.  In a future version of Stan, we
 %% plan to rank such messages by severity and turn this one off by
 %% default so as not to needlessly worry users.
 

--- a/src/docs/cmdstan-guide/installation.tex
+++ b/src/docs/cmdstan-guide/installation.tex
@@ -37,9 +37,9 @@ The only two absolute requirements for running \CmdStan are the
 
 \subsection{\CmdStan Source}
 
-In order to compile \Stan program, the \CmdStan source code is
+In order to compile Stan program, the \CmdStan source code is
 required.  The \CmdStan source code distribution includes \CmdStan's
-source code, \Stan's source code, documentation, build scripts, unit
+source code, Stan's source code, documentation, build scripts, unit
 tests, documentation and source for the required libraries, Stan Math
 Library, Boost, and Eigen, and the source for an optional testing
 library, Google Test.
@@ -66,7 +66,7 @@ http://mc-stan.org/source-repos.html
 \subsubsection{Stan Library Source}
 
 The source code for Stan's parse and implementation of inference
-algorithms are in the \Stan library.
+algorithms are in the Stan library.
 %
 \begin{itemize}
 \item Home: \url{http://mc-stan.org/stan.html}
@@ -74,12 +74,12 @@ algorithms are in the \Stan library.
 \item Tested Version: 2.15.0
 \end{itemize}
 %
-The \Stan source code is distributed with \CmdStan.
+The Stan source code is distributed with \CmdStan.
 
 \subsubsection{Stan Math Library Source}
 
-\Stan's mathematical functions and inference algorithm rely on the
-reverse-mode automatic differentiation implemented in the \Stan Math
+Stan's mathematical functions and inference algorithm rely on the
+reverse-mode automatic differentiation implemented in the Stan Math
 Library.
 %
 \begin{itemize}
@@ -88,11 +88,11 @@ Library.
 \item Tested Version: 2.15.0
 \end{itemize}
 %
-The \Stan Math Library source code is distributed with \CmdStan
+The Stan Math Library source code is distributed with \CmdStan
 
 \subsubsection{Boost C++ Library Source}
 
-\Stan's parser and some of its mathematical functions and template
+Stan's parser and some of its mathematical functions and template
 metaprogramming facilities are implemented with the Boost \Cpp
 Library.
 %
@@ -107,7 +107,7 @@ The Boost source code is distributed with \CmdStan.
 
 \subsubsection{Eigen Matrix and Linear Algebra Library Source}
 
-\Stan's matrix algebra depends on the Eigen \Cpp matrix and linear
+Stan's matrix algebra depends on the Eigen \Cpp matrix and linear
 algebra library.  
 %
 \begin{itemize}
@@ -459,7 +459,7 @@ with
 
 \subsection{Setting a Variable}
 \CmdStan uses \code{make} for building the \CmdStan tools and
-compiling \Stan programs as executables. Users can customize how the
+compiling Stan programs as executables. Users can customize how the
 tools are built by editing \code{make/local} inside the
 \code{<cmdstan-home>} directory.
 
@@ -475,7 +475,7 @@ variables, write \Verb|<variable>+=<value>|.
 The most common options to set are the compiler options:
 %
 \begin{itemize}
-  \item \Verb|CC|. The compiler used to build \CmdStan and the \Stan
+  \item \Verb|CC|. The compiler used to build \CmdStan and the Stan
     executables. The default is \Verb|CC=g++|.
   \item \Verb|O|. The optimization level for the compiler. The default
     is \Verb|O=3|. Both \gpp and \clang recognize \Verb|0,1,2,3|, and
@@ -503,18 +503,18 @@ There are two options for controlling \stanc:
 \subsubsection{Changing Library Locations}
 
 The next set of variables allow for easy replacement of dependent
-libraries. \CmdStan depends on \Stan, Boost, Eigen, and
+libraries. \CmdStan depends on Stan, Boost, Eigen, and
 CVODES. Although \CmdStan is bundled with a particular verison of
-\Stan, other versions can be used. The same is true with Boost, Eigen,
+Stan, other versions can be used. The same is true with Boost, Eigen,
 and CVODES.
 
-The \Stan developers typically replace the tagged version of \Stan in
+The Stan developers typically replace the tagged version of Stan in
 \code{<cmdstan-home>/stan} with an updated version and do not set
 these variables. That said, it is easy to point \CmdStan to other
 versions of these libraries in other directories.
 %
 \begin{itemize}
-  \item \Verb|STAN|. The location of the \Stan source
+  \item \Verb|STAN|. The location of the Stan source
     directory. The default is \Verb|STAN=stan_2.15.0/|. Note: the
     trailing forward slash is necessary.
   \item \Verb|MATH|. The location of the Stan Math Library. The
@@ -542,7 +542,7 @@ These are the additional options and typically do not need to be set.
     programs. The default value is dependent on the operating system.
   \item \Verb|LDLIBS|. The libraries used for linking \CmdStan
     programs. The default value is dependent on the operating system.
-  \item \Verb|LDLIBS_STANC|. The libraries used for linking the \Stan
+  \item \Verb|LDLIBS_STANC|. The libraries used for linking the Stan
     compiler, \code{stanc}. The default is the value of \Verb|LDLIBS|.
   \item \Verb|BIT|. The bitness of the executable. This variable only
     applies to Windows. The default is \Verb|BIT=64|. If building on a
@@ -569,7 +569,7 @@ for the changes to take place. The easiest way to do this is to type:
   \end{Verbatim}
 \end{quote}
 %
-Then rebuild \CmdStan and the \Stan programs of interest.
+Then rebuild \CmdStan and the Stan programs of interest.
 
 
 \section{MKL Compiler Instructions}
@@ -680,7 +680,7 @@ License: BSD
 Tested Version(s): 1.7.0
 \end{itemize}
 %
-The Google Test framework is distributed with \Stan.
+The Google Test framework is distributed with Stan.
 
 
 \section{Tips for Mac OS X}
@@ -786,7 +786,7 @@ the installation approximately 3.5GB].
 Once it is downloaded, just click on the \code{.mpkg} file and then
 follow the installer instructions.  The installer will add the command
 to the \code{PATH} environment variable so that the \code{pdflatex}
-used by \Stan is available from the command line.
+used by Stan is available from the command line.
 
 
 %% \subsection{Lucida Console Font}

--- a/src/docs/cmdstan-guide/introduction.tex
+++ b/src/docs/cmdstan-guide/introduction.tex
@@ -2,7 +2,7 @@
 
 \noindent
 This document is a user's guide for the \CmdStan interface to the
-\Stan statistical modeling language. \CmdStan takes \Stan programs
+Stan statistical modeling language. \CmdStan takes Stan programs
 and generates executables that can be run directly from the command
 line. \CmdStan is one of several interfaces to Stan; there are also R,
 Python, Matlab, Julia, and Stata interfaces.
@@ -43,8 +43,8 @@ page (see \refsection{home-page}).
 \section{Benefits of \CmdStan}
 
 Although \CmdStan has the least amount of functionality among the
-\Stan interfaces, the minimal nature of \CmdStan makes it trivial to
-install and use the latest development version of the \Stan
+Stan interfaces, the minimal nature of \CmdStan makes it trivial to
+install and use the latest development version of the Stan
 library. It also has the fewest dependencies, which makes it easier to
 run in limited environments such as clusters. The output generated is
 in CSV format and can be post-processed using other Stan interfaces or

--- a/src/docs/cmdstan-guide/licensing.tex
+++ b/src/docs/cmdstan-guide/licensing.tex
@@ -1,7 +1,7 @@
 \chapter{Licensing}\label{licensing.appendix}
 
 \noindent
-\CmdStan, \Stan, and \Stan's three dependent libraries, Stan Math Library, Boost, and Eigen, are
+\CmdStan, Stan, and Stan's three dependent libraries, Stan Math Library, Boost, and Eigen, are
 distributed under liberal freedom-respecting%
 %
 \footnote{The link
@@ -19,7 +19,7 @@ be open source if they are redistributed.
 This chapter describes the licenses for the tools that are distributed
 with \CmdStan.  The next chapter explains some of the build tools that
 are not distributed with \CmdStan, but are required to build and run
-\Stan models.
+Stan models.
 
 \section{\CmdStan's License}
 
@@ -29,17 +29,17 @@ are not distributed with \CmdStan, but are required to build and run
 \url{http://www.opensource.org/licenses/BSD-3-Clause}
 \end{quote}
 
-\section{\Stan's License}
+\section{Stan's License}
 
-\Stan is distributed under the BSD 3-clause license (BSD New).
+Stan is distributed under the BSD 3-clause license (BSD New).
 %
 \begin{quote}
 \url{http://www.opensource.org/licenses/BSD-3-Clause}
 \end{quote}
 
-\section{\Stan Math Library's License}
+\section{Stan Math Library's License}
 
-The \Stan Math Library is distributed under the BSD 3-clause license (BSD New).
+The Stan Math Library is distributed under the BSD 3-clause license (BSD New).
 %
 \begin{quote}
 \url{http://www.opensource.org/licenses/BSD-3-Clause}

--- a/src/docs/cmdstan-guide/running.tex
+++ b/src/docs/cmdstan-guide/running.tex
@@ -167,7 +167,7 @@ written.
 \subsection{Variational Inference}
 
 \CmdStan can fit a variational approximation to the posterior. The approximation
-is a Gaussian in the unconstrained variable space. \Stan implements two
+is a Gaussian in the unconstrained variable space. Stan implements two
 variational algorithms. The \code{algorithm=meanfield} option uses a fully
 factorized Gaussian for the approximation. The \code{algorithm=fullrank} option
 uses a Gaussian with a full-rank covariance matrix for the approximation.
@@ -199,7 +199,7 @@ uses a Gaussian with a full-rank covariance matrix for the approximation.
 \CmdStan has a basic diagnostic feature that will calculate gradients of
 the initial state and compare them with those calculated with finite
 differences.  If there are discrepancies, there is a problem with the
-model or initial states (or a bug in \Stan).  To run on the different
+model or initial states (or a bug in Stan).  To run on the different
 platforms, use one of the following.
 
 \subsubsection{Mac OS and Linux}
@@ -596,9 +596,9 @@ memoryless windows; often fast parameters will be adapted here
 as well.  Lastly the fast parameters are allowed to adapt to the final
 update of the slow parameters.
 
-Currently all \Stan sampling algorithms utilize dual averaging to
+Currently all Stan sampling algorithms utilize dual averaging to
 optimize the step size (this optimization during adaptation of the
-sampler should not be confused with running \Stan's optimization method).
+sampler should not be confused with running Stan's optimization method).
 This optimization procedure is extremely flexible and for completeness
 we have exposed each option, using the notation of
 \citep{Hoffman-Gelman:2011, Hoffman-Gelman:2014}.  In practice the
@@ -776,18 +776,18 @@ For more information on the NUTS algorithm see \citep{Hoffman-Gelman:2011, Hoffm
 
 \subsubsection{Euclidean Metric}
 
-All HMC implementations in \Stan utilize quadratic kinetic energy
+All HMC implementations in Stan utilize quadratic kinetic energy
 functions which are specified up to the choice of a symmetric,
 positive-definite matrix known as a \textit{mass matrix} or, more
 formally, a \textit{metric} \citep{Betancourt-Stein:2011}.
 
 If the metric is constant then the resulting implementation is known
-as \textit{Euclidean} HMC.  \Stan allows for three Euclidean HMC
+as \textit{Euclidean} HMC.  Stan allows for three Euclidean HMC
 implementations: a unit metric, a diagonal metric, and a dense
 metric.  These can be specified with the values \code{unit\_e},
 \code{diag\_e}, and \code{dense\_e}, respectively.
 
-Future versions of \Stan will also include dynamic metrics associated
+Future versions of Stan will also include dynamic metrics associated
 with \textit{Riemannian} HMC \citep{GirolamiCalderhead:2011, Betancourt:2012}.
 %
 \begin{description}
@@ -1210,7 +1210,7 @@ generated quantities are ignored.
 
 The hierarchical structure of the command-line options can be
 intimidating, and here we provide an example workflow to help ease the
-introduction to new users, especially those used to \Stan 1.3 or
+introduction to new users, especially those used to Stan 1.3 or
 earlier releases.  The examples in this section are for Mac OS and
 Linux; on Windows, just remove the \code{./} before the executable and
 change the line-continuation character from Unix's
@@ -1239,7 +1239,7 @@ Failed to parse arguments, terminating Stan
 %
 The problem is that we forgot to specify a method.
 
-All \Stan arguments have default values, except for the method.  This
+All Stan arguments have default values, except for the method.  This
 is the only argument that must be specified by the user and a model
 will not run without it (not to say that the model will run without error,
 for example a model that requires data will eventually fail unless an input file

--- a/src/docs/cmdstan-guide/stanc.tex
+++ b/src/docs/cmdstan-guide/stanc.tex
@@ -1,4 +1,4 @@
-\chapter{{\tt\bfseries stanc}: Translating \Stan to C++}\label{stanc.chapter}
+\chapter{{\tt\bfseries stanc}: Translating Stan to C++}\label{stanc.chapter}
 
 \section{Building the \stanc Compiler}
 
@@ -24,8 +24,8 @@ To change the default compiler or the optimization level, see
 
 \section{The \stanc Compiler}
 
-The \stanc compiler converts \Stan programs to \Cpp concepts. The
-first stage of compilation involves parsing the text of the \Stan
+The \stanc compiler converts Stan programs to \Cpp concepts. The
+first stage of compilation involves parsing the text of the Stan
 program.  If the parser is successful, the second stage of compilation
 generates \Cpp code.  If the parser fails, it will provide an error
 message indicating the location in the input where the failure
@@ -69,7 +69,7 @@ any \Cpp reserved keyword.
 
 The \Cpp code implementing the class is written to the file
 \code{bernoulli.hpp} in the current directory.  The final argument,
-\code{bernoulli.stan}, is the file from which to read the \Stan
+\code{bernoulli.stan}, is the file from which to read the Stan
 program.
 
 \section{Command-Line Options for {\tt\bfseries stanc}}
@@ -80,7 +80,7 @@ The model translation program \code{stanc} is called as follows.
 \code{> stanc [options] {\slshape model\_file}}
 \end{quote}
 %
-The argument \code{\slshape model\_file} is a path to a \Stan model
+The argument \code{\slshape model\_file} is a path to a Stan model
 file ending in suffix \code{.stan}.  The options are as follows.
 %
 \begin{description}
@@ -98,7 +98,7 @@ and asking for help on the mailing lists.
 \item[\tt {-}-name={\slshape class\_name}]
 \mbox{ } \\ 
 Specify the name of the class used for the implementation of the
-\Stan model in the generated \Cpp code.  
+Stan model in the generated \Cpp code.  
 \\[2pt]
 Default: {\tt {\slshape class\_name = model\_file}\_model}
 %

--- a/src/docs/cmdstan-guide/tools.tex
+++ b/src/docs/cmdstan-guide/tools.tex
@@ -1,21 +1,21 @@
 \chapter{Overview}
 
 \noindent
-\CmdStan is the command-line interface for \Stan. The next two
+\CmdStan is the command-line interface for Stan. The next two
 chapters describes tools that are built as part of \CmdStan
 installation: \code{stanc} and \code{stansummary}. The process of building a
-\CmdStan executable from a \Stan program is as follows:
+\CmdStan executable from a Stan program is as follows:
 %
 \begin{enumerate}
-  \item A \Stan program is written to file with a \code{.stan}
+  \item A Stan program is written to file with a \code{.stan}
     extension.
-  \item \code{stanc} is used to translate the \Stan program into a
+  \item \code{stanc} is used to translate the Stan program into a
     \Cpp file. This \Cpp file is not a full program that can be
-    compiled to executable directly, but a translation from the \Stan
+    compiled to executable directly, but a translation from the Stan
     language into a \Cpp concept. Each interface will generate identical
-    \Cpp for the same \Stan program.
+    \Cpp for the same Stan program.
   \item A \CmdStan exectuable is generated from the \CmdStan source
-    and the generated \Cpp. Each \Stan program will have its own
+    and the generated \Cpp. Each Stan program will have its own
     \CmdStan executable. The options to the \CmdStan executable are
     described in \refchapter{stan-cmd}.
 \end{enumerate}


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [X Declare copyright holder and open-source license: see below

#### Summary:
Stan reference manual no longer has defined newcommand "\Stan", removed use of this macro in the CmdStan manual.

#### Intended Effect:
Permit manual to build, cmdstan release to proceed.

#### How to Verify:
run "make manual"

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Mitzi Morris

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
