### PR TITLE
Clarifying use of forward slash for Windows in doc

### DIFF
--- a/src/docs/cmdstan-guide/getting-started.tex
+++ b/src/docs/cmdstan-guide/getting-started.tex
@@ -189,9 +189,8 @@ A Stan program must be in a file with the file extension
 \code{.stan}. To create an executable from a Stan program, \code{make}
 will be called with the name of the executable as its argument. For
 Mac and Linux, it is the name of the Stan program with the
-\code{.stan} omitted. For Windows, replace .stan with .exe, and make
-sure that the path is given with slashes and not backslashes.
-\code{.exe}.
+\code{.stan} omitted. For Windows, replace \code{.stan} with \code{.exe},
+and make sure that the path is given with slashes and not backslashes.
 
 To build the Bernoulli example, use the following command for Mac and
 Linux:

--- a/src/docs/cmdstan-guide/getting-started.tex
+++ b/src/docs/cmdstan-guide/getting-started.tex
@@ -186,10 +186,11 @@ first translate the Stan program to \Cpp, then compile the \Cpp code
 to an executable.)
 
 A Stan program must be in a file with the file extension
-\code{.stan}. To create an executable from a Stan program,
-\code{make} will be called with the name of the executable as its
-argument. For Mac and Linux, it is the name of the Stan program with
-the \code{.stan} omitted. For Windows, replace \code{.stan} with
+\code{.stan}. To create an executable from a Stan program, \code{make}
+will be called with the name of the executable as its argument. For
+Mac and Linux, it is the name of the Stan program with the
+\code{.stan} omitted. For Windows, replace .stan with .exe, and make
+sure that the path is given with slashes and not backslashes.
 \code{.exe}.
 
 To build the Bernoulli example, use the following command for Mac and
@@ -202,7 +203,7 @@ Linux:
 \end{quote}
 %
 For Windows, the command is the same with the addition of \code{.exe}
-at the end of the target:
+at the end of the target (note: use forward slashes):
 \begin{quote}
 \begin{Verbatim}[fontshape=sl]
 > make examples/bernoulli/bernoulli.exe
@@ -959,4 +960,3 @@ and on Windows with
 %% matrices) or may be misformulated.  In a future version of Stan, we
 %% plan to rank such messages by severity and turn this one off by
 %% default so as not to needlessly worry users.
-


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Address #557: adding note to use forward slash in doc.

#### Intended Effect:

Make directions for Windows users clearer.

#### How to Verify:

See doc.

#### Side Effects:

None.

#### Documentation:

All doc.

#### Reviewer Suggestions: 

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Stan Group

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
