### PR TITLE
Create AppVeyor.yml to test windows builds

### DIFF
--- a/AppVeyor.yml
+++ b/AppVeyor.yml
@@ -1,0 +1,116 @@
+# Notes:
+#   - Minimal appveyor.yml file is an empty file. All sections are optional.
+#   - Indent each level of configuration with 2 spaces. Do not use tabs!
+#   - All section names are case-sensitive.
+#   - Section names should be unique on each level.
+
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+# version format
+version: 1.0.{build}
+
+# you can use {branch} name in version format too
+# version: 1.0.{build}-{branch}
+
+# branches to build
+branches:
+  # whitelist
+  only:
+    - master
+
+  # blacklist
+  except:
+    - gh-pages
+
+
+# Maximum number of concurrent jobs for the project
+max_jobs: 1
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+# Build worker image (VM template)
+image: Visual Studio 2017
+
+# scripts that are called at very beginning, before repo cloning
+init:
+  - git config --global core.autocrlf input
+
+# clone directory
+clone_folder: c:\projects\cmdstan
+
+# set clone depth
+clone_depth: 1                      # clone entire repository history if not defined
+
+# this is how to allow failing jobs in the matrix
+matrix:
+  fast_finish: true     # set this flag to immediately finish build once one of the jobs fails.
+  allow_failures:
+    - platform: x86
+      configuration: Debug
+    - platform: x64
+      configuration: Release
+
+# exclude configuration from the matrix. Works similarly to 'allow_failures' but build not even being started for excluded combination.
+  exclude:
+    - platform: x86
+      configuration: Debug
+
+# build cache to preserve files/folders between builds
+cache:
+  - c:\Rtools  
+  - Rtools34.exe
+
+
+# scripts that run after cloning repository
+install:
+  - git submodule update --init --recursive
+  - ps: Start-FileDownload 'https://cran.r-project.org/bin/windows/Rtools/Rtools34.exe' 
+  - Rtools34.exe /VERYSILENT /SP- /NORESTART  #TODO: dont download and install if c:\rtools folder exists.
+
+
+
+# build Configuration, i.e. Debug, Release, etc.
+configuration: Release
+
+
+# scripts to run before build
+before_build:
+
+# to run your custom scripts instead of automatic MSBuild
+build_script:
+  - echo This is my custom build script
+  - set PATH=C:\Rtools\bin;c:\Rtools\mingw_64\bin;%PATH%
+  - echo %PATH%
+  - make build
+
+# scripts to run after build (working directory and environment changes are persisted from the previous steps)
+after_build:
+  - echo AfterBuild
+
+
+#---------------------------------#
+#       tests configuration       #
+#---------------------------------#
+
+# scripts to run before tests (working directory and environment changes are persisted from the previous steps such as "before_build")
+before_test:
+  - echo script1
+  - ps: Write-Host "script1"
+
+# to run your custom scripts instead of automatic tests
+test_script:
+  - echo This is my custom test script
+  - echo %PATH%  
+  - set PATH=C:\Rtools\bin;c:\Rtools\mingw_64\bin;%PATH%
+  - echo %PATH%  
+  - make examples/bernoulli/bernoulli
+
+# scripts to run after tests
+after_test:
+
+# to disable automatic tests
+#test: off

--- a/AppVeyor.yml
+++ b/AppVeyor.yml
@@ -9,10 +9,8 @@
 #---------------------------------#
 
 # version format
-version: 1.0.{build}
+version: 1.0.{build}-{branch}
 
-# you can use {branch} name in version format too
-# version: 1.0.{build}-{branch}
 
 # branches to build
 branches:
@@ -60,10 +58,7 @@ matrix:
       configuration: Debug
 
 # build cache to preserve files/folders between builds
-cache:
-  - c:\Rtools  
-  - Rtools34.exe
-
+# TODO: implement cache for Rtools
 
 # scripts that run after cloning repository
 install:
@@ -71,14 +66,8 @@ install:
   - ps: Start-FileDownload 'https://cran.r-project.org/bin/windows/Rtools/Rtools34.exe' 
   - Rtools34.exe /VERYSILENT /SP- /NORESTART  #TODO: dont download and install if c:\rtools folder exists.
 
-
-
 # build Configuration, i.e. Debug, Release, etc.
-configuration: Release
-
-
-# scripts to run before build
-before_build:
+configuration: Debug
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:
@@ -87,30 +76,16 @@ build_script:
   - echo %PATH%
   - make build
 
-# scripts to run after build (working directory and environment changes are persisted from the previous steps)
-after_build:
-  - echo AfterBuild
-
-
 #---------------------------------#
 #       tests configuration       #
 #---------------------------------#
 
 # scripts to run before tests (working directory and environment changes are persisted from the previous steps such as "before_build")
 before_test:
-  - echo script1
-  - ps: Write-Host "script1"
+  - echo BeforeTest
 
 # to run your custom scripts instead of automatic tests
 test_script:
   - echo This is my custom test script
-  - echo %PATH%  
   - set PATH=C:\Rtools\bin;c:\Rtools\mingw_64\bin;%PATH%
-  - echo %PATH%  
   - make examples/bernoulli/bernoulli
-
-# scripts to run after tests
-after_test:
-
-# to disable automatic tests
-#test: off


### PR DESCRIPTION

#### Submisison Checklist

- [ x ] Run tests: (This is only a config file with no side effects.)
- [ x ] Declare copyright holder and open-source license: see below

#### Summary:

AppVeyor is a continous integration tool which can be used to test the build process on windows. 

Adding this file allows you to test the window builds using AppVeyor. (You need to setup an AppVeyor to do that.) This is an initial draft configuration file which downloads Rtools34 and executes `make build`. see #627   



#### Intended Effect:

AppVeyor should attempt to build cmdstan - later it can also run the test suite.

#### How to Verify:

* Open an account at AppVeyor
* Add the cmdstan repo to AppVeyor
* Manually trigger a build from the AppVeyor pages.


#### Side Effects:

The windows build is currently failing (as reported in various issues on github). Perhaps AppVeyor will help somebody solve the problem even if they dont use windows themselves. 

#### Documentation:

https://www.appveyor.com/docs/appveyor-yml/

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Aslak Grinsted

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
