### PR TITLE
Adds OpenCL Capabilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,23 +93,6 @@ pipeline {
                         }
                     }
                 }
-                stage('Non-windows interface tests with OpenCL') {
-                    agent { label 'gpu' }
-                    steps {
-                        setupCXX()
-                        sh "echo STAN_OPENCL=true>> make/local"
-                        sh "echo OPENCL_PLATFORM_ID=0>> make/local"
-                        sh "echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID}>> make/local"
-                        sh runTests("./")
-                    }
-                    post {
-                        always {
-                            warnings consoleParsers: [[parserName: 'GNU C Compiler 4 (gcc)']], failedTotalAll: '0', usePreviousBuildAsReference: false, canRunOnFailed: true
-                            warnings consoleParsers: [[parserName: 'Clang (LLVM based)']], failedTotalAll: '0', usePreviousBuildAsReference: false, canRunOnFailed: true
-                            deleteDir()
-                        }
-                    }
-                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,7 +99,7 @@ pipeline {
                 stage('Non-windows interface tests with OpenCL') {
                     agent { label 'gpu' }
                     steps {
-                        sh "echo CXX=${env.CXX} -Werror > make/local"
+                        sh "echo CXX=${env.CXX} -Werror >> make/local"
                         sh "echo STAN_OPENCL=true>> make/local"
                         sh "echo OPENCL_PLATFORM_ID=0>> make/local"
                         sh "echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID}>> make/local"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,15 +91,12 @@ pipeline {
                             warnings consoleParsers: [[parserName: 'Clang (LLVM based)']], failedTotalAll: '0', usePreviousBuildAsReference: false, canRunOnFailed: true
                             deleteDir()
                         }
-                        success { script { utils.mailBuildResults("SUCCESSFUL") } }
-                        unstable { script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com") } }
-                        failure { script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com") } }
                     }
                 }
                 stage('Non-windows interface tests with OpenCL') {
                     agent { label 'gpu' }
                     steps {
-                        sh "echo CXX=${env.CXX} -Werror >> make/local"
+                        setupCXX()
                         sh "echo STAN_OPENCL=true>> make/local"
                         sh "echo OPENCL_PLATFORM_ID=0>> make/local"
                         sh "echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID}>> make/local"
@@ -107,17 +104,18 @@ pipeline {
                     }
                     post {
                         always {
-                            archiveArtifacts 'build-opencl.log'
                             warnings consoleParsers: [[parserName: 'GNU C Compiler 4 (gcc)']], failedTotalAll: '0', usePreviousBuildAsReference: false, canRunOnFailed: true
                             warnings consoleParsers: [[parserName: 'Clang (LLVM based)']], failedTotalAll: '0', usePreviousBuildAsReference: false, canRunOnFailed: true
                             deleteDir()
                         }
-                        success { script { utils.mailBuildResults("SUCCESSFUL") } }
-                        unstable { script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com") } }
-                        failure { script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com") } }
                     }
                 }
             }
         }
+    }
+    post {
+        success { script { utils.mailBuildResults("SUCCESSFUL") } }
+        unstable { script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com") } }
+        failure { script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com") } }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,6 +96,27 @@ pipeline {
                         failure { script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com") } }
                     }
                 }
+                stage('Non-windows interface tests with OpenCL') {
+                    agent { label 'gpu' }
+                    steps {
+                        sh "echo CXX=${env.CXX} -Werror > make/local"
+                        sh "echo STAN_OPENCL=true>> make/local"
+                        sh "echo OPENCL_PLATFORM_ID=0>> make/local"
+                        sh "echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID}>> make/local"
+                        sh runTests("./")
+                    }
+                    post {
+                        always {
+                            archiveArtifacts 'build-opencl.log'
+                            warnings consoleParsers: [[parserName: 'GNU C Compiler 4 (gcc)']], failedTotalAll: '0', usePreviousBuildAsReference: false, canRunOnFailed: true
+                            warnings consoleParsers: [[parserName: 'Clang (LLVM based)']], failedTotalAll: '0', usePreviousBuildAsReference: false, canRunOnFailed: true
+                            deleteDir()
+                        }
+                        success { script { utils.mailBuildResults("SUCCESSFUL") } }
+                        unstable { script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com") } }
+                        failure { script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com") } }
+                    }
+                }
             }
         }
     }

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -39,6 +39,7 @@
 #include <stan/services/experimental/advi/fullrank.hpp>
 #include <stan/services/experimental/advi/meanfield.hpp>
 #include <stan/math/prim/arr/functor/mpi_cluster.hpp>
+#include <stan/math/opencl/opencl_context.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <fstream>
@@ -76,7 +77,7 @@ namespace cmdstan {
     return result;
   }
 
-  static int hmc_fixed_cols = 7; // hmc sampler outputs columns __lp + 6 
+  static int hmc_fixed_cols = 7; // hmc sampler outputs columns __lp + 6
 
 
   template <class Model>
@@ -194,7 +195,7 @@ namespace cmdstan {
       size_t num_cols = param_names.size();
       size_t num_rows = fitted_params.metadata.num_samples;
 
-      // check that all parameter names are in sample, in order 
+      // check that all parameter names are in sample, in order
       if (num_cols + hmc_fixed_cols > fitted_params.header.size()) {
         std::stringstream msg;
         msg << "Mismatch between model and fitted_parameters csv file \"" << fname << "\"" << std::endl;

--- a/src/docs/cmdstan-guide/auto/installation.el
+++ b/src/docs/cmdstan-guide/auto/installation.el
@@ -1,0 +1,11 @@
+(TeX-add-style-hook
+ "installation"
+ (lambda ()
+   (LaTeX-add-labels
+    "install.appendix"
+    "install-windows.appendix"
+    "install-mac.appendix"
+    "install-linux.appendix"
+    "make-options.appendix"))
+ :latex)
+

--- a/src/docs/cmdstan-guide/installation.tex
+++ b/src/docs/cmdstan-guide/installation.tex
@@ -296,7 +296,7 @@ is installed as part of Rtools).
 %
 \begin{quote}
 \begin{Verbatim}[fontshape=sl,fontsize=\small]
-> tar --no-same-owner -xzf cmdstan-2.18.1.tar.gz 
+> tar --no-same-owner -xzf cmdstan-2.18.1.tar.gz
 \end{Verbatim}
 \end{quote}
 %
@@ -604,8 +604,10 @@ computations which ensure that divergent transitions are reported:
 \section{Optional Parallelization Support}
 
 \CmdStan has optional support for within-chain parallelization using
-threads or multiple processes which are linked via the message passing
-interface (MPI).
+threading and OpenCL or multiple processes which are linked via the message
+passing interface (MPI).
+
+\subsection{Threading and MPI}
 %
 \begin{description}
   \item[Threads] can utilize multiple cores on a single
@@ -618,12 +620,17 @@ interface (MPI).
     different machines. Please refer to
     \url{https://github.com/stan-dev/math/wiki/MPI-Parallelism} for
     more details.
+  \item[OpenCL] in \CmdStan enables Cholesky decompositions to utilize a GPU
+   for large parallel computations. Please refer to
+   \url{https://github.com/stan-dev/math/wiki/OpenCL-GPU-Routines} for setup
+   instructions.
 \end{description}
 %
-The within-chain parallelization is used in the Stan language to
-parallelize the evaluation of the \Verb|map_rect| command. Note that
+The within-chain parallelization for threading and MPI is used in the Stan
+language to parallelize the evaluation of the \Verb|map_rect| command. Note that
 MPI parallelism will take precendence in case both features are
-enabled.
+enabled. Currently, OpenCL will only pass matrices over to the GPU if their
+dimensions are larger than 1250x1250.
 
 \section{Optional Components for Developers}
 

--- a/src/docs/cmdstan-guide/installation.tex
+++ b/src/docs/cmdstan-guide/installation.tex
@@ -629,7 +629,26 @@ enabled.
 
 \subsection{OpenCL}
 
-OpenCL in \CmdStan enables Cholesky decompositions to utilize a GPU for large parallel computations. Please refer to \url{https://github.com/stan-dev/math/wiki/OpenCL-GPU-Routines} for setup instructions. Currently, OpenCL will only pass matrices over to the GPU if their dimensions are larger than 1250x1250.
+OpenCL in \CmdStan enables Cholesky decompositions to utilize a GPU for large parallel computations. In order to use OpenCL, a few lines need to be added to \code{make/local}. 
+\begin{itemize}
+  \item \Verb|STAN_OPENCL=true| Enable the use of OpenCL.
+  \item \Verb|OPENCL_PLATFORM_ID=<int>| Set which OpenCL platform to use.  
+  \item \Verb|OPENCL_DEVICE_ID=<int>| Set which OpenCL device on the selected platform to use.
+\end{itemize}
+
+Windows users need to additionally specify the following two flags depending on the GPU you are running OpenCL on.
+
+\subsubsection{NVIDIA GPU}
+\begin{itemize}
+  \item \Verb|LDFLAGS_OPENCL= -L"\$(CUDA_PATH)\lib\x64" -lOpenCL|
+\end{itemize}
+
+\subsubsection{AMD GPU}
+\begin{itemize}
+  \item \Verb|LDFLAGS_OPENCL= -L"\$(AMDAPPSDKROOT)lib\x86_64" -lOpenCL|
+\end{itemize}
+
+If you are unsure if your devices support OpenCL, we suggest running the \code{clinfo} application that lists all available OpenCL supported devices. Please refer to \url{https://github.com/stan-dev/math/wiki/OpenCL-GPU-Routines} for additional setup instructions. Currently, OpenCL will only pass matrices over to the GPU if their dimensions are larger than $1250\times 1250$.
 
 \section{Optional Components for Developers}
 

--- a/src/docs/cmdstan-guide/installation.tex
+++ b/src/docs/cmdstan-guide/installation.tex
@@ -620,17 +620,16 @@ passing interface (MPI).
     different machines. Please refer to
     \url{https://github.com/stan-dev/math/wiki/MPI-Parallelism} for
     more details.
-  \item[OpenCL] in \CmdStan enables Cholesky decompositions to utilize a GPU
-   for large parallel computations. Please refer to
-   \url{https://github.com/stan-dev/math/wiki/OpenCL-GPU-Routines} for setup
-   instructions.
 \end{description}
 %
 The within-chain parallelization for threading and MPI is used in the Stan
 language to parallelize the evaluation of the \Verb|map_rect| command. Note that
 MPI parallelism will take precendence in case both features are
-enabled. Currently, OpenCL will only pass matrices over to the GPU if their
-dimensions are larger than 1250x1250.
+enabled.
+
+\subsection{OpenCL}
+
+OpenCL in \CmdStan enables Cholesky decompositions to utilize a GPU for large parallel computations. Please refer to \url{https://github.com/stan-dev/math/wiki/OpenCL-GPU-Routines} for setup instructions. Currently, OpenCL will only pass matrices over to the GPU if their dimensions are larger than 1250x1250.
 
 \section{Optional Components for Developers}
 

--- a/src/docs/cmdstan-guide/installation.tex
+++ b/src/docs/cmdstan-guide/installation.tex
@@ -604,8 +604,7 @@ computations which ensure that divergent transitions are reported:
 \section{Optional Parallelization Support}
 
 \CmdStan has optional support for within-chain parallelization using
-threading and OpenCL or multiple processes which are linked via the message
-passing interface (MPI).
+threading, OpenCL, or MPI (Message Passing Interface).
 
 \subsection{Threading and MPI}
 %
@@ -616,7 +615,7 @@ passing interface (MPI).
     instructions on how to setup threading.
   \item[MPI] is typically used on large computing clusters. The MPI
     standard allows to link together a large number of processes which
-    can run locally on the same and/or accross potentially many
+    can run locally on one machine or across many
     different machines. Please refer to
     \url{https://github.com/stan-dev/math/wiki/MPI-Parallelism} for
     more details.
@@ -629,10 +628,10 @@ enabled.
 
 \subsection{OpenCL}
 
-OpenCL in \CmdStan enables Cholesky decompositions to utilize a GPU for large parallel computations. In order to use OpenCL, a few lines need to be added to \code{make/local}. 
+OpenCL in \CmdStan enables Cholesky decompositions to utilize a GPU for large parallel computations. In order to use OpenCL, a few lines need to be added to \code{make/local}.
 \begin{itemize}
   \item \Verb|STAN_OPENCL=true| Enable the use of OpenCL.
-  \item \Verb|OPENCL_PLATFORM_ID=<int>| Set which OpenCL platform to use.  
+  \item \Verb|OPENCL_PLATFORM_ID=<int>| Set which OpenCL platform to use.
   \item \Verb|OPENCL_DEVICE_ID=<int>| Set which OpenCL device on the selected platform to use.
 \end{itemize}
 

--- a/src/test/interface/opencl_test.cpp
+++ b/src/test/interface/opencl_test.cpp
@@ -1,0 +1,13 @@
+#ifdef STAN_OPENCL
+
+#include <cmdstan/command.hpp>
+#include <gtest/gtest.h>
+#include <CL/cl.hpp>
+#include <stan/math/prim/arr.hpp>
+
+TEST(StanUiCommand, opencl_ready) {
+  // Check if  the OpenCL context has a device ready
+  EXPECT_TRUE(stan::math::opencl_context.device()[0].getInfo<CL_DEVICE_AVAILABLE>());
+}
+
+#endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: Steve Bronder

#### Summary:
1. Adds tests on Jenkins with OpenCL turned on
2. Updates the CmdStan docs with a brief explanation of how OpenCL is used
3. Adds test opencl_test.cpp that checks if the OpenCL context is on
4. Adds opencl_context.hpp to the command.hpp includes

#### Intended Effect:

Gives users directions and access to the GPU OpenCL routines for Cholesky Decompositions 

#### How to Verify:

Assuming you have a single valid OpenCL installation (if not see wiki [here](https://github.com/stan-dev/math/wiki/OpenCL-GPU-Routines)), you can set the device and platform ID as below.

```bash
echo STAN_OPENCL=true>> make/local
echo OPENCL_PLATFORM_ID=0>> make/local
echo OPENCL_DEVICE_ID=0>> make/local
./runCmdStanTests.py src/test/interface/opencl_test.cpp 
```

Otherwise install `clinfo` and set the values for the platform and device ID as returned from `clinfo -l`

#### Tests:

What level of testing is needed at this level? For now I only included a test to check if the OpenCL context has an available device.

#### Side Effects:

Cholesky is now executed on GPU if matrix size N is greater than threshold of 1250

#### Documentation:

Documentation added to installation.tex. I'm tagging Sebastian for review here as I'm adding the OpenCL docs to his section on parallelism.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Steve Bronder

