### PR TITLE
Cmdstan will now trigger Cmdstand performance tests on success. Cmdst…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,13 @@ pipeline {
         }
     }
     post {
-        success { script { utils.mailBuildResults("SUCCESSFUL") } }
+        success { 
+            script { 
+                utils.mailBuildResults("SUCCESSFUL") 
+            }
+            // Use wait=false to detach CmdStan Performance Tests from the current Job when starting
+            build job: 'CmdStan Performance Tests', wait: false
+        }
         unstable { script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com") } }
         failure { script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com") } }
     }


### PR DESCRIPTION
…an performance tests Job will run detached from the Cmdstan job.

#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [ ] Declare copyright holder and open-source license: see below

#### Summary: Cmdstan will now trigger Cmdstand performance tests on success.

#### Intended Effect:

#### How to Verify: 

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
