### PR TITLE
Fixes #610 - add pre-compiled headers to build makefile target.

### DIFF
--- a/makefile
+++ b/makefile
@@ -150,10 +150,13 @@ build-mpi: $(MPI_TARGETS)
 	@echo '--- boost mpi bindings built ---'
 
 .PHONY: build
-build: bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE) $(LIBSUNDIALS) $(MPI_TARGETS) $(STAN)src/stan/model/model_header.hpp.gch
+build: bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE) $(LIBSUNDIALS) $(MPI_TARGETS)
 	@echo ''
 	@echo '--- CmdStan v$(CMDSTAN_VERSION) built ---'
 
+ifeq ($(CXX_TYPE),clang)
+build: $(STAN)src/stan/model/model_header.hpp.gch
+endif
 
 ##
 # Clean up.

--- a/makefile
+++ b/makefile
@@ -150,7 +150,7 @@ build-mpi: $(MPI_TARGETS)
 	@echo '--- boost mpi bindings built ---'
 
 .PHONY: build
-build: bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE) $(LIBSUNDIALS) $(MPI_TARGETS)
+build: bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE) $(LIBSUNDIALS) $(MPI_TARGETS) $(STAN)src/stan/model/model_header.hpp.gch
 	@echo ''
 	@echo '--- CmdStan v$(CMDSTAN_VERSION) built ---'
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
the `build` target is intended to create all of the cmdstan files used - some distros require this and then put the 'built' CmdStan somewhere read-only. The pre-compiled headers should have been included in the `build` target when they were added. This PR remedies that.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
