### PR TITLE
adds compile_info make target

### DIFF
--- a/makefile
+++ b/makefile
@@ -139,6 +139,7 @@ help-dev:
 	@echo '                   bin/stanc$(EXE))'
 	@echo '- *$(EXE)        : If a Stan model exists at *.stan, this target will build'
 	@echo '                   the Stan model as an executable.'
+	@echo '- compile_info   : prints compiler flags for compiling a CmdStan executable.'
 	@echo ''
 	@echo 'Documentation:'
 	@echo ' - manual:          Build the Stan manual and the CmdStan user guide.'

--- a/makefile
+++ b/makefile
@@ -212,8 +212,12 @@ manual: src/docs/cmdstan-guide/cmdstan-guide.pdf
 	cd $(dir $@); latexmk -pdf -pdflatex="pdflatex -file-line-error" -use-make $(notdir $^)
 
 
+.PHONY: compile_info
+compile_info:
+	@echo '$(LINK.cpp) $(CXXFLAGS_PROGRAM) $(CMDSTAN_MAIN) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS)'
 
 ##
 # Debug target that allows you to print a variable
 ##
+.PHONY: print-%
 print-%  : ; @echo $* = $($*)


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Adds `make compile_info`. It will print the C++ compiler invocation to be used (without the `-include <stan generated header file> -o <executable name>`).

#### Intended Effect:
Makes it easier to compile CmdStan programs. This will allow for spaces in paths by scripting outside of `make`.

#### How to Verify:
Type:
```
make compile_info
```

#### Side Effects:
None.

#### Documentation:
Added some doc to `make help-dev`

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): 

Generable

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
