### PR TITLE
Add the pre-compiled header to the `build` make target.

### DIFF
--- a/makefile
+++ b/makefile
@@ -242,7 +242,7 @@ endif
 	@echo '--------------------------------------------------------------------------------'
 
 .PHONY: build
-build: bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE) $(LIBCVODES)
+build: bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE) $(LIBCVODES) $(MODEL_PCH)
 	@echo ''
 	@echo '--- CmdStan v$(CMDSTAN_VERSION) built ---'
 


### PR DESCRIPTION
This lets us get all of the binaries out of the way at once, which is
useful for figuring out what to ship for e.g. nix packages.

Fixes #610

We need to double check that this works on all of our supported
compilers.

#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
