### PR TITLE
revert to old develop Makefile; trying to fix grammar too large on Windows

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,37 +23,12 @@ help:
 
 STAN ?= stan/
 MATH ?= $(STAN)lib/stan_math/
-
-##########################
-## FIXME(DL): Default compiler options broken in math tagged v2.18.1.
-##            Once fixed, remove lines and replace with include
-#-include $(MATH)make/default_compiler_options
-O = 3
-O_STANC = 0
-AR = ar
-CPPFLAGS = -DNO_FPRINTF_OUTPUT -pipe
-# CXXFLAGS are just used for C++
-CXXFLAGS = -Wall -I . -isystem $(EIGEN) -isystem $(BOOST) -isystem $(SUNDIALS)/include -std=c++1y -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION -Wno-unused-function -Wno-uninitialized
-GTEST_CXXFLAGS = -DGTEST_USE_OWN_TR1_TUPLE
-LDLIBS =
-EXE =
-WINE =
-
-
-##########################
-
-
-CXXFLAGS += -I src -isystem $(STAN)src -isystem $(MATH)
-CXXFLAGS += -DFUSION_MAX_VECTOR_SIZE=12 -Wno-unused-local-typedefs
-CXXFLAGS += -DEIGEN_NO_DEBUG
-LDLIBS_STANC = -Lbin -lstanc
-STANCFLAGS ?=
+ifeq ($(OS),Windows_NT)
+  O_STANC ?= 3
+endif
+O_STANC ?= 0
+INC_FIRST ?= -I src -I $(STAN)src
 USER_HEADER ?= $(dir $<)user_header.hpp
-PATH_SEPARATOR = /
-CMDSTAN_VERSION := 2.18.1
-
--include $(HOME)/.config/cmdstan/make.local  # define local variables
--include make/local                       # overwrite local variables
 
 -include $(MATH)make/compiler_flags
 -include $(MATH)make/dependencies


### PR DESCRIPTION
Seems like the makefile on `master` has its own commits that weren't on develop until I merged master into develop as part of the standard gitflow hotfix process. We've been seeing weird error messages on pull requests and develop about grammar size being too large on Windows only, so this PR is an attempt to see if reverting to the old makefile from `develop` will fix those issues on Windows.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
