### PR TITLE
Use precompiled headers to shave off ~15% compile time for models.

### DIFF
--- a/make/models
+++ b/make/models
@@ -2,17 +2,21 @@
 # Models (to be passed through stanc)
 ##
 MODEL_HEADER := $(STAN)src/stan/model/model_header.hpp
+MODEL_PCH := $(MODEL_HEADER:.hpp=.hpp.gch)
 CMDSTAN_MAIN := src/cmdstan/main.cpp
 
+$(MODEL_PCH) : $(MODEL_HEADER)
+	@echo 'Compiling pre-compiled header'
+	$(COMPILE.cc) -O$O $(MODEL_HEADER) -o $@
 
 .PRECIOUS: %.hpp %.o
-$(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE) : %.hpp %.stan bin/stanc$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) $(LIBCVODES)
+$(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE) : %.hpp %.stan bin/stanc$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) $(LIBCVODES) $(MODEL_PCH)
 	@echo ''
 	@echo '--- Linking C++ model ---'
 ifneq (,$(findstring allow_undefined,$(STANCFLAGS)))
-	$(LINK.cc) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< -include $(USER_HEADER) $(LIBCVODES)
+	$(LINK.cc) -include-pch $(MODEL_PCH) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< -include $(USER_HEADER) $(LIBCVODES)
 else
-	$(LINK.cc) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< $(LIBCVODES)
+	$(LINK.cc) -include-pch $(MODEL_PCH) -O$O $(OUTPUT_OPTION) $(CMDSTAN_MAIN) -include $< $(LIBCVODES)
 endif
 
 .PRECIOUS: %.hpp
@@ -20,4 +24,3 @@ endif
 	@echo ''
 	@echo '--- Translating Stan model to C++ code ---'
 	$(WINE) bin$(PATH_SEPARATOR)stanc$(EXE) $(STANCFLAGS) $< --o=$@
-

--- a/makefile
+++ b/makefile
@@ -249,6 +249,7 @@ clean-manual:
 
 clean-all: clean clean-libraries
 	$(RM) -r bin
+	$(RM) $(STAN)src/stan/model/model_header.hpp.gch
 
 ##
 # Submodule related tasks


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Change CmdStan to use precompiled headers. On my machine this cuts out about 4-5 seconds of compile time (once everything else is compiled and we're just compiling and linking the CPP model). I doubt this scales linearly with more complicated models but who knows! My bernoulli example takes about 24s without PCH and 19s with. @bgoodri might be worth porting to RStan?

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
