### PR TITLE
fix makefiles in case MPI is turned on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_script:
   - echo ${CXX}
   - ${CXX} --version
   - echo "CXX=$CXX" > make/local
+  - echo "CXXFLAGS+=$CXXFLAGS" >> make/local
 
 linux_clang: &linux_clang
   os: linux
@@ -48,6 +49,7 @@ matrix:
     - <<: *linux_clang
       env:
         - MATRIX_EVAL="CXX=clang++-3.8"
+          CXXFLAGS="-stdlib=libc++"
           PARALLEL=2
     - <<: *linux_gcc
       env:
@@ -56,6 +58,7 @@ matrix:
     - <<: *mpi_linux_clang
       env:
         - MATRIX_EVAL="CXX=\"mpicxx -cxx=clang++-3.8\""
+          CXXFLAGS="-stdlib=libc++"
           STAN_MPI=true
           PARALLEL=2
     - <<: *mpi_linux_gcc

--- a/make/models
+++ b/make/models
@@ -7,16 +7,16 @@ CMDSTAN_MAIN := src/cmdstan/main.cpp
 
 $(MODEL_PCH) : $(MODEL_HEADER)
 	@echo 'Compiling pre-compiled header'
-	$(COMPILE.cc) -O$O $(MODEL_HEADER) -o $@
+	$(COMPILE.cc) -O$O $(CXXFLAGS_MPI) $(MODEL_HEADER) -o $@
 
 .PRECIOUS: %.hpp %.o
 $(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE) : %.hpp %.stan bin/stanc$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) $(LIBMPI) $(LIBSUNDIALS) $(MODEL_PCH)
 	@echo ''
 	@echo '--- Linking C++ model ---'
 ifneq (,$(findstring allow_undefined,$(STANCFLAGS)))
-	$(LINK.cc) $(CMDSTAN_MAIN) $(if $(filter $(CC_TYPE),clang++),-include-pch $(MODEL_PCH)) -O$O $(OUTPUT_OPTION) -include $< -include $(USER_HEADER) $(LIBSUNDIALS) $(LIBMPI)
+	$(LINK.cc) $(CMDSTAN_MAIN) $(if $(filter $(CC_TYPE),clang++),-include-pch $(MODEL_PCH)) -O$O $(OUTPUT_OPTION) -include $< -include $(USER_HEADER) $(LIBSUNDIALS) $(CXXFLAGS_MPI) $(LIBMPI) $(LDFLAGS_MPI)
 else
-	$(LINK.cc) $(CMDSTAN_MAIN) $(if $(filter $(CC_TYPE),clang++),-include-pch $(MODEL_PCH)) -O$O $(OUTPUT_OPTION) -include $< $(LIBSUNDIALS) $(LIBMPI)
+	$(LINK.cc) $(CMDSTAN_MAIN) $(if $(filter $(CC_TYPE),clang++),-include-pch $(MODEL_PCH)) -O$O $(OUTPUT_OPTION) -include $< $(LIBSUNDIALS) $(CXXFLAGS_MPI) $(LIBMPI) $(LDFLAGS_MPI)
 endif
 
 .PRECIOUS: %.hpp


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run tests: `./runCmdStanTests.py src/test`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Ensure that with enabled MPI the models are build with the MPI flags for the compiler.

#### Intended Effect:
Make MPI models work as advertised.

#### How to Verify:
Put
```
CXX=mpicxx
STAN_MPI=true
```
into `make/local`; then build cmdstan and compile the bernoulli example. On the old develop no `-DSTAN_MPI` shows up in the options for the compiler, but in this version it does show up as it has to be.

#### Side Effects:
None

#### Documentation:
?

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)