### PR TITLE
Issue/660 makefile for cmdstan manual

### DIFF
--- a/makefile
+++ b/makefile
@@ -45,9 +45,6 @@ endif
 
 CMDSTAN_VERSION := 2.18.0
 
--include $(STAN)make/manual
-
-
 .PHONY: help
 help:
 	@echo '--------------------------------------------------------------------------------'
@@ -205,9 +202,16 @@ stan-revert:
 ##
 # Manual related
 ##
+
 .PHONY: src/docs/cmdstan-guide/cmdstan-guide.tex
 manual: src/docs/cmdstan-guide/cmdstan-guide.pdf
-	mv -f src/docs/cmdstan-guide/cmdstan-guide.pdf doc/cmdstan-guide-$(VERSION_STRING).pdf
+	mkdir -p doc
+	mv -f src/docs/cmdstan-guide/cmdstan-guide.pdf doc/cmdstan-guide-$(CMDSTAN_VERSION).pdf
+
+%.pdf: %.tex
+	cd $(dir $@); latexmk -pdf -pdflatex="pdflatex -file-line-error" -use-make $(notdir $^)
+
+
 
 ##
 # Debug target that allows you to print a variable

--- a/src/docs/cmdstan-guide/bibtex/all.bib
+++ b/src/docs/cmdstan-guide/bibtex/all.bib
@@ -1,0 +1,1298 @@
+% a do-nothing command that serves a purpose
+@preamble{ " \newcommand{\noop}[1]{} " }
+
+@book{Feller1968,
+  title={An Introduction to Probability Theory and its Applications},
+  author={Feller, William},
+  volume={1},
+  number={3},
+  year={1968},
+  publisher={Wiley, New York}
+}
+
+@article{NavarroFuss2009,
+  title={Fast and accurate calculations for first-passage times in {W}iener diffusion models},
+  author={Navarro, Daniel J and Fuss, Ian G},
+  journal={Journal of Mathematical Psychology},
+  volume={53},
+  number={4},
+  pages={222--230},
+  year={2009}
+}
+
+@article{barnard-mcculloch-meng:2000,
+  title={Modeling covariance matrices in terms of standard deviations and correlations, with application to shrinkage},
+  author={Barnard, John and McCulloch, Robert and Meng, Xiao-Li},
+  journal={Statistica Sinica},
+  pages={1281--1311},
+  year={2000},
+}
+
+@article{lancaster:2000,
+  title={The incidental parameter problem since 1948},
+  author={Lancaster, Tony},
+  journal={Journal of Econometrics},
+  volume={95},
+  number={2},
+  pages={391--413},
+  year={2000}
+}
+
+@manual{minpack:1980,
+	Address = {9700 South Cass Avenue, Argonne, Illinois 60439},
+	Author = {Jorge J. More, Burton S. Garbow, Kenneth E. Hillstrom},
+	Month = {August},
+	Organization = {Argonne National Laboratory},
+	Title = {User Guide for MINPACK-1},
+	Year = {1980}
+}
+
+@incollection{Powell:1970,
+	Author = {Powell, Michael J. D.},
+	Booktitle = {Numerical Methods for Nonlinear Algebraic Equations},
+	Editor = {Rabinowitz, P.},
+	Publisher = {Gordon and Breach},
+	Title = {A Hybrid Method for Nonlinear Equations},
+	Year = {1970}
+}
+
+@inproceedings{PiironenVehtari:2016,
+  title={Projection predictive model selection for {Gaussian} processes},
+  author={Piironen, Juho and Vehtari, Aki},
+  booktitle={Machine Learning for Signal Processing (MLSP), 2016 IEEE 26th International Workshop on},
+  note = {doi:10.1109/MLSP.2016.7738829},
+  year=2016,
+  organization={IEEE}
+}
+
+@article{AhnertMulansky:2011,
+  author={Ahnert, Karsten and Mulansky, Mario},
+  year={2011},
+  title={Odeint---solving ordinary differential equations in {C}++},
+  journal={arXiv},
+  volume={1110.3397}
+}
+
+@article{DormandPrince:1980,
+  author={Dormand, John R and Prince, Peter J},
+  year={1980},
+  title={A family of embedded {R}unge-{K}utta formulae},
+  journal={Journal of Computational and Applied Mathematics},
+  volume={6},
+  number={1},
+  pages={19--26}
+}
+
+@article{CohenHindmarsh:1996,
+  author={Cohen, Scott D and Hindmarsh, Alan C},
+  year={1996},
+  title={{CVODE}, a stiff/nonstiff {ODE} solver in {C}},
+  journal={Computers in Physics},
+  volume={10},
+  number={2},
+  pages={138--143}
+}
+
+@inproceedings{SerbanHindmarsh:2005,
+  author={Serban, Radu and Hindmarsh, Alan C},
+  year={2005},
+  title={{CVODES}: the sensitivity-enabled {ODE} solver in {SUNDIALS}},
+  booktitle={ASME 2005 International Design Engineering Technical Conferences and Computers and Information in Engineering Conference},
+  pages={257--269},
+  organization={American Society of Mechanical Engineers}
+}
+
+@article{HoetingEtAl:1999,
+  title={Bayesian model averaging: a tutorial},
+  author={Hoeting, Jennifer A. and Madigan, David
+          and Raftery, Adrian E and Volinsky, Chris T.},
+  journal={Statistical Science},
+  volume = {14},
+  number = {4},
+  pages={382--417},
+  year={1999}
+}
+
+@article{Marsaglia:1972,
+  title={Choosing a point from the surface of a sphere},
+  author={Marsaglia, George},
+  journal={The Annals of Mathematical Statistics},
+  volume={43},
+  number={2},
+  pages={645--646},
+  year={1972}
+}
+
+@book{HopcroftMotwani:2006,
+  title={Introduction to Automata Theory, Languages, and Computation},
+  author={Hopcroft, John E. and Rajeev Motwani},
+  year={2006},
+  edition={3rd},
+  publisher={Pearson Education}
+}
+
+@article{Church:1936,
+  title={An unsolvable problem of elementary number theory},
+  author={Church, Alonzo},
+  journal={American Journal of Mathematics},
+  pages={345--363},
+  year={1936}
+}
+
+@article{turing:1936,
+  title={On computable numbers, with an application to the {E}ntscheidungsproblem},
+  author={Turing, Alan Mathison},
+  journal={J. of Math},
+  volume={58},
+  number={345-363},
+  pages={5},
+  year={1936}
+}
+
+@article{Kucukelbir:2015,
+  title = {Automatic Variational Inference in {S}tan},
+  author = {Alp Kucukelbir and Rajesh Ranganath and Andrew Gelman
+  and David M. Blei},
+  year = {2015},
+  journal = {arXiv},
+  volume = {1506.03431},
+  url = {http://arxiv.org/abs/1506.03431}
+}
+
+@article{Jordan:1999,
+  Author = {Jordan, Michael I and Ghahramani, Zoubin and Jaakkola, Tommi S and Saul, Lawrence K},
+  Journal = {Machine Learning},
+  Number = {2},
+  Pages = {183--233},
+  Publisher = {Springer},
+  Title = {An introduction to variational methods for graphical models},
+  Volume = {37},
+  Year = {1999}
+}
+
+@article{Wainwright-Jordan:2008,
+  Author = {Wainwright, Martin J and Jordan, Michael I},
+  Journal = {Foundations and Trends in Machine Learning},
+  Number = {1-2},
+  Pages = {1--305},
+  Title = {Graphical models, exponential families, and variational inference},
+  Volume = {1},
+  Year = {2008}
+}
+
+@article{Hoffman:2013,
+  Author = {Hoffman, Matthew D and Blei, David M and Wang, Chong and Paisley, John},
+  Journal = {The Journal of Machine Learning Research},
+  Number = {1},
+  Pages = {1303--1347},
+  Title = {Stochastic variational inference},
+  Volume = {14},
+  Year = {2013}
+}
+
+@book{Bishop:2006,
+  Author = {Bishop, Christopher M},
+  Publisher = {Springer New York},
+  Title = {Pattern Recognition and Machine Learning},
+  Year = {2006}
+}
+
+@article{Duchi:2011,
+  Author = {Duchi, John and Hazan, Elad and Singer, Yoram},
+  Journal = {The Journal of Machine Learning Research},
+  Pages = {2121--2159},
+  Title = {Adaptive subgradient methods for online learning and stochastic optimization},
+  Volume = {12},
+  Year = {2011}}
+
+
+@article{Zellner:1962,
+  author = {Arnold Zellner},
+  year = {1962},
+  title = {An efficient method of estimating seemingly unrelated regression equations
+           and tests for aggregation bias},
+  journal = {Journal of the American Statistical Association},
+  volume={57},
+  pages = {348--368}
+}
+
+@book{Greene:2011,
+  author = {William H. Greene},
+  year = {2011},
+  title = {Econometric Analysis},
+  edition = {7th},
+  publisher = {Prentice-Hall}
+}
+
+@techreport{CordenKreitzer:2014,
+  author = {Martyn J. Corden and David Kreitzer},
+  year = {2014},
+  title = {Consistency of Floating-Point Results using
+           the {I}ntel Compiler or {W}hy doesn't my application always
+           give the same answer?},
+  institution = {Intel Corporation},
+  url = {https://software.intel.com/en-us/articles/consistency-of-floating-point-results-using-the-intel-compiler}
+}
+
+@article{LangfordEtAl:2009,
+  author = {John Langford and Lihong Li and Tong Zhang},
+  year = {2009},
+  title = {Sparse online learning via truncated gradient},
+  journal = {Journal of Machine Learning Research},
+  volume = {10},
+  pages = {777--801}
+}
+
+@book{LeeWagenmakers:2013,
+  author = {Michael D. Lee and Eric-Jan Wagenmakers},
+  year = {2013},
+  title = {Bayesian Cognitive Modeling: A Practical Course},
+  publisher = {Cambridge University Press}
+}
+
+
+@book{Kruschke:2014,
+  author = {John Kruschke},
+  year = {2014},
+  title = {Doing Bayesian Data Analysis: A Tutorial with R, JAGS, and Stan},
+  edition = {2nd},
+  publisher = {Academic Press}
+}
+
+@book{Chacon:2014,
+  author = {Scott Chacon and Ben Straub},
+  year = {2014},
+  title = {Pro Git},
+  edition = {2nd},
+  publisher = {Apress}
+}
+
+@misc{Driessen:2010,
+  author = {Vincent Driessen},
+  year = {2010},
+  title = {A successful {G}it branching model},
+  url = {http://nvie.com/posts/a-successful-git-branching-model/},
+  note = {Online, accessed 6-January-2015}
+}
+
+@techreport{RProject:2014,
+  author = {{R Project}},
+  year = {2014},
+  institution = {The R Foundation for Statistical Computing},
+  title = {{R}: Regulatory Compliance and Validation Issues;
+           A Guidance Document for the Use of {R} in Regulated Clinical
+           Trial Environments},
+  date = {December 15, 2014},
+  note = {www.r-project.org/doc/R-FDA.pdf}
+}
+
+@book{HastieTibshiraniFriedman:2009,
+	Author = {Trevor Hastie and Robert Tibshirani and Jerome Friedman},
+	Year = {2009},
+	Title = {The Elements of Statistical Learning: Data Mining,
+                 Inference, and Prediction},
+        Edition = {Second},
+	Publisher = {Springer-Verlag},
+	Address = {New York}
+}
+
+@article{RobertsEtAl:1997,
+  Author = {Roberts, G.O. and Andrew Gelman and Walter R. Gilks},
+  Year = {1997},
+  Title = {Weak convergence and optimal scaling of random walk {M}etropolis algorithms},
+  Journal = {Annals of Applied Probability},
+  Volume = {7},
+  number = {1},
+  Pages = {110--120}
+}
+
+
+@article{ChungEtAl:2013,
+  author={Chung, Yeojin and Rabe-Hesketh, Sophia and Dorie, Vincent and Gelman, Andrew and Liu, Jingchen},
+  title={A nondegenerate penalized likelihood estimator for variance parameters in multilevel models},
+  year={2013},
+  journal={Psychometrika},
+  volume={78},
+  number={4},
+  pages={685--709}
+}
+
+@article{GelmanJakulinPittauEtAl:2008,
+  author = {Andrew Gelman and Aleks Jakulin and Maria Grazia Pittau
+            and Yu-Sung Su},
+  year = {2008},
+  title = {A weakly informative default prior distribution for logistic
+           and other regression models},
+  journal = {Annals of Applied Statistics},
+  volume = {2},
+  number = {4},
+  pages = {1360--1383}}
+
+
+@article{Gelman:2006,
+	Author = {Gelman, A.},
+	Journal = {Bayesian Analysis},
+	Number = {3},
+	Pages = {515--534},
+	Title = {Prior distributions for variance parameters in hierarchical models},
+	Volume = {1},
+	Year = {2006}}
+
+@book{LunnEtAl:2012,
+  author = {David Lunn and Christopher Jackson
+            and Nicky Best and Andrew Thomas
+            and David Spiegelhalter},
+  year = {2012},
+  title = {The {BUGS} Book: A Practical Introduction to {B}ayesian Analysis},
+  publisher = {CRC Press/Chapman \& Hall}
+}
+
+@article{EfronMorris:1975,
+	Author = {Efron, B. and Morris, C.},
+	Journal = {Journal of the American Statistical Association},
+	Pages = {311--319},
+	Title = {Data analysis using Stein's estimator and its generalizations},
+	Volume = {70},
+	Year = {1975}}
+
+@book{NocedalWright:2006,
+    Author = { Jorge Nocedal and Stephen J.~Wright},
+    Year = {2006},
+    Publisher = {Springer-{V}erlag},
+    Address = {Berlin},
+    Title = {Numerical Optimization},
+    Edition = {Second}
+}
+
+@article{ZyczkowskiSommers:2001,
+  title={Induced measures in the space of mixed quantum states},
+  author={Zyczkowski, K. and Sommers, H.J.},
+  journal={Journal of Physics A: Mathematical and General},
+  volume={34},
+  number={35},
+  pages={7111},
+  year={2001},
+  publisher={IOP Publishing}
+}
+
+@article{aguilar-west:2000,
+  title={Bayesian dynamic factor models and portfolio allocation},
+  author={Aguilar, Omar and West, Mike},
+  journal={Journal of Business \& Economic Statistics},
+  volume={18},
+  number={3},
+  pages={338--357},
+  year={2000},
+  publisher={Taylor \& Francis}
+}
+
+@inproceedings{Airoldi:2009,
+  Author = {Airoldi, E. and Blei, D. and Fienberg, S. and Xing, E.},
+  Booktitle = {Neural Information Processing Systems},
+  Date-Added = {2008-12-20 13:05:43 -0500},
+  Date-Modified = {2008-12-31 10:06:13 -0500},
+  Keywords = {graphs},
+  Title = {Mixed Membership Stochastic Blockmodels},
+  Year = {2009}
+}
+
+@inproceedings{Akaike:1973,
+  Address = {Budapest},
+  Author = {Akaike, H.},
+  Booktitle = {Proceedings of the Second International Symposium on Information Theory},
+  Editor = {B. N. Petrov and F. Csaki},
+  Note = {Reprinted in Breakthroughs in Statistics (pages 610--624), edited by S. Kotz, published by Springer-Verlag, New York in 1992},
+  Pages = {267--281},
+  Publisher = {Akademiai Kiado},
+  Title = {Information theory and an extension of the maximum likelihood principle},
+  Year = {1973}
+}
+
+@article{AlbertChib:1993,
+  Author = {Albert, J. H. and Chib, S.},
+  Journal = {Journal of the American Statistical Association},
+  Pages = {669--679},
+  Title = {Bayesian analysis of binary and polychotomous response data},
+  Volume = {88},
+  Year = {1993}
+}
+
+@article{Andrieu:2008,
+  title={A tutorial on adaptive {MCMC}},
+  author={Andrieu, C. and Thoms, J.},
+  journal={Statistics and Computing},
+  volume={18},
+  number={4},
+  pages={343--373},
+  year={2008},
+  publisher={Springer}
+}
+
+@article{Betancourt:2016,
+  title = {Identifying the Optimal Integration Time in
+           {H}amiltonian {M}onte {C}arlo},
+  author = {Betancourt, Michael},
+  year = {2016},
+  journal = {arXiv},
+  volume = {1601.00225},
+  url = {https://arxiv.org/abs/1601.00225}
+}
+
+@article{Betancourt:2016b,
+  title = {Diagnosing Suboptimal Cotangent Disintegrations in
+           {H}amiltonian {M}onte {C}arlo},
+  author = {Betancourt, Michael},
+  year = {2016},
+  journal = {arXiv},
+  volume = {1604.00695},
+  url = {https://arxiv.org/abs/1604.00695}
+}
+
+
+
+@article{Betancourt:2012,
+  title = {A General Metric for {R}iemannian Manifold {H}amiltonian {M}onte {C}arlo},
+  author = {Betancourt, Michael},
+  year = {2012},
+  journal = {arXiv},
+  volume = {1212.4693},
+  url = {http://arxiv.org/abs/1212.4693}
+}
+
+@article{Betancourt:2010,
+  author = {Betancourt, Michael},
+  title = {Cruising The Simplex: {H}amiltonian {M}onte {C}arlo and the {D}irichlet Distribution},
+  journal = {arXiv},
+  year = {2010},
+  volume = {1010.3436},
+  url = {http://arxiv.org/abs/1010.3436}
+}
+
+@article{Betancourt-Girolami:2013,
+  author = {Betancourt, Michael and Girolami, Mark},
+  title = {{H}amiltonian {M}onte {C}arlo for Hierarchical Models},
+  journal = {arXiv},
+  year = {2013},
+  volume = {1312.0906},
+  url = {http://arxiv.org/abs/1312.0906}
+}
+
+@article{Betancourt-Stein:2011,
+  author = {Betancourt, Michael and Stein, Leo C.},
+  title = {The Geometry of {H}amiltonian {M}onte {C}arlo},
+  journal = {arXiv},
+  year = {2011},
+  volume = {1112.4118},
+  url = {http://arxiv.org/abs/1112.4118}
+}
+
+@article{BleiNgJordan:2003,
+  author = {Blei, David M. and Ng, Andrew Y. and Jordan, Michael I.},
+  year = {2003},
+  title = {Latent {D}irichlet Allocation},
+  journal = {Journal of Machine Learning Research},
+  volume = {3},
+  pages = {993--1022}
+}
+
+@article{BleiLafferty:2007,
+  author = {Blei, David M. and Lafferty, John D.},
+  year = {2007},
+  title = {A Correlated Topic Model of \emph{{S}cience}},
+  journal = {The Annals of Applied Statistics},
+  volume = {1},
+  number = {1},
+  pages = {17--37}
+}
+
+@article{Blurton2012,
+	author = {Blurton, Steven P. and Kesselmeier, Miriam and Gondan, Matthias},
+	journal = {Journal of Mathematical Psychology},
+	number = {6},
+	pages = {470-475},
+	title = {Fast and accurate calculations for cumulative first-passage time distributions in {Wiener} diffusion models},
+	volume = {56},
+	year = {2012},
+	doi = {10.1016/j.jmp.2012.09.002},
+}
+
+@MISC{Boost:2011,
+  author={Sch\"aling, Boris},
+  year = {2011},
+  title = {The {B}oost {C++} Libraries.},
+  publisher = {XML Press},
+  isbn = {9780982219195},
+  howpublished = {http://en.highscore.de/cpp/boost/}
+}
+
+@article{BowlingEtAl:2009,
+  author={Bowling, Shannon R. and Khasawneh, Mohammad T. and Kaewkuekool, Sittichai and Cho, Byung Rae},
+  year={2009},
+  title={A logistic approximation to the cumulative normal distribution},
+  journal={Journal of Industrial Engineering and Management},
+  volume={2},
+  number={1},
+  pages = {114--127}
+}
+
+@techreport{ChungRabe-HeskethGelman:2011,
+  Author = {Chung, Yeojin and Rabe-Hesketh, Sophia and Gelman, Andrew and Dorie, Vincent and Liu, Jinchen},
+  Date-Added = {2011-10-11 09:19:22 -0400},
+  Date-Modified = {2011-10-11 09:20:18 -0400},
+  Title = {Avoiding Boundary Estimates in Linear Mixed Models Through Weakly Informative Priors},
+  Year = {2011}
+}
+
+@incollection{Clayton:1992,
+  author={Clayton, D. G. },
+  year = {1992},
+  title = {Models for the analysis of cohort and case-control studies with inaccurately measured exposures},
+  editor = {Dwyer, James H. and Feinleib, Manning and Lippert, Peter and Hoffmeister, Hans},
+  booktitle = {Statistical Models for Longitudinal Studies of Exposure and Health},
+  publisher = {Oxford University Press},
+  location = {New York},
+  pages = {301--331}
+}
+
+@book{Congdon:2003,
+  location = {London},
+  Author = {Congdon, Peter},
+  Publisher = {Wiley},
+  Title = {Applied Bayesian Modelling},
+  isbn = {9780470864227},
+  series = {Wiley Series in Probability and Statistics},
+  Year = {2003}
+}
+
+@book{Congdon:2005,
+  author = {Congdon, Peter},
+  title = {Bayesian Models for Categorical Data},
+  isbn = {9780470092385},
+  series = {Wiley Series in Probability and Statistics},
+  year = {2005},
+  publisher = {Wiley}
+}
+
+@book{Congdon:2007,
+  author = {Congdon, Peter},
+  year = {2007},
+  title = {Bayesian Statistical Modelling},
+  edition = {Second},
+  isbn = {9780470035931},
+  series = {Wiley Series in Probability and Statistics},
+  publisher = {Wiley}
+}
+
+@book{Congdon:2010,
+  author={Congdon, Peter},
+  year = {2010},
+  title = {Applied Bayesian Hierarchical Modeling},
+  isbn = {9781584887218},
+  publisher = {Chapman and Hall/CRC}
+}
+
+@article{CookGelmanRubin:2006,
+  author = {Cook, Samantha R. and Gelman, Andrew and Rubin, Donald B},
+  title = {Validation of Software for {B}ayesian Models Using Posterior Quantiles},
+  journal = {Journal of Computational and Graphical Statistics},
+  volume = {15},
+  number = {3},
+  pages = {675--692},
+  year = {2006},
+  doi = {10.1198/106186006X136976},
+  URL = {http://amstat.tandfonline.com/doi/abs/10.1198/106186006X136976},
+  eprint = {http://amstat.tandfonline.com/doi/pdf/10.1198/106186006X136976}
+}
+
+@article{Cormack:1964,
+  title={Estimates of survival from the sighting of marked animals},
+  author={Cormack, R.~M.},
+  year={1964},
+  journal={Biometrika},
+  volume = {51},
+  number = {3/4},
+  pages={429--438}
+}
+@article{Jolly:1965,
+  author={Jolly, G.~M.},
+  year={1965},
+  title={Explicit estimates from capture-recapture data with both
+         death and immigration-stochastic model},
+  journal={Biometrika},
+  pages={225--247},
+  volume={52},
+  number={1/2}
+}
+@article{Seber:1965,
+  author={Seber, G.~A.~F.},
+  year={1965},
+  title={A note on the multiple-recapture census},
+  journal={Biometrika},
+  volume={52},
+  number={1/2},
+  pages={249--259}
+}
+
+@article{Curtis:2010,
+  title={{BUGS} code for Item Response Theory},
+  author={Curtis, S.~McKay},
+  journal={Journal of Statistical Software},
+  volume={36},
+  number={1},
+  pages={1--34},
+  year={2010},
+  publisher={American Statistical Association}
+}
+
+@techreport{DaumeIII:2007,
+  Author = {Daum{\'e}, III, Hal},
+  Title = {{HBC}: Hierarchical {B}ayes Compiler},
+  Url = {http://hal3.name/HBC},
+  Year = {2007},
+  Institution = {University of Utah}
+}
+
+@article{DawidSkene:1979,
+  author={Dawid, A.~P. and Skene, A.~M.},
+  year={1979},
+  title={Maximum likelihood estimation of observer error-rates using
+                  the {EM} algorithm},
+  journal={Journal of the Royal Statistical Society. Series C (Applied
+                  Statistics)},
+  volume = {28},
+  number = {1},
+  pages={20--28}
+}
+
+@article{dempster-et-al:1977,
+  title={Maximum likelihood from incomplete data via the {EM} algorithm},
+  author={Dempster, A.~P. and Laird, N.~M. and Rubin, D.~B.},
+  journal={Journal of the Royal Statistical Society. Series B (Methodological)},
+  pages={1--38},
+  year={1977},
+  volume={39},
+  number={1}
+}
+
+@MISC{Doxygen:2011,
+  author = {van~Heesch, Dimitri},
+  howpublished = {http://www.stack.nl/~dimitri/doxygen/index.html},
+  title = {Doxygen: Generate Documentation from Source Code},
+  year = {2011}
+}
+
+@article{Duane:1987,
+  title={Hybrid {M}onte {C}arlo},
+  author={Duane, AD and Kennedy, A. and Pendleton, B. and Roweth, D.},
+  journal={Physics Letters {B}},
+  volume={195},
+  number={2},
+  pages={216--222},
+  year={1987},
+  publisher={Elsevier}
+}
+
+@book{DurbinKoopman:2001,
+  author={Durbin, J. and Koopman, S. J.},
+  title={Time Series Analysis by State Space Methods},
+  year={2001},
+  publisher={Oxford University Press},
+  address={New York}
+}
+
+@article{Engle:1982,
+  author={Engle, Robert F.},
+  year={1982},
+  title={Autoregressive Conditional Heteroscedasticity with Estimates of Variance of {U}nited {K}ingdom Inflation},
+  journal={Econometrica},
+  volume={50},
+  pages={987--1008}
+}
+
+@Article{EddelbuettelFrancois:2011,
+  title = {{Rcpp}: Seamless {R} and {C++} Integration},
+  author = {Eddelbuettel, Dirk and Fran\c{c}ois, Romain},
+  journal = {Journal of Statistical Software},
+  year = {2011},
+  volume = {40},
+  number = {8},
+  pages = {1--18},
+  url = {http://www.jstatsoft.org/v40/i08/},
+}
+
+@BOOK{Efron:2012,
+  author = {Efron, Bradley},
+  year = {2012},
+  title = {Large-Scale Inference: Empirical Bayes Methods for Estimation, Testing, and Prediction},
+  series={Institute of Mathematical Statistics Monographs},
+  publisher = {Cambridge Univesity Press}
+}
+
+@MISC{Eigen:2013,
+  author = {Guennebaud, Ga\"{e}l and Jacob, Beno\^{i}t and others},
+  title = {Eigen v3},
+  howpublished = {http://eigen.tuxfamily.org},
+  year = {2010}
+}
+
+@book{FowlerEtAl:1999,
+  author={Fowler, Martin and Beck, Kent and Brant, John and Opdyke, William and Roberts, Don},
+  year={1999},
+  title={Refactoring: Improving the Design of Existing Code},
+  publisher={Addison-Wesley}
+}
+
+@incollection{Gay:2005,
+  Author = {Gay, David M.},
+  Year = {2005},
+  BookTitle = {Automatic Differentiation: Applications, Theory, and Implementations},
+  Editor = {B\"ucker, H.~Martin and Corliss, George F. and Hovland, Paul and Naumann, Uwe and Norris, Boyana},
+  Title = {Semiautomatic Differentiation for Efficient Gradient Computations},
+  Series = {Lecture Notes in Computational Science and Engineering},
+  Volume = {50},
+  isbn = {978-3-540-28403-1},
+  doi = {10.1007/3-540-28438-9_13},
+  pages = {147--158},
+  Publisher = {Springer},
+  Address = {New York}
+}
+
+@article{Gelman:2004,
+  author = {Andrew Gelman},
+  year = {2004},
+  title = {Parameterization and {B}ayesian Modeling},
+  journal = {Journal of the American Statistical Association},
+  volume = {99},
+  pages = {537--545}
+}
+
+@book{GelmanEtAl:2013,
+  Author = {Gelman, Andrew and Carlin, J.~B. and Stern, Hal S. and Dunson, David B. and Vehtari, Aki and Rubin, Donald B.},
+  Edition = {Third},
+  Publisher = {Chapman \&Hall/CRC Press},
+  Title = {Bayesian Data Analysis},
+  Year = {2013},
+  Address = {London}
+}
+
+@book{GelmanHill:2007,
+  Address = {Cambridge, United Kingdom},
+  Author = {Gelman, Andrew and Hill, Jennifer},
+  Publisher = {Cambridge University Press},
+  Title = {Data Analysis Using Regression and Multilevel-Hierarchical Models},
+  Year = {2007}
+}
+
+@article{GelmanRubin:1992,
+  Author = {Gelman, Andrew and Rubin, Donald B.},
+  Year = {1992},
+  Title = {Inference from iterative simulation using multiple sequences},
+  Journal = {Statistical Science},
+  Pages = {457--472},
+  Volume = {7},
+  Number = {4},
+  Issn = {0883-4237}
+}
+
+@article{Geyer:1992,
+  title={Practical Markov chain Monte Carlo},
+  author={Geyer, Charles J},
+  journal={Statistical science},
+  pages={473--483},
+  year={1992}
+}
+
+@incollection{Geyer:2011,
+  author = {Charles J. Geyer},
+  year = {2011},
+  title = {Introduction to {M}arkov Chain {M}onte {C}arlo},
+  booktitle = {Handbook of {M}arkov Chain {M}onte {C}arlo},
+  editor = {Brooks, Steve and Gelman, Andrew and Jones, Galin L. and Meng, Xiao-Li},
+  publisher = {Chapman and Hall/CRC},
+  pages = {3--48}
+}
+
+
+@techreport{Giesler:2000,
+  Author = {Giesler, Gregg C.},
+  Title = {{MCNP} Software Quality: Then and Now},
+  Year = {2000},
+  Institution = {Los Alamos National Laboratory},
+  Number = {LA-UR-00-2532}
+}
+
+@article{GirolamiCalderhead:2011,
+  title = {Riemann manifold {L}angevin and {H}amiltonian {M}onte {C}arlo methods},
+  author = {Girolami, Mark and Calderhead, Ben},
+  journal = {Journal of the Royal Statistical Society: Series B (Statistical Methodology)},
+  volume = {73},
+  number = {2},
+  pages = {123--214},
+  year = {2011}
+}
+
+@misc{GoogleTest:2011,
+  title = {Google {C++} Testing Framework},
+  author = {Google},
+  howpublished = {http://code.google.com/p/googletest/},
+  year = {2011}
+}
+
+@article{Hastings:1970,
+  Author = {Hastings, W.~K.},
+  Year = {1970},
+  Title = {Monte {C}arlo Sampling Methods Using {M}arkov Chains and Their Applications},
+  Journal = {Biometrika},
+  Volume = {57},
+  Number = {1},
+  Pages = {97--109}
+}
+
+@article{HoerlKennard:1970,
+  author = {Hoerl, Arthur E. and Kennard, Robert W.},
+  year = {1970},
+  title = {Ridge regression: biased estimation for nonorthogonal problems},
+  journal = {Technometrics},
+  volume = {12},
+  number = {1},
+  pages = {55--67}
+}
+
+@article{Hoffman-Gelman:2011,
+  Author = {Hoffman, Matthew D. and Gelman, Andrew},
+  Title = {The No-{U}-Turn Sampler: Adaptively Setting Path Lengths in {H}amiltonian {M}onte {C}arlo},
+  Journal = {arXiv},
+  Volume = {1111.4246},
+  url = {http://arxiv.org/abs/1111.4246},
+  Year = {2011}
+}
+
+@article{Hoffman-Gelman:2014,
+  Title = {{T}he {N}o-{U}-{T}urn {S}ampler: {A}daptively {S}etting {P}ath {L}engths in {H}amiltonian {M}onte {C}arlo},
+  Author = {Hoffman, Matthew D. and Gelman, Andrew},
+  Journal = {Journal of Machine Learning Research},
+  Year = {2014},
+  Volume = {15},
+  Pages = {1593--1623},
+  url  = {http://jmlr.org/papers/v15/hoffman14a.html}
+}
+
+@inproceedings{Hoffman:2010,
+  Author = {Hoffman, M.D. and Blei, D.M. and Cook, P.R.},
+  Booktitle = {ICML},
+  Location = {Haifa, Israel},
+  Title = {{B}ayesian Nonparametric Matrix Factorization for Recorded Music},
+  Year = {2010}
+}
+
+@book{HuntThomas:99,
+  author = {Hunt, Andrew and Thomas, David},
+  year = {1999},
+  title = {The Pragmatic Programmer},
+  publisher = {Addison-Wesley}
+}
+
+@inproceedings{JamesStein:1961,
+  author = {James, W. and Stein, Charles},
+  year = {1961},
+  title = {Estimation with quadratic loss},
+  editor = {Jerzey Neyman},
+  booktitle = {Proceedings of the Fourth Berkeley Symposium on Mathematical Statistics and Probability},
+  volume = {1},
+  pages = {361--379},
+  publisher = {University of California Press}
+}
+
+@article{Jarret:1979,
+  title={A note on the intervals between coal-mining disasters},
+  author={Jarrett, R.~G.},
+  journal={Biometrika},
+  volume={66},
+  number={1},
+  pages={191--193},
+  year={1979},
+  publisher={Biometrika Trust}
+}
+
+@article{KimShephardChib:1998,
+  author = {Kim, Sangjoon and Shephard, Neil and Chib, Siddhartha},
+  year = {1998},
+  title = {Stochastic Volatility: Likelihood Inference and Comparison with {ARCH} Models},
+  journal = {Review of Economic Studies},
+  volume = {65},
+  pages = {361--393}
+}
+@article{Lambert:1992,
+  author = {Lambert, Diane},
+  year = {1992},
+  title = {Zero-Inflated {P}oisson Regression, With an Application to Defects in Manufacturing},
+  journal = {Technometrics},
+  volume = {34},
+  number = {1},
+  page = {1--14}
+}
+
+@article{Lecuyer:1999,
+  author = {{L'Ecuyer}, Pierre},
+  year = {1999},
+  title = {Good parameters and implementations for combined multiple recursive random number generators},
+  journal = {Operations Research},
+  volume = {47},
+  pages = {159--164}
+}
+
+@book{LeimkuhlerReich:2004,
+  author = {Benedict Leimkuhler and Sebastian Reich},
+  year = {2004},
+  title = {Simulating Hamiltonian Dynamics},
+  publisher = {Cambridge University Press},
+  location = {Cambridge}
+}
+
+
+@article{LewandowskiKurowickaJoe:2009,
+  Author = {Lewandowski, Daniel and Kurowicka, Dorota and Joe, Harry},
+  Year = {2009},
+  Title = {Generating random correlation matrices based on vines and extended onion method},
+  Journal = {Journal of Multivariate Analysis},
+  Volume = {100},
+  Pages = {1989--2001}
+}
+
+@article{Lincoln:1930,
+  author = {F.~C. Lincoln},
+  year = {1930},
+  title = {Calculating Waterfowl Abundance on the Basis of Banding Returns},
+  journal = {United States Department of Agriculture Circular},
+  volume={118},
+  pages = {1--4}
+}
+
+@manual{LunnEtAl:1999,
+  author = {Lunn, D. J.
+            and Wakefield, J.
+            and Thomas, A.
+            and Best, N.
+            and Spiegelhalter, D.},
+  year={1999},
+  title={{PKB}ugs User Guide},
+  note = {Dept. Epidemiology and Public Health,
+               Imperial College School of Medicine, London}
+}
+
+
+@book{McConnell:2004,
+  Author = {McConnell, Steve},
+  Year = {2004},
+  Title = {Code Complete: A Practical Handbook of Software Construction},
+  Edition = {Second},
+  Publisher = {Microsoft Press}
+}
+
+@article{Metropolis:1953,
+  Author = {Metropolis, N. and Rosenbluth, A. and Rosenbluth, M. and Teller, M. and Teller, E.},
+  Date-Modified = {2007-06-11 11:46:55 -0400},
+  Journal = {Journal of Chemical Physics},
+  Pages = {1087--1092},
+  Title = {Equations of State Calculations by Fast Computing Machines},
+  Volume = {21},
+  Year = {1953}
+}
+
+@article{MetropolisUlam:1949,
+  Author = {Metropolis, Nicholas and Ulam, Stanislaw},
+  Title = {The {M}onte {C}arlo Method},
+  Journal = {Journal of the American Statistical Association},
+  Year = {1949},
+  Volume = {44},
+  Number = {247},
+  Pages = {335--341}
+}
+
+@article{Neal:1994,
+  Author = {Neal, Radford M.},
+  Year = {1994},
+  Title = {An improved acceptance procedure for the hybrid Monte Carlo algorithm},
+  Journal = {Journal of Computational Physics},
+  Volume = {111},
+  Pages = {194--203}
+}
+
+@article{Neal:1996b,
+  author = {Neal, Radford M.},
+  year = {1996},
+  title = {Sampling from multimodal distributions using tempered transitions},
+  journal = {Statistics and Computing},
+  volume = {6},
+  number = {4},
+  pages = {353--366}
+}
+
+@techreport{Neal:1997,
+  author = {Neal, Radford M.},
+  year = {1997},
+  title = {Monte {C}arlo Implementation of {G}aussian Process Models for {B}ayesian Regression and Classification},
+  institution = {University of Toronto, Department of Statistics},
+  number = {9702}
+}
+
+@article{Neal:2003,
+  Author = {Neal, Radford M.},
+  Year = {2003},
+  Title = {Slice Sampling},
+  Journal = {Annals of Statistics},
+  Volume = {31},
+  Number = {3},
+  Pages = {705--767}
+}
+
+@incollection{Neal:2011,
+  Author = {Neal, Radford},
+  Year = {2011},
+  Title = {{MCMC} Using {H}amiltonian Dynamics},
+  Booktitle = {Handbook of {M}arkov Chain {M}onte {C}arlo},
+  Editor = {Brooks, Steve and Gelman, Andrew and Jones, Galin L. and Meng, Xiao-Li},
+  Publisher = {Chapman and Hall/CRC},
+  Pages = {116--162}
+}
+
+@book{Neal:1996,
+  author = {Neal, Radford M.},
+  year = {1996},
+  title = {Bayesian Learning for Neural Networks},
+  series = {Lecture Notes in Statistics},
+  number = {118},
+  publisher = {Springer},
+  location = {New York}
+}
+
+@article{Nesterov:2009,
+  title={Primal-dual subgradient methods for convex problems},
+  author={Nesterov, Y.},
+  journal={Mathematical Programming},
+  volume={120},
+  number={1},
+  pages={221--259},
+  year={2009},
+  publisher={Springer}
+}
+
+@article{numpy:2011,
+  author = {Walt, Stefan van der and Colbert, S.~Chris and Varoquaux, Gael},
+  title = {The NumPy Array: A Structure for Efficient Numerical Computation},
+  journal = {Computing in Science and Engg.},
+  issue_date = {March 2011},
+  volume = {13},
+  issue = {2},
+  month = {March},
+  year = {2011},
+  issn = {1521-9615},
+  pages = {22--30},
+  numpages = {9},
+  url = {http://dx.doi.org/10.1109/MCSE.2011.37},
+  doi = {http://dx.doi.org/10.1109/MCSE.2011.37},
+  acmid = {1957466},
+  publisher = {IEEE Educational Activities Department},
+  address = {Piscataway, NJ, USA}
+}
+
+@article{papa-et-al:2007,
+  author = {Papaspiliopoulos, Omiros and Roberts, Gareth O. and Sk{\"o}ld, Martin},
+  year = {2007},
+  title = {A General Framework for the Parametrization of Hierarchical Models},
+  journal = {Statistical Science},
+  volume = {22},
+  number = {1},
+  pages = {59--73}
+}
+
+@article{Petersen:1896,
+  author = {C.~G.~J. Petersen},
+  year = {1896},
+  title ={The Yearly Immigration of Young Plaice Into the {L}imfjord From the {G}erman {S}ea},
+  journal = {Report of the Danish Biological Station},
+  volume = {6},
+  pages = {5--84}
+}
+
+
+@article{PinheiroBates:1996,
+  author = {Pinheiro, Jos{\'e} C. and Bates, Douglas M.},
+  title = {Unconstrained Parameterizations for Variance-Covariance Matrices},
+  journal = {Statistics and Computing},
+  year = {1996},
+  volume = {6},
+  pages = {289--296}
+}
+
+@manual{PyMC:2014,
+  title = {PyMC User's Guide},
+  author = {Chris Fonnesbeck
+            and Anand Patil
+            and David Huard
+            and John Salvatier},
+  note = {Version 2.3},
+  year = {2013}
+}
+
+
+@Manual{R:2014,
+  title = {R: A Language and Environment for Statistical Computing},
+  author = {{R Development Core Team}},
+  organization = {R Foundation for Statistical Computing},
+  address = {Vienna, Austria},
+  year = {2014},
+  note = {{ISBN} 3-900051-07-0},
+  url = {http://www.R-project.org},
+}
+
+@book{RasmussenWilliams:2006,
+  author={Rasmussen, Carl Edward and Williams, Christopher K.~I.},
+  title={Gaussian Processes for Machine Learning},
+  year={2006},
+  publisher={MIT Press}
+}
+
+@article{RichardsonGilks:1993,
+  author = {Richardson, Sylvia and Gilks, Walter R.},
+  year = {1993},
+  title = {A {B}ayesian approach to measurement error problems in epidemiology using conditional independence models},
+  journal = {American Journal of Epidemiology},
+  volume = {138},
+  number = {6},
+  pages = {430--442}
+}
+
+@ARTICLE{Rnews:Plummer+Best+Cowles+Vines:2006,
+  AUTHOR = {Plummer, Martyn and Best, Nicky and Cowles, Kate and Vines, Karen},
+  TITLE = {{CODA}: Convergence Diagnosis and Output Analysis for {MCMC}},
+  JOURNAL = {R News},
+  YEAR = 2006,
+  VOLUME = 6,
+  NUMBER = 1,
+  PAGES = {7--11},
+  MONTH = {March},
+  URL = {http://CRAN.R-project.org/doc/Rnews/},
+  PDF = {http://CRAN.R-project.org/doc/Rnews/Rnews_2006-1.pdf}
+}
+
+@article{Rubin:1981,
+  author = {Rubin, Donald B.},
+  year = {1981},
+  title = {Estimation in parallel randomized experiments},
+  journal = {Journal of Educational Statistics},
+  volume = {6},
+  pages = {377--401}
+}
+
+@phdthesis{Schofield:2007,
+  author = {Schofield, Matthew R.},
+  year = {2007},
+  title = {Hierarchical Capture-Recapture Models},
+  school = {Department of of Statistics, University of Otago, Dunedin}
+}
+
+@article{SmithSpiegelhalterThomas:1995,
+  author = {Smith, Teresa C. and Spiegelhalter, David J. and Thomas, Andrew},
+  year = {1995},
+  title = {{B}ayesian approaches to random-effects meta-analysis: a comparative study},
+  journal = {Statistics in Medicine},
+  volume = {14},
+  number = {24},
+  pages = {2685--2699}
+}
+
+@article{SwendsenWang:1986,
+  author = {Swendsen, Robert H. and Wang, Jian-Sheng},
+  year = {1986},
+  title = {Replica {M}onte {C}arlo simulation of spin glasses},
+  journal = {Physical Review Letters},
+  volume = {57},
+  pages = {2607--2609}
+}
+
+@article{Tibshirani:1996,
+  author = {Tibshirani, Robert},
+  year = {1996},
+  title = {Regression shrinkage and selection via the lasso},
+  journal = {Journal of the Royal Statistical Society, Series B},
+  volume = {58},
+  number = {1},
+  pages = {267--288}
+}
+
+@techreport{TokudaGoodrichVanMechelen:2010,
+  Author = {Tokuda, Tomoki and Goodrich, Ben and Van Mechelen, Iven and Gelman, Andrew and Tuerlinckx, Francis},
+  Date-Added = {2011-10-11 09:21:36 -0400},
+  Date-Modified = {2011-10-11 09:22:14 -0400},
+  Title = {Visualizing distributions of covariance matrices},
+  Institution = {Columbia University, Department of Statistics},
+  Url = {http://www.stat.columbia.edu/~gelman/research/unpublished/Visualization.pdf},
+  Year = {2010}
+}
+
+@article{Vandekerckhove-Wabersich:2014,
+  Title = {The {R}{W}iener package: an {R} package providing distribution functions for the {W}iener diffusion model},
+  Author = {Joachim Vandekerckhove and Dominik Wabersich},
+  Journal = {The R Journal},
+  Year = {2014},
+  Volume = {6/1},
+  Url = {http://journal.r-project.org/archive/2014-1/vandekerckhove-wabersich.pdf},
+}
+
+@article{Vrugt:2009,
+ title = {Equifinality of formal ({DREAM}) and informal ({GLUE}) {B}ayesian approaches in hydrologic modeling?},
+ author = {Vrugt, J.A. and Ter Braak, C.J.F. and Gupta, H.V. and Robinson, B.A.},
+ journal = {Stochastic environmental research and risk assessment},
+ volume = {23},
+ number = {7},
+ pages = {1011--1026},
+ year = {2009},
+ publisher = {Springer}
+}
+
+@article{WainwrightJordan:2008,
+ Author = {Wainwright, M.~J. and Jordan, M.~I.},
+ Title = {Graphical models, exponential families, and variational inference},
+ Volume = {1},
+ Pages = {1--305},
+ Year = {2008},
+ Journal = {Foundations and Trends in Machine Learning}
+}
+
+@article{WarnThompsonSpiegelhalter:2002,
+  author = {Warn, David E. and Thompson, S.~G. and Spiegelhalter, David J.},
+  year = {2002},
+  title = {{B}ayesian random effects meta-analysis of trials with binary outcomes: methods for the absolute risk difference and relative risk scales},
+  journal = {Statistics in Medicine},
+  volume = {21},
+  pages = {1601--1623}
+}
+
+@article{zhang-gp:2004,
+  title={Inconsistent estimation and asymptotically equal interpolations in model-based geostatistics},
+  author={Zhang, Hao},
+  journal={Journal of the American Statistical Association},
+  volume={99},
+  number={465},
+  pages={250--261},
+  year={2004},
+  publisher={Taylor \& Francis}
+}
+
+@inproceedings{Zhang:2011,
+  title={Quasi-{N}ewton Methods for {M}arkov Chain {M}onte {C}arlo},
+  author={Zhang, Y. and Sutton, C.},
+  booktitle={Advances in Neural Information Processing Systems 24 ({NIPS})},
+  year={2011}
+}
+
+@article{ZouHastie:2005,
+  author = {Zou, Hui and Hastie, Trevor},
+  year = {2005},
+  title = {Regularization and variable selection via the elastic net},
+  journal = {Journal of the Royal Statistical Society, Series B},
+  volume = {67},
+  number = {2},
+  pages = {301--320}
+}

--- a/src/docs/cmdstan-guide/cmdstan-guide.tex
+++ b/src/docs/cmdstan-guide/cmdstan-guide.tex
@@ -1,6 +1,6 @@
 \documentclass[10pt,openany]{book}
 
-\usepackage{../../../stan/src/docs/stan-reference/stan-manuals}
+\usepackage{stan-manuals}
 
 \newcommand{\cmdstanversion}{2.18.0}
 \newcommand{\CmdStan}{CmdStan\xspace}

--- a/src/docs/cmdstan-guide/cmdstan-guide.tex
+++ b/src/docs/cmdstan-guide/cmdstan-guide.tex
@@ -1,6 +1,6 @@
 \documentclass[10pt,openany]{book}
 
-\usepackage{stan-manuals}
+\usepackage{../../../stan/src/docs/stan-reference/stan-manuals}
 
 \newcommand{\cmdstanversion}{2.18.0}
 \newcommand{\CmdStan}{CmdStan\xspace}

--- a/src/docs/cmdstan-guide/references.tex
+++ b/src/docs/cmdstan-guide/references.tex
@@ -4,4 +4,4 @@
 \makeatletter
 \renewcommand\@biblabel[1]{}
 \makeatother
-\bibliography{../../../stan/src/docs/bibtex/all}
+\bibliography{bibtex/all}

--- a/src/docs/cmdstan-guide/stan-manuals.sty
+++ b/src/docs/cmdstan-guide/stan-manuals.sty
@@ -1,0 +1,242 @@
+\IfFileExists{lucimatx.sty}{
+  % ----- if Lucida availalable------------------
+  \usepackage[
+    scale=0.875,
+    stdmathitalics=true,
+    stdmathdigits=true]{lucimatx}
+ \linespread{1.02}
+}{
+  \usepackage{charter}
+  \usepackage{amssymb}
+  \linespread{1.05}
+}
+
+%suppress underfull hbox warnings by setting hbadness to max
+\hbadness=10000
+
+\usepackage{makeidx}
+\makeindex
+
+% \usepackage{index}
+% \newindex{funs}{fdx}{fns}{Functions}
+
+\usepackage[T1]{fontenc} % needed for |
+\usepackage{amsmath}
+\usepackage{xspace}
+\usepackage{fancyvrb}
+%\usepackage{fancyhdr}
+\usepackage{titlesec}
+\usepackage{graphicx}
+\usepackage{natbib}
+\usepackage{url}
+\usepackage{changebar}
+\usepackage{upquote}
+\usepackage{alltt}
+\usepackage{lscape}
+\usepackage{relsize} % defines \mathlarger
+
+\usepackage[titles]{tocloft}
+\setlength{\cftbeforechapskip}{1ex}
+\setlength{\cftbeforesecskip}{1ex}
+\renewcommand{\cftchapfont}{\normalsize\rm}
+\renewcommand{\cftchappagefont}{\normalsize\rm}
+\renewcommand{\cftpartfont}{\normalsize\rm\bfseries}
+\renewcommand{\cftpartpagefont}{\normalsize\rm\bfseries}
+\renewcommand{\cftchapaftersnum}{.}
+\renewcommand{\cftchapaftersnumb}{\hspace*{8pt}}
+\renewcommand{\@pnumwidth}{5em}
+\renewcommand{\@tocrmarg}{4em}
+\setcounter{tocdepth}{0}
+
+
+\titleformat{\chapter}{\bfseries\LARGE}{\thechapter.}{1.5pc}{}{}%{1.5pc}{}{}
+\titlespacing{\chapter}{0pt}{-24pt}{12pt}{}
+%
+\titleformat{\section}{\bfseries\large}{\thesection.}{1em}{}
+%\titlespacing{\section}{0pt}{12pt}{6pt}
+%
+\titleformat{\subsection}{\bfseries}{}{0em}{}
+%\titlespacing{\subsection}{-1em}{12pt}{6pt}
+\titleformat{\subsubsection}{\slshape}{}{0em}{}
+%\titlespacing{\subsection}{-1em}{12pt}{6pt}
+
+\usepackage{xcolor}
+\definecolor{linkcolor}{RGB}{0,0,128}
+\usepackage[pagebackref,pdfpagelabels,plainpages=false,hypertexnames=true,colorlinks=true,linkcolor=linkcolor,anchorcolor=linkcolor,citecolor=linkcolor,filecolor=linkcolor,menucolor=linkcolor,runcolor=linkcolor,urlcolor=linkcolor,pdfborder={0 0 0}]{hyperref}
+
+
+% BG: Stuff for changed text
+\usepackage[final,author=]{fixme}
+\fxuselayouts{pdfcmargin}
+\fxusetargetlayout{changebar}
+\newcommand{\A}[1]{\cbstart#1\cbend}
+\newcounter{FXNOTE}[page]
+\newcommand{\FXA}[1][\value{FXNOTE}]{\ifnum#1=0\fxnote{Addition to section \thesection}\stepcounter{FXNOTE}\fi}
+\newcommand{\FXC}[1][\value{FXNOTE}]{\ifnum#1=0\fxnote{Change to section \thesection}\stepcounter{FXNOTE}\fi}
+\renewcommand\englishlistfixmename{List of changes}
+
+\newcommand{\stanc}{{\ttfamily stanc}\xspace}
+\newcommand*{\Cpp}{C\raise.15ex\hbox{\footnotesize ++}\xspace} %\ensuremath{++}
+\newcommand{\clang}{{\ttfamily clang\raise.2ex\hbox{\footnotesize ++}}\xspace}
+\newcommand{\gpp}{{\ttfamily g\raise.2ex\hbox{\footnotesize ++}}\xspace}
+
+\newcommand{\acronym}[1]{#1\xspace}
+
+\newcommand{\ASCII}{\acronym{ASCII}}
+\newcommand{\BNF}{\acronym{BNF}}
+\newcommand{\MATLAB}{\acronym{MATLAB}}
+\newcommand{\R}{\acronym{R}}
+\newcommand{\SPLUS}{\acronym{S}}
+\newcommand{\BUGS}{\acronym{BUGS}}
+\newcommand{\JAGS}{\acronym{JAGS}}
+\newcommand{\MCMC}{\acronym{MCMC}}
+\newcommand{\HMC}{\acronym{HMC}}
+\newcommand{\NUTS}{\acronym{NUTS}}
+\newcommand{\MSVC}{\acronym{MSVC}}
+\newcommand{\LKJ}{\acronym{LKJ}}
+\newcommand{\CPC}{\acronym{CPC}}
+
+\newcommand{\code}[1]{{\tt #1}}
+\newcommand{\mycaption}[2]{\caption{{\it #2}\label{#1.figure}}}
+
+\newcommand{\distro}[1]{\mbox{\sf #1}}
+\newcommand{\Betafun}{\mbox{B}}
+\newcommand{\setlist}[1]{\{ #1 \}}
+\newcommand{\reals}{\mathbb{R}}
+\newcommand{\posreals}{\mathbb{R}^+}
+\newcommand{\nats}{\mathbb{N}}
+\newcommand{\bigo}[1]{{\mathcal{O}}(#1)}
+\newcommand{\erfc}[1]{\operatorname{erfc}#1}
+\newcommand{\erf}[1]{\operatorname{erf}#1}
+\newcommand{\sech}[1]{\operatorname{sech}#1}
+
+% math macros for variational inference
+\newcommand{\KL}[2]{\ensuremath{\textrm{KL}\left[#1\;\|\;#2}\right]}
+\DeclareMathOperator*{\argmax}{arg\,max}
+\DeclareMathOperator*{\argmin}{arg\,min}
+\newcommand{\E}{\mathbb{E}}
+
+\newcommand{\ternary}[3]{#1 \ ? \ #2 \ : \ #3}
+
+\newcommand{\refappendix}[1]{Appendix~\ref{#1.appendix}}
+\newcommand{\refpart}[1]{Part~\ref{#1.part}}
+\newcommand{\refchapter}[1]{Chapter~\ref{#1.chapter}}
+\newcommand{\refsection}[1]{Section~\ref{#1.section}}
+\newcommand{\reffigure}[1]{Figure~\ref{#1.figure}}
+\newcommand{\refnote}[1]{Footnote~\ref{#1.footnote}}
+\newcommand{\refequation}[1]{Equation~(\ref{#1.equation})}
+
+
+% \textwidth = 5in
+\newcommand{\fitem}[4]{\item[\begin{minipage}{4.9in}{\tt #1 {\bfseries #2}(#3)}\end{minipage}]\mbox{ }
+  \\[-10pt] #4\index{{\tt\bfseries #2 }!{\tt (#3):\,#1}|hyperpage}}
+
+\newcommand{\fitemnobody}[3]{\item[\begin{minipage}{4.9in}{\tt #1 {\bfseries #2}(#3)}\end{minipage}]\mbox{ }
+ \\[-30pt]\index{{\tt\bfseries #2 }!{\tt (#3):\,#1}|hyperpage}}
+
+\newcommand{\fitemtwolines}[5]{\item[\begin{minipage}{4.9in}{\tt
+      #1 {\bfseries #2}(#3, \\ \hspace*{60pt}#4\vspace*{8pt})}\end{minipage}]\mbox{ }
+  \\[-10pt] #5\index{{\tt\bfseries #2 }!{\tt (#3 #4):\,#1}|hyperpage}}
+
+\newcommand{\fitemthreelines}[6]{\item[\begin{minipage}{4.9in}{\tt
+      #1 {\bfseries #2}(#3, \\ \hspace*{60pt}#4, \\ \hspace*{60pt}#5\vspace*{8pt})}\end{minipage}]\mbox{ }
+ \\[-10pt] #6\index{{\tt\bfseries #2 }!{\tt (#3, #4, #5):\,#1}|hyperpage}}
+
+\newcommand{\fitemfourlines}[7]{\item[\begin{minipage}{4.9in}{\tt
+      #1 {\bfseries #2}(#3, \\ \hspace*{60pt}#4, \\ \hspace*{60pt}#5, \\ \hspace*{60pt}#6\vspace*{8pt})}\end{minipage}]\mbox{ }
+ \\[-10pt] #7\index{{\tt\bfseries #2 }!{\tt (#3, #4, #5, #6):\,#1}|hyperpage}}
+
+
+\newcommand{\fitemindex}[5]{\item[\begin{minipage}{4.9in}{\tt #1 {\bfseries #2}(#3)}\end{minipage}]\mbox{ }
+  \\[-10pt] #4\index{{\tt\bfseries #5 }!{\tt (#3):\,#1}|hyperpage}}
+\newcommand{\fitemindexnobody}[4]{\item[\begin{minipage}{4.9in}{\tt #1 {\bfseries #2}(#3)}\end{minipage}]\mbox{ }
+  \\[-30pt] \index{{\tt\bfseries #4 }!{\tt (#3):\,#1}|hyperpage}}
+
+
+\newcommand{\fitemUnaryVec}[3]{
+  \fitem{R}{#1}{T \farg{x}}{Returns the (elementwise) #2, #3
+    for any argument type \code{T};  see
+    \refsection{fun-vectorization} for details including return type
+    \code{R}.}
+}
+\newcommand{\fitemUnaryVecSort}[4]{
+  \fitemindexsort{R}{#1}{T \farg{x}}{Returns the (elementwise) #2, #3
+    for any argument type \code{T};  see
+    \refsection{fun-vectorization} for details including return type
+    \code{R}.}{#1}{#4}
+}
+
+
+\newcommand{\fitemindexsort}[6]{\item[{\tt #1 {\bfseries #2}(#3)}]\mbox{ }
+  \\[2pt] #4\index{{\tt\bfseries #6 }@{\tt\bfseries #5 }!{\tt
+      (#3):\,#1}|hyperpage}}
+
+\newcommand{\indexref}[2]{\index{{\tt\bfseries #1}@{\tt #1}|see {#2}}}
+
+\newcommand{\farg}[1]{{\tt\slshape #1}}
+
+\newcommand{\pitemImpl}[4]{\subsubsection{Sampling Statement}
+\begin{description}
+\item {\tt \farg{#1} \textasciitilde\ {\bfseries #2}(\farg{#3});}
+  \\
+  Increment target log probability density with {\tt #2\_#4(\farg{#1} \textbar\ \farg{#3})},
+  dropping constant additive terms; \refsection{sampling-statements}
+  explains sampling statements.%
+\index{{\tt\bfseries #2 }!sampling statement|hyperpage}
+\end{description}}
+
+\newcommand{\pitemTwoImpl}[3]{\subsubsection{Sampling Statement}
+\begin{description}
+\item {\tt \farg{#1} \textasciitilde\ {\bfseries #2}();}
+  \\
+  Increment target log probability density with {\tt #2\_#3(\farg{#1})},
+  dropping constant additive terms; \refsection{sampling-statements}
+  explains sampling statements.%
+\index{{\tt\bfseries #2 }!sampling statement|hyperpage}
+\end{description}}
+
+
+\newcommand{\pitem}[3]{\pitemImpl{#1}{#2}{#3}{lpdf}}
+\newcommand{\pitemdisc}[3]{\pitemImpl{#1}{#2}{#3}{lpmf}}
+
+\newcommand{\pitemTwo}[2]{\pitemTwoImpl{#1}{#2}{lpmf}}
+
+\newcommand{\indentarrow}{ \rotatebox[origin=c]{180}{\ensuremath{\Lsh}} }
+
+\newcommand{\hiershortcmd}[3]{\item[#1 \tt #2] \mbox{ } \\ #3}
+\newcommand{\hierlongcmd}[4]{\item[#1 \tt #2] \mbox{ } \\ #3 \\ #4}
+\newcommand{\hiercmdarg}[6]{\item[#1 \tt #2={\slshape <#3>}] \mbox{ } \\ #4 \\ #5 \\ (#6)}
+
+\newcommand{\shortcmd}[2]{ \hiershortcmd{}{#1}{#2} }
+\newcommand{\longcmd}[3]{ \hierlongcmd{}{#1}{#2}{#3} }
+\newcommand{\cmdarg}[5]{ \hiercmdarg{}{#1}{#2}{#3}{#4}{#5} }
+
+\newcommand{\samp}{{\lower.78ex\hbox{\texttt{\char`\~}}}}%
+%{{\lower1.1ex\hbox{\Large\texttt{\char`\~}}}}
+
+% iPad: 3w x 4h,
+
+\setlength{\paperwidth}{6in}
+\setlength{\paperheight}{8in}
+\pdfpagewidth=\paperwidth
+\pdfpageheight=\paperheight
+
+\setlength{\textwidth}{5in}
+\setlength{\textheight}{6.875in}
+\setlength{\oddsidemargin}{-0.5in}
+\setlength{\evensidemargin}{-0.5in}
+\setlength{\topmargin}{-0.875in}
+\setlength{\headsep}{18pt}
+
+\renewcommand{\topfraction}{0.9}
+\renewcommand{\bottomfraction}{0.8}
+\renewcommand{\floatpagefraction}{0.75}
+\renewcommand{\textfraction}{0.07}
+
+
+% environment for Stan code
+\DefineVerbatimEnvironment{stancode}{Verbatim}{fontsize=\small,xleftmargin=2em}
+
+\raggedbottom
+
+\sloppy % no line overruns


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Removed dependency on makefile `stan/make/manual`, see issue #660.

#### Intended Effect:
Allow removal of all docs and assosicated make tasks from `stan` repo, as the Stan documentation has been moved over to the `docs` repo  (issue: https://github.com/stan-dev/stan/issues/2706)

#### How to Verify:

- run task `make clean-all`, verify no top-level `doc` dir
- run task `make manual`, verify that top-level `doc` dir exists, contains versioned CmdStan guide (pdf).

#### Side Effects:
N/A

#### Documentation:
N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)