### PR TITLE
fix Intel compiler doc

### DIFF
--- a/src/docs/cmdstan-guide/installation.tex
+++ b/src/docs/cmdstan-guide/installation.tex
@@ -614,9 +614,10 @@ performance gains.
 \subsection{Additional compiler options}
 
 By default, Intel's compiler trades off accuracy for speed. This,
-unfortunately, isn't ideal behavior for the inference algorithms
-and may cause divergent transitions. Add these flags to \code{make/local}
-to force more accurate floating point computations:
+unfortunately, isn't ideal behavior for the inference algorithms and
+may cause divergent transitions to go {\em unreported}. Add these
+flags to \code{make/local} to force more accurate floating point
+computations which ensure that divergent transitions are reported:
 \begin{itemize}
   \item \Verb|CXXFLAGS += -fp-model precise -fp-model source|
 \end{itemize}


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:
Correct the doc for Intel compilers... the reason to switch on the precision arguments for Intel need to corrected.

#### Intended Effect:
Make doc correct.

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
