### PR TITLE
Fixes #653. Doesn't include things when calling stan-update

### DIFF
--- a/makefile
+++ b/makefile
@@ -38,7 +38,7 @@ include make/program
 include make/tests
 include make/command
 
-ifneq ($(filter-out clean clean-% print-% help help-% manual,$(MAKECMDGOALS)),)
+ifneq ($(filter-out clean clean-% print-% help help-% manual stan-update/% stan-update stan-pr/%,$(MAKECMDGOALS)),)
 -include $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP))
 -include src/cmdstan/stanc.d
 endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

When running `make stan-update`, it stops building the dependency files.

#### Intended Effect:

Get back to intended behavior.

#### How to Verify:

Run `make stan-update`. It shouldn't be calling `g++` as it currently does now.

#### Side Effects:

None.

#### Documentation:

None.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Generable

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
