### PR TITLE
add libstanmath_mpi to makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -83,6 +83,7 @@ CXX = $(CC)
 -include $(MATH)make/detect_os
 
 -include $(MATH)make/setup_mpi
+-include $(MATH)make/libstanmath_mpi # $(MATH)bin/libstanmath_mpi.a
 
 include make/libstan  # libstan.a
 include make/models   # models


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Sync makefile for MPI builds.

#### Intended Effect:
Bring makefiles in sync with stan-math in case of MPI enabled builds. This (should) fixes the currently broken tests on Jenkins which blocks all down-stream tests.

#### How to Verify:
Enable MPI (put `STAN_MPI= true` & `CC=mpicxx` in `make/local`) and then a 
`make build-mpi`
should work again.

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
