### PR TITLE
Remove "Reviewer Suggestions" from the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,6 @@
 
 #### Documentation:
 
-#### Reviewer Suggestions: 
-
 #### Copyright and Licensing
 
 Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test` (N/A)
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Updating the pull request template to remove "Reviewer Suggestions". It's now in the GitHub pull request web interface.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Generable

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
