### PR TITLE
Bugfix/issue 602 adapt stepsize

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -252,7 +252,10 @@ namespace cmdstan {
         double stepsize = dynamic_cast<real_argument*>(hmc->arg("stepsize"))->value();
         double stepsize_jitter= dynamic_cast<real_argument*>(hmc->arg("stepsize_jitter"))->value();
 
-        if (engine->value() == "nuts" && metric->value() == "dense_e" && adapt_engaged == false && metric_supplied == false) {
+        if (adapt_engaged == true && num_warmup == 0) {
+          info("The number of warmup samples (num_warmup) must be greater than zero if adaptation is enabled.");
+          return_code = stan::services::error_codes::CONFIG;
+        } else if (engine->value() == "nuts" && metric->value() == "dense_e" && adapt_engaged == false && metric_supplied == false) {
           int max_depth = dynamic_cast<int_argument*>(dynamic_cast<categorical_argument*>(algo->arg("hmc")->arg("engine")->arg("nuts"))->arg("max_depth"))->value();
           return_code = stan::services::sample::hmc_nuts_dense_e(model,
                                                                  init_context,

--- a/src/docs/cmdstan-guide/running.tex
+++ b/src/docs/cmdstan-guide/running.tex
@@ -810,8 +810,9 @@ The \code{metric\_file} option can be used with and without adaptation enabled.
 If adaptation is enabled, the provided metric will be used as the initial
 guess in the adaptation process. If the initial guess is good, then adaptation
 should not change it much. If the metric is no good, then the adaptation will
-override the initial guess. An example of running the sampler with adaptation
-enabled without specifying a stepsize is
+override the initial guess. If adaptation is enabled, \code{num\_warmup} must be
+set to a value greater than zero. An example of running the sampler with
+adaptation enabled without specifying a stepsize is
 
 \begin{quote}
   \begin{Verbatim}[fontshape=sl]

--- a/src/test/interface/csv_header_consistency_test.cpp
+++ b/src/test/interface/csv_header_consistency_test.cpp
@@ -21,7 +21,7 @@ TEST(interface,csv_header_consistency) {
 
   std::string command
     = path
-    + " sample num_warmup=0 num_samples=1"
+    + " sample num_warmup=1 num_samples=1"
     + " output file=" + samples;
 
   run_command_output out = run_command(command);

--- a/src/test/interface/metric_test.cpp
+++ b/src/test/interface/metric_test.cpp
@@ -61,19 +61,24 @@ TEST(StanUiCommand, metric_file_test) {
                 " stepsize=" + stepsize + " output file=test/output.csv";
 
               run_command_output out = run_command(command);
-              EXPECT_EQ(int(stan::services::error_codes::OK), out.err_code);
+              if(adapt == "1" && num_warmup == "0") {
+                EXPECT_EQ(int(stan::services::error_codes::CONFIG),
+                          out.err_code);
+              } else {
+                EXPECT_EQ(int(stan::services::error_codes::OK), out.err_code);
 
-              std::fstream output_csv_stream("test/output.csv");
-              std::stringstream output_sstream;
-              output_sstream << output_csv_stream.rdbuf();
-              output_csv_stream.close();
-              std::string output = output_sstream.str();
+                std::fstream output_csv_stream("test/output.csv");
+                std::stringstream output_sstream;
+                output_sstream << output_csv_stream.rdbuf();
+                output_csv_stream.close();
+                std::string output = output_sstream.str();
 
-              EXPECT_EQ(1, count_matches(expected_output[model][metric],
-                                         output));
-              if(adapt == "0")
-                EXPECT_EQ(1, count_matches("# Step size = " + stepsize,
+                EXPECT_EQ(1, count_matches(expected_output[model][metric],
                                            output));
+                if(adapt == "0")
+                  EXPECT_EQ(1, count_matches("# Step size = " + stepsize,
+                                             output));
+              }
             }
           }
         }

--- a/src/test/interface/metric_test.cpp
+++ b/src/test/interface/metric_test.cpp
@@ -18,6 +18,8 @@ TEST(StanUiCommand, metric_file_test) {
   std::vector<std::string> engines = { "static", "nuts" };
   std::vector<std::string> metrics = { "diag_e", "dense_e" };
   std::vector<std::string> adapts = { "0", "1" };
+  std::vector<std::string> stepsizes = { "0.1", "0.5", "1.25" };
+  std::vector<std::string> num_warmups = { "0", "1", "100" };
 
   std::map<std::string, std::map<std::string, std::string> > expected_output = {
     { "proper", {
@@ -36,34 +38,44 @@ TEST(StanUiCommand, metric_file_test) {
     for (auto engine : engines) {
       for (auto metric : metrics) {
         for (auto adapt : adapts) {
-          std::vector<std::string> model_path;
-          model_path.push_back("src");
-          model_path.push_back("test");
-          model_path.push_back("test-models");
-          model_path.push_back(model);
+          for (auto stepsize : stepsizes) {
+            for (auto num_warmup : num_warmups) {
+              std::vector<std::string> model_path;
+              model_path.push_back("src");
+              model_path.push_back("test");
+              model_path.push_back("test-models");
+              model_path.push_back(model);
 
-          std::vector<std::string> metric_file_path;
-          metric_file_path.push_back("src");
-          metric_file_path.push_back("test");
-          metric_file_path.push_back("test-models");
-          metric_file_path.push_back(model + "." + metric + "_metric.dat.R");
+              std::vector<std::string> metric_file_path;
+              metric_file_path.push_back("src");
+              metric_file_path.push_back("test");
+              metric_file_path.push_back("test-models");
+              metric_file_path.push_back(model + "." + metric +
+                                         "_metric.dat.R");
 
-          std::string command = convert_model_path(model_path) +
-            " method=sample num_samples=1 num_warmup=1 adapt engaged=" + adapt +
-            " algorithm=hmc engine=" + engine + " metric=" + metric +
-            " metric_file=" + convert_model_path(metric_file_path) +
-            " output file=test/output.csv";
+              std::string command = convert_model_path(model_path) +
+                " method=sample num_samples=100 num_warmup=" + num_warmup +
+                " adapt engaged=" + adapt + " algorithm=hmc engine=" + engine +
+                " metric=" + metric +
+                " metric_file=" + convert_model_path(metric_file_path) +
+                " stepsize=" + stepsize + " output file=test/output.csv";
 
-          run_command_output out = run_command(command);
-          EXPECT_EQ(int(stan::services::error_codes::OK), out.err_code);
+              run_command_output out = run_command(command);
+              EXPECT_EQ(int(stan::services::error_codes::OK), out.err_code);
 
-          std::fstream output_csv_stream("test/output.csv");
-          std::stringstream output_sstream;
-          output_sstream << output_csv_stream.rdbuf();
-          output_csv_stream.close();
-          std::string output = output_sstream.str();
+              std::fstream output_csv_stream("test/output.csv");
+              std::stringstream output_sstream;
+              output_sstream << output_csv_stream.rdbuf();
+              output_csv_stream.close();
+              std::string output = output_sstream.str();
 
-          EXPECT_EQ(1, count_matches(expected_output[model][metric], output));
+              EXPECT_EQ(1, count_matches(expected_output[model][metric],
+                                         output));
+              if(adapt == "0")
+                EXPECT_EQ(1, count_matches("# Step size = " + stepsize,
+                                           output));
+            }
+          }
         }
       }
     }

--- a/src/test/interface/model_output_test.cpp
+++ b/src/test/interface/model_output_test.cpp
@@ -16,7 +16,7 @@ TEST(interface, check_model_output) {
 
   std::string command 
     = convert_model_path(model_path)
-    + " sample num_warmup=0 num_samples=0"
+    + " sample num_warmup=1 num_samples=0"
     + " output file=" + convert_model_path(model_path) + ".csv";
   
   run_command_output out = run_command(command);

--- a/src/test/interface/print_uninitialized_test.cpp
+++ b/src/test/interface/print_uninitialized_test.cpp
@@ -16,7 +16,7 @@ TEST(interface,print_uninitialized) {
 
   std::string command 
     = convert_model_path(model_path)
-    + " sample num_warmup=0 num_samples=0"
+    + " sample num_warmup=1 num_samples=0"
     + " output file=" + convert_model_path(model_path) + ".csv";
   
   run_command_output out = run_command(command);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Adds more tests for custom specified metrics and also adds an error that gets thrown if adaptation is enabled with num_warmup=0

To reviewer: Am I putting that check in the right place? It's right here: https://github.com/bbbales2/cmdstan-rus/blob/95cb7995d25c307f6054f53ad4675e5cbe80c08e/src/cmdstan/command.hpp#L255. Doesn't seem to be a whole lot of other checking going on in command.hpp.

#### How to Verify:

Build the bernoulli example and then try to run it with:

```
./bernoulli method=sample num_samples=1 num_warmup=0 adapt engaged=1 algorithm=hmc engine=nuts stepsize=1e-7 data file=bernoulli.data.R output file=output1.csv
```

And you should get the message:

"The number of warmup samples (num_warmup) must be greater than zero if adaptation is enabled."

And the program should exit

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): University of California, Santa Barbara

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
