### PR TITLE
[WIP] Try fixing the default compiler setting on Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - eval "${MATRIX_EVAL}"
   - echo ${CXX}
   - ${CXX} --version
-  - echo "CC=$CXX" > make/local
+  - echo "CXX=$CXX" > make/local
 
 linux_clang: &linux_clang
   os: linux

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ def checkout_pr(String repo, String pr) {
 
 def setupCC(CC = env.CXX) {
     unstash 'CmdStanSetup'
-    writeFile(file: "make/local", text: "CC = ${CC}\n")
+    writeFile(file: "make/local", text: "CXX = ${CC}\n")
 }
 
 def runTests(String prefix = "") {

--- a/makefile
+++ b/makefile
@@ -60,8 +60,6 @@ CMDSTAN_VERSION := 2.17.1
 -include $(HOME)/.config/cmdstan/make.local  # define local variables
 -include make/local                       # overwrite local variables
 
-CXX = $(CC)
-
 -include $(MATH)make/libraries
 
 ##

--- a/src/docs/cmdstan-guide/getting-started.tex
+++ b/src/docs/cmdstan-guide/getting-started.tex
@@ -910,7 +910,7 @@ and on Windows with
 %% \emph{Warning}: \ The unit tests can take 30+ minutes and consume 3+
 %% GB of memory with the default compiler, \code{g++}.  The distribution
 %% test and model tests can take even longer.  It is faster to run the
-%% Clang compiler (option \code{CC=clang++}), and to run in multiple
+%% Clang compiler (option \code{CXX=clang++}), and to run in multiple
 %% processes in parallel (e.g., option \code{-j4} for four threads).
 
 %% \subsection{Compile-time Errors}


### PR DESCRIPTION
Seems like on Mac, the default situation (without any `make/local` file) is broken for at least some of us. There are errors [like this one](http://d1m1s1b1.stat.columbia.edu:8080/job/CmdStan%20Performance%20Tests/job/master/153/console)

```
cc -Wall -I . -isystem stan/lib/stan_math/lib/eigen_3.3.3 -isystem stan/lib/stan_math/lib/boost_1.66.0 -isystem stan/lib/stan_math/lib/sundials_3.1.0/include -std=c++1y -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION -Wno-unused-function -Wno-uninitialized -I src -isystem stan/src -isystem stan/lib/stan_math/ -DFUSION_MAX_VECTOR_SIZE=12 -Wno-unused-local-typedefs -DEIGEN_NO_DEBUG -march=core2 -DNO_FPRINTF_OUTPUT -pipe   -O0 -o bin/diagnose bin/cmdstan/diagnose.o
Undefined symbols for architecture x86_64:
  "std::logic_error::what() const", referenced from:
      vtable for boost::exception_detail::error_info_injector<std::logic_error> in diagnose.o
      vtable for boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<std::logic_error> > in diagnose.o
      vtable for boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<std::domain_error> > in diagnose.o
      vtable for boost::exception_detail::error_info_injector<std::domain_error> in diagnose.o
  "std::runtime_error::what() const", referenced from:
      vtable for boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<std::overflow_error> > in diagnose.o
      vtable for boost::exception_detail::error_info_injector<std::overflow_error> in diagnose.o
      vtable for boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::math::rounding_error> > in diagnose.o
      vtable for boost::exception_detail::error_info_injector<boost::math::rounding_error> in diagnose.o
      vtable for boost::math::rounding_error in diagnose.o
      vtable for boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::math::evaluation_error> > in diagnose.o
      vtable for boost::exception_detail::error_info_injector<boost::math::evaluation_error> in diagnose.o
      ...

```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
