### PR TITLE
Updated Jenkinsfile to support the new warnings plugin. ( The Jenkins…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,8 +64,20 @@ pipeline {
                     }
                     post {
                         always {
-                            warnings consoleParsers: [[parserName: 'GNU C Compiler 4 (gcc)']], failedTotalAll: '0', usePreviousBuildAsReference: false, canRunOnFailed: true
-                            warnings consoleParsers: [[parserName: 'Clang (LLVM based)']], failedTotalAll: '0', usePreviousBuildAsReference: false, canRunOnFailed: true
+
+                            recordIssues id: "non_windows", 
+                            name: "Non-windows interface tests",
+                            enabledForFailure: true, 
+                            aggregatingResults : true, 
+                            tools: [
+                                gcc4(id: "non_windows_gcc4", name: "Non-windows interface tests@GCC4"),
+                                clang(id: "non_windows_clang", name: "Non-windows interface tests@CLANG")
+                            ],
+                            blameDisabled: false,
+                            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                            healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+                            referenceJobName: env.BRANCH_NAME
+
                             deleteDir()
                         }
                     }
@@ -87,8 +99,20 @@ pipeline {
                     post {
                         always {
                             archiveArtifacts 'build-mpi.log'
-                            warnings consoleParsers: [[parserName: 'GNU C Compiler 4 (gcc)']], failedTotalAll: '0', usePreviousBuildAsReference: false, canRunOnFailed: true
-                            warnings consoleParsers: [[parserName: 'Clang (LLVM based)']], failedTotalAll: '0', usePreviousBuildAsReference: false, canRunOnFailed: true
+
+                            recordIssues id: "non_windows_mpi", 
+                            name: "Non-windows interface tests with MPI",
+                            enabledForFailure: true, 
+                            aggregatingResults : true,
+                            blameDisabled: false,
+                            tools: [
+                                gcc4(id: "non_windows_mpi_gcc4", name: "Non-windows interface tests with MPI@GCC4"),
+                                clang(id: "non_windows_mpi_clang", name: "Non-windows interface tests with MPI@CLANG")
+                            ],
+                            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                            healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+                            referenceJobName: env.BRANCH_NAME
+                            
                             deleteDir()
                         }
                     }


### PR DESCRIPTION
… Warnings Next Generation Plugin )

#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [ ] Declare copyright holder and open-source license: see below

#### Summary: Updated Jenkinsfile to support the new warnings plugin.

#### Intended Effect: Stop using the deprecated,  old plugin. Visualize warnings. Make use of new features.

#### How to Verify: Check the Jenkins pipeline results.

#### Side Effects: None

#### Documentation: 

`aggregatingResults` - Ties the results together, so we have tied together the gcc4 & clang in the same UI. Can be disabled by setting it to `false`
`blameDisabled` - Determines who is the author of an issue. ( See https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#source-code-blames-for-git-projects )
`qualityGates` - Quality gates let you modify Jenkins' build status so that you immediately see if the desired quality of your product is met ( See https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#quality-gate-configuration )
`healthy` - Health report of the project ( See https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#health-report-configuration )
`referenceJobName` - References the baseline, used for the classification of issues. ( See 
https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#control-the-selection-of-the-reference-build-baseline )

For the complete documentation please visit: https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md
For the complete list of tools please visit: https://github.com/jenkinsci/warnings-ng-plugin/blob/master/SUPPORTED-FORMATS.md

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
