### PR TITLE
Move stan/io/json files to the cmdstan repository

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -9,6 +9,7 @@
 #include <cmdstan/arguments/arg_random.hpp>
 #include <cmdstan/write_model.hpp>
 #include <cmdstan/write_stan.hpp>
+#include <cmdstan/io/json/json_data.hpp>
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/stream_logger.hpp>
@@ -17,7 +18,6 @@
 #include <stan/io/dump.hpp>
 #include <stan/io/stan_csv_reader.hpp>
 #include <stan/io/ends_with.hpp>
-#include <stan/io/json/json_data.hpp>
 #include <stan/model/model_base.hpp>
 #include <stan/services/diagnose/diagnose.hpp>
 #include <stan/services/optimize/bfgs.hpp>

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -78,9 +78,9 @@ namespace cmdstan {
       throw std::invalid_argument(msg.str());
     }
     if (stan::io::ends_with(".json", file)) {
-      stan::json::json_data var_context(stream);
+      cmdstan::json::json_data var_context(stream);
       stream.close();
-      std::shared_ptr<stan::io::var_context> result = std::make_shared<stan::json::json_data>(var_context);
+      std::shared_ptr<stan::io::var_context> result = std::make_shared<cmdstan::json::json_data>(var_context);
       return result;
     }
     stan::io::dump var_context(stream);

--- a/src/cmdstan/io/json/json_data.hpp
+++ b/src/cmdstan/io/json/json_data.hpp
@@ -1,0 +1,211 @@
+#ifndef STAN_IO_JSON_JSON_DATA_HPP
+#define STAN_IO_JSON_JSON_DATA_HPP
+
+#include <boost/throw_exception.hpp>
+#include <boost/lexical_cast.hpp>
+#include <stan/io/var_context.hpp>
+#include <stan/io/json/json_error.hpp>
+#include <stan/io/json/json_parser.hpp>
+#include <stan/io/json/json_data_handler.hpp>
+#include <cctype>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace stan {
+
+  namespace json {
+
+    /**
+     * A <code>json_data</code> is a <code>var_context</code> object
+     * that represents a set of named values which are typed to either
+     * <code>double</code> or <code>int</code> and can be either scalar
+     * value or a non-empty array of values of any dimensionality.
+     * Arrays must be retangular and the values of an array are all of
+     * the same type, either double or int.
+     *
+     * <p>The dimensions and values of variables are accessed by variable name.
+     * The values of a variable are stored as a vector of values and
+     * a vector of array dimensions, where a scalar value consists of
+     * a single value and an emtpy vector for the dimensionality.
+     * Multidimensional arrays are stored in column-major order,
+     * meaning the first index changes the most quickly.
+     * If all the values of an array are int values, the array will be
+     * stored as a vector of ints, else the array will be stored
+     * as a vector of type double.
+     *
+     * <p><code>json_data</code> objects are created by using the
+     * <code>json_parser</code> and a <code>json_data_handler</code>
+     * to read a single JSON text from an input stream.
+     */
+    class json_data : public stan::io::var_context {
+    private:
+      vars_map_r vars_r_;
+      vars_map_i vars_i_;
+
+      std::vector<double> const empty_vec_r_;
+      std::vector<int> const empty_vec_i_;
+      std::vector<size_t> const empty_vec_ui_;
+
+      /**
+       * Return <code>true</code> if this json_data contains the specified
+       * variable name defined as a real-valued variable. This method
+       * returns <code>false</code> if the values are all integers.
+       *
+       * @param name Variable name to test.
+       * @return <code>true</code> if the variable exists in the
+       * real values of the json_data.
+       */
+      bool contains_r_only(const std::string& name) const {
+        return vars_r_.find(name) != vars_r_.end();
+      }
+
+    public:
+      /**
+       * Construct a json_data object from the specified input stream.
+       *
+       * <b>Warning:</b> This method does not close the input stream.
+       *
+       * @param in Input stream from which to read.
+       * @throws json_exception if data is not well-formed stan data declaration
+       */
+      explicit json_data(std::istream& in) : vars_r_(), vars_i_() {
+        json_data_handler handler(vars_r_, vars_i_);
+        stan::json::parse(in, handler);
+      }
+
+      /**
+       * Return <code>true</code> if this json_data contains the specified
+       * variable name. This method returns <code>true</code>
+       * even if the values are all integers.
+       *
+       * @param name Variable name to test.
+       * @return <code>true</code> if the variable exists.
+       */
+      bool contains_r(const std::string& name) const {
+        return contains_r_only(name) || contains_i(name);
+      }
+
+      /**
+       * Return <code>true</code> if this json_data contains an integer
+       * valued array with the specified name.
+       *
+       * @param name Variable name to test.
+       * @return <code>true</code> if the variable name has an integer
+       * array value.
+       */
+      bool contains_i(const std::string& name) const {
+        return vars_i_.find(name) != vars_i_.end();
+      }
+
+      /**
+       * Return the double values for the variable with the specified
+       * name or null.
+       *
+       * @param name Name of variable.
+       * @return Values of variable.
+       */
+      std::vector<double> vals_r(const std::string& name) const {
+        if (contains_r_only(name)) {
+          return (vars_r_.find(name)->second).first;
+        } else if (contains_i(name)) {
+          std::vector<int> vec_int = (vars_i_.find(name)->second).first;
+          std::vector<double> vec_r(vec_int.size());
+          for (size_t ii = 0; ii < vec_int.size(); ii++) {
+            vec_r[ii] = vec_int[ii];
+          }
+          return vec_r;
+        }
+        return empty_vec_r_;
+      }
+
+      /**
+       * Return the dimensions for the variable with the specified
+       * name.
+       *
+       * @param name Name of variable.
+       * @return Dimensions of variable.
+       */
+      std::vector<size_t> dims_r(const std::string& name) const {
+        if (contains_r_only(name)) {
+          return (vars_r_.find(name)->second).second;
+        } else if (contains_i(name)) {
+          return (vars_i_.find(name)->second).second;
+        }
+        return empty_vec_ui_;
+      }
+
+      /**
+       * Return the integer values for the variable with the specified
+       * name.
+       *
+       * @param name Name of variable.
+       * @return Values.
+       */
+      std::vector<int> vals_i(const std::string& name) const {
+        if (contains_i(name)) {
+          return (vars_i_.find(name)->second).first;
+        }
+        return empty_vec_i_;
+      }
+
+      /**
+       * Return the dimensions for the integer variable with the specified
+       * name.
+       *
+       * @param name Name of variable.
+       * @return Dimensions of variable.
+       */
+      std::vector<size_t> dims_i(const std::string& name) const {
+        if (contains_i(name)) {
+          return (vars_i_.find(name)->second).second;
+        }
+        return empty_vec_ui_;
+      }
+
+      /**
+       * Return a list of the names of the floating point variables in
+       * the json_data.
+       *
+       * @param names Vector to store the list of names in.
+       */
+      virtual void names_r(std::vector<std::string>& names) const {
+        names.resize(0);
+        for (vars_map_r::const_iterator it = vars_r_.begin();
+             it != vars_r_.end(); ++it)
+          names.push_back((*it).first);
+      }
+
+      /**
+       * Return a list of the names of the integer variables in
+       * the json_data.
+       *
+       * @param names Vector to store the list of names in.
+       */
+      virtual void names_i(std::vector<std::string>& names) const {
+        names.resize(0);
+        for (vars_map_i::const_iterator it = vars_i_.begin();
+             it != vars_i_.end(); ++it)
+          names.push_back((*it).first);
+      }
+
+      /**
+       * Remove variable from the object.
+       *
+       * @param name Name of the variable to remove.
+       * @return If variable is removed returns <code>true</code>, else
+       *   returns <code>false</code>.
+       */
+      bool remove(const std::string& name) {
+        return (vars_i_.erase(name) > 0)
+          || (vars_r_.erase(name) > 0);
+      }
+    };
+
+  }
+
+}
+#endif

--- a/src/cmdstan/io/json/json_data.hpp
+++ b/src/cmdstan/io/json/json_data.hpp
@@ -1,12 +1,12 @@
-#ifndef STAN_IO_JSON_JSON_DATA_HPP
-#define STAN_IO_JSON_JSON_DATA_HPP
+#ifndef CMDSTAN_IO_JSON_JSON_DATA_HPP
+#define CMDSTAN_IO_JSON_JSON_DATA_HPP
 
 #include <boost/throw_exception.hpp>
 #include <boost/lexical_cast.hpp>
 #include <stan/io/var_context.hpp>
-#include <stan/io/json/json_error.hpp>
-#include <stan/io/json/json_parser.hpp>
-#include <stan/io/json/json_data_handler.hpp>
+#include <cmdstan/io/json/json_error.hpp>
+#include <cmdstan/io/json/json_parser.hpp>
+#include <cmdstan/io/json/json_data_handler.hpp>
 #include <cctype>
 #include <iostream>
 #include <limits>
@@ -15,7 +15,7 @@
 #include <string>
 #include <vector>
 
-namespace stan {
+namespace cmdstan {
 
   namespace json {
 
@@ -23,8 +23,8 @@ namespace stan {
      * A <code>json_data</code> is a <code>var_context</code> object
      * that represents a set of named values which are typed to either
      * <code>double</code> or <code>int</code> and can be either scalar
-     * value or a non-empty array of values of any dimensionality.
-     * Arrays must be retangular and the values of an array are all of
+     * value or an array of values of any dimensionality.
+     * Arrays must be rectangular and the values of an array are all of
      * the same type, either double or int.
      *
      * <p>The dimensions and values of variables are accessed by variable name.
@@ -74,7 +74,7 @@ namespace stan {
        */
       explicit json_data(std::istream& in) : vars_r_(), vars_i_() {
         json_data_handler handler(vars_r_, vars_i_);
-        stan::json::parse(in, handler);
+        parse(in, handler);
       }
 
       /**

--- a/src/cmdstan/io/json/json_data_handler.hpp
+++ b/src/cmdstan/io/json/json_data_handler.hpp
@@ -1,0 +1,357 @@
+#ifndef STAN_IO_JSON_JSON_DATA_HANDLER_HPP
+#define STAN_IO_JSON_JSON_DATA_HANDLER_HPP
+
+#include <boost/throw_exception.hpp>
+#include <boost/lexical_cast.hpp>
+#include <stan/io/var_context.hpp>
+#include <stan/io/json/json_error.hpp>
+#include <stan/io/json/json_parser.hpp>
+#include <stan/io/json/json_handler.hpp>
+#include <cctype>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace stan {
+
+  namespace json {
+
+    typedef
+    std::map<std::string,
+             std::pair<std::vector<double>,
+                       std::vector<size_t> > >
+    vars_map_r;
+
+    typedef
+    std::map<std::string,
+             std::pair<std::vector<int>,
+                       std::vector<size_t> > >
+    vars_map_i;
+
+    /**
+     * A <code>json_data_handler</code> is an implementation of a
+     * <code>json_handler</code> that restricts the allowed JSON text
+     * to a set of Stan variable declarations in JSON format.
+     * Each Stan variable consists of a JSON key : value pair.
+     * The key is a string and the value is either a single numeric
+     * scalar value or a JSON array of numeric values.
+     *
+     * <p>The <code>json_data_handler</code> checks that the top-level
+     * JSON object contains a set of name-value pairs
+     * where the values can be either numeric scalar objects or
+     * or numeric arrays of any dimensionality. Arrays must be rectangular.
+     * Empty arrays are not allowed, nor are arrays of empty arrays.
+     * The strings \"Inf\" and \"Infinity\" are mapped to positive infinity,
+     * the strings \"-Inf\" and \"-Infinity\" are mapped to negative infinity,
+     * and the string \"NaN\" is mapped to not-a-number.
+     * Bare versions of Infinity, -Infinity, and NaN are also allowed.
+     */
+    class json_data_handler : public stan::json::json_handler {
+    private:
+      vars_map_r& vars_r_;
+      vars_map_i& vars_i_;
+      std::string key_;
+      std::vector<double> values_r_;
+      std::vector<int> values_i_;
+      std::vector<size_t> dims_;
+      std::vector<size_t> dims_verify_;
+      std::vector<bool> dims_unknown_;
+      size_t dim_idx_;
+      size_t dim_last_;
+      bool is_int_;
+
+      void reset() {
+        key_.clear();
+        values_r_.clear();
+        values_i_.clear();
+        dims_.clear();
+        dims_verify_.clear();
+        dims_unknown_.clear();
+        dim_idx_ = 0;
+        dim_last_ = 0;
+        is_int_ = true;
+      }
+
+      bool is_init() {
+        return (key_.size() == 0
+                && values_r_.size() == 0
+                && values_i_.size() == 0
+                && dims_.size() == 0
+                && dims_verify_.size() == 0
+                && dims_unknown_.size() == 0
+                && dim_idx_ == 0
+                && dim_last_ == 0
+                && is_int_);
+      }
+
+
+    public:
+      /**
+       * Construct a json_data_handler object.
+       *
+       * <b>Warning:</b> This method does not close the input stream.
+       *
+       * @param vars_r name-value map for real-valued variables
+       * @param vars_i name-value map for int-valued variables
+       */
+      json_data_handler(vars_map_r& vars_r, vars_map_i& vars_i)
+        : json_handler(), vars_r_(vars_r), vars_i_(vars_i),
+          key_(), values_r_(), values_i_(),
+          dims_(), dims_verify_(), dims_unknown_(),
+          dim_idx_(0), dim_last_(0), is_int_(true) {
+      }
+
+      void start_text() {
+        vars_i_.clear();
+        vars_r_.clear();
+        reset();
+      }
+
+      void end_text() {
+        reset();
+      }
+
+      void start_array() {
+        if (0 == key_.size()) {
+          throw json_error("expecting JSON object, found array");
+        }
+        if (dim_idx_ > 0 && dim_last_ == dim_idx_) {
+            std::stringstream errorMsg;
+            errorMsg << "variable: " << key_
+                     << ", error: non-scalar array value";
+            throw json_error(errorMsg.str());
+          }
+        incr_dim_size();
+        dim_idx_++;
+        if (dims_.size() < dim_idx_) {
+          dims_.push_back(0);
+          dims_unknown_.push_back(true);
+          dims_verify_.push_back(0);
+        } else {
+          dims_verify_[dim_idx_-1] = 0;
+        }
+      }
+
+      void end_array() {
+        if (dims_[dim_idx_-1] == 0) {
+          std::stringstream errorMsg;
+          errorMsg << "variable: " << key_
+                   << ", error: empty array not allowed";
+          throw json_error(errorMsg.str());
+        }
+        if (dims_unknown_[dim_idx_-1] == true) {
+          dims_unknown_[dim_idx_-1] = false;
+        } else if (dims_verify_[dim_idx_-1] != dims_[dim_idx_-1]) {
+          std::stringstream errorMsg;
+          errorMsg << "variable: " << key_ << ", error: non-rectangular array";
+          throw json_error(errorMsg.str());
+        }
+        if (0 == dim_last_
+            && ((is_int_ && values_i_.size() > 0) || (values_r_.size() > 0)))
+          dim_last_ = dim_idx_;
+        dim_idx_--;
+      }
+
+      void start_object() {
+        if (!is_init()) {
+          std::stringstream errorMsg;
+          errorMsg << "variable: " << key_
+                   << ", error: nested objects not allowed";
+          throw json_error(errorMsg.str());
+        }
+      }
+
+      void end_object() {
+        save_current_key_value_pair();
+        reset();
+      }
+
+      void null() {
+        std::stringstream errorMsg;
+        errorMsg << "variable: " << key_ << ", error: null values not allowed";
+        throw json_error(errorMsg.str());
+      }
+
+      void boolean(bool p) {
+        std::stringstream errorMsg;
+        errorMsg << "variable: " << key_
+                 << ", error: boolean values not allowed";
+        throw json_error(errorMsg.str());
+      }
+
+      void string(const std::string& s) {
+        double tmp;
+        if (0 == s.compare("-Inf")) {
+          tmp = -std::numeric_limits<double>::infinity();
+        } else if (0 == s.compare("-Infinity")) {
+          tmp = -std::numeric_limits<double>::infinity();
+        } else if (0 == s.compare("Inf")) {
+          tmp = std::numeric_limits<double>::infinity();
+        } else if (0 == s.compare("Infinity")) {
+          tmp = std::numeric_limits<double>::infinity();
+        } else if (0 == s.compare("NaN")) {
+          tmp = std::numeric_limits<double>::quiet_NaN();
+        } else {
+          std::stringstream errorMsg;
+          errorMsg << "variable: " << key_
+                   << ", error: string values not allowed";
+          throw json_error(errorMsg.str());
+        }
+        if (is_int_) {
+          for (std::vector<int>::iterator it = values_i_.begin();
+               it != values_i_.end(); ++it)
+            values_r_.push_back(*it);
+        }
+        is_int_ = false;
+        values_r_.push_back(tmp);
+        incr_dim_size();
+      }
+
+      void key(const std::string& key) {
+        save_current_key_value_pair();
+        reset();
+        key_ = key;
+      }
+
+      void number_double(double x) {
+        set_last_dim();
+        if (is_int_) {
+          for (std::vector<int>::iterator it = values_i_.begin();
+               it != values_i_.end(); ++it)
+            values_r_.push_back(*it);
+        }
+        is_int_ = false;
+        values_r_.push_back(x);
+        incr_dim_size();
+      }
+
+      // NOLINTNEXTLINE(runtime/int)
+      void number_long(long n) {
+        set_last_dim();
+        if (is_int_) {
+          values_i_.push_back(n);
+        } else {
+          values_r_.push_back(n);
+        }
+        incr_dim_size();
+      }
+
+      // NOLINTNEXTLINE(runtime/int)
+      void number_unsigned_long(unsigned long n) {
+        set_last_dim();
+        if (is_int_) {
+          values_i_.push_back(n);
+        } else {
+          values_r_.push_back(n);
+        }
+        incr_dim_size();
+      }
+
+      void save_current_key_value_pair() {
+        if (0 == key_.size()) return;
+
+        // redefinition or variables not allowed
+        if (vars_r_.find(key_) != vars_r_.end()
+            || vars_i_.find(key_) != vars_i_.end()) {
+            std::stringstream errorMsg;
+            errorMsg << "attempt to redefine variable: " << key_;
+            throw json_error(errorMsg.str());
+        }
+
+        // transpose order of array values to column-major
+        if (is_int_) {
+          std::pair<std::vector<int>,
+                    std::vector<size_t> > pair;
+          if (dims_.size() > 1) {
+            std::vector<int> cm_values_i(values_i_.size());
+            to_column_major(cm_values_i, values_i_, dims_);
+            pair = make_pair(cm_values_i, dims_);
+
+          } else {
+            pair = make_pair(values_i_, dims_);
+          }
+          vars_i_[key_] = pair;
+        } else {
+          std::pair<std::vector<double>,
+                    std::vector<size_t> > pair;
+          if (dims_.size() > 1) {
+            std::vector<double> cm_values_r(values_r_.size());
+            to_column_major(cm_values_r, values_r_, dims_);
+            pair = make_pair(cm_values_r, dims_);
+          } else {
+            pair = make_pair(values_r_, dims_);
+          }
+          vars_r_[key_] = pair;
+        }
+      }
+
+      void incr_dim_size() {
+        if (dim_idx_ > 0) {
+          if (dims_unknown_[dim_idx_-1])
+            dims_[dim_idx_-1]++;
+          else
+            dims_verify_[dim_idx_-1]++;
+        }
+      }
+
+      template <typename T>
+      void to_column_major(std::vector<T>& cm_vals,
+                           const std::vector<T>& rm_vals,
+                           const std::vector<size_t>& dims) {
+        for (size_t i = 0; i< rm_vals.size(); i++) {
+          size_t idx = convert_offset_rtl_2_ltr(i, dims);
+          cm_vals[idx] = rm_vals[i];
+        }
+      }
+
+      void set_last_dim() {
+        if (dim_last_ > 0 && dim_idx_ < dim_last_) {
+          std::stringstream errorMsg;
+          errorMsg << "variable: " << key_ << ", error: non-rectangular array";
+          throw json_error(errorMsg.str());
+        }
+        dim_last_ = dim_idx_;
+      }
+
+      // convert row-major offset to column-major offset
+      size_t convert_offset_rtl_2_ltr(size_t rtl_offset,
+                                      const std::vector<size_t>& dims) {
+        size_t rtl_dsize = 1;
+        for (size_t i = 1; i < dims.size(); i++)
+          rtl_dsize *= dims[i];
+
+        // array index should be valid, but check just in case
+        if (rtl_offset >= rtl_dsize*dims[0]) {
+          std::stringstream errorMsg;
+          errorMsg << "variable: " << key_ << ", unexpected error";
+          throw json_error(errorMsg.str());
+        }
+
+        // calculate offset by working left-to-right to get array indices
+        // for row-major offset left-most dimensions are divided out
+        // for column-major offset successive dimensions are multiplied in
+        size_t rem = rtl_offset;
+        size_t ltr_offset = 0;
+        size_t ltr_dsize = 1;
+        for (size_t i = 0; i < dims.size()-1; i++) {
+          size_t idx = rem / rtl_dsize;
+          ltr_offset +=  idx * ltr_dsize;
+          rem = rem - idx * rtl_dsize;
+          rtl_dsize = rtl_dsize / dims[i+1];
+          ltr_dsize *= dims[i];
+        }
+        ltr_offset +=  rem * ltr_dsize;  // for loop stops 1 early
+
+        return ltr_offset;
+      }
+    };
+
+  }
+
+}
+
+#endif

--- a/src/cmdstan/io/json/json_data_handler.hpp
+++ b/src/cmdstan/io/json/json_data_handler.hpp
@@ -1,12 +1,12 @@
-#ifndef STAN_IO_JSON_JSON_DATA_HANDLER_HPP
-#define STAN_IO_JSON_JSON_DATA_HANDLER_HPP
+#ifndef CMDSTAN_IO_JSON_JSON_DATA_HANDLER_HPP
+#define CMDSTAN_IO_JSON_JSON_DATA_HANDLER_HPP
 
 #include <boost/throw_exception.hpp>
 #include <boost/lexical_cast.hpp>
 #include <stan/io/var_context.hpp>
-#include <stan/io/json/json_error.hpp>
-#include <stan/io/json/json_parser.hpp>
-#include <stan/io/json/json_handler.hpp>
+#include <cmdstan/io/json/json_error.hpp>
+#include <cmdstan/io/json/json_parser.hpp>
+#include <cmdstan/io/json/json_handler.hpp>
 #include <cctype>
 #include <iostream>
 #include <limits>
@@ -16,7 +16,7 @@
 #include <vector>
 #include <utility>
 
-namespace stan {
+namespace cmdstan {
 
   namespace json {
 
@@ -44,13 +44,12 @@ namespace stan {
      * JSON object contains a set of name-value pairs
      * where the values can be either numeric scalar objects or
      * or numeric arrays of any dimensionality. Arrays must be rectangular.
-     * Empty arrays are not allowed, nor are arrays of empty arrays.
      * The strings \"Inf\" and \"Infinity\" are mapped to positive infinity,
      * the strings \"-Inf\" and \"-Infinity\" are mapped to negative infinity,
      * and the string \"NaN\" is mapped to not-a-number.
      * Bare versions of Infinity, -Infinity, and NaN are also allowed.
      */
-    class json_data_handler : public stan::json::json_handler {
+    class json_data_handler : public cmdstan::json::json_handler {
     private:
       vars_map_r& vars_r_;
       vars_map_i& vars_i_;
@@ -137,12 +136,6 @@ namespace stan {
       }
 
       void end_array() {
-        if (dims_[dim_idx_-1] == 0) {
-          std::stringstream errorMsg;
-          errorMsg << "variable: " << key_
-                   << ", error: empty array not allowed";
-          throw json_error(errorMsg.str());
-        }
         if (dims_unknown_[dim_idx_-1] == true) {
           dims_unknown_[dim_idx_-1] = false;
         } else if (dims_verify_[dim_idx_-1] != dims_[dim_idx_-1]) {

--- a/src/cmdstan/io/json/json_error.hpp
+++ b/src/cmdstan/io/json/json_error.hpp
@@ -1,0 +1,26 @@
+#ifndef STAN_IO_JSON_JSON_ERROR_HPP
+#define STAN_IO_JSON_JSON_ERROR_HPP
+
+#include <stdexcept>
+#include <string>
+
+namespace stan {
+
+  namespace json {
+
+    /**
+     * Exception type for JSON errors.
+     */
+    struct json_error : public std::logic_error {
+      /**
+       * Construct a JSON error with the specified message
+       * @param what Message to attach to error
+       */
+      explicit json_error(const std::string& what)
+        : logic_error(what) {
+      }
+    };
+
+  }
+}
+#endif

--- a/src/cmdstan/io/json/json_error.hpp
+++ b/src/cmdstan/io/json/json_error.hpp
@@ -1,10 +1,10 @@
-#ifndef STAN_IO_JSON_JSON_ERROR_HPP
-#define STAN_IO_JSON_JSON_ERROR_HPP
+#ifndef CMDSTAN_IO_JSON_JSON_ERROR_HPP
+#define CMDSTAN_IO_JSON_JSON_ERROR_HPP
 
 #include <stdexcept>
 #include <string>
 
-namespace stan {
+namespace cmdstan {
 
   namespace json {
 

--- a/src/cmdstan/io/json/json_handler.hpp
+++ b/src/cmdstan/io/json/json_handler.hpp
@@ -1,0 +1,105 @@
+#ifndef STAN_IO_JSON_JSON_HANDLER_HPP
+#define STAN_IO_JSON_JSON_HANDLER_HPP
+
+#include <string>
+
+namespace stan {
+
+  namespace json {
+
+    /**
+     * Abstract base class for JSON handlers.  More efficient to just
+     * implement directly and pass in as a template, but this version
+     * is available for convenience.
+     */
+    class json_handler {
+    public:
+      json_handler() { }
+
+      ~json_handler() { }
+
+      /**
+       * Handle the the start of the text.
+       */
+      virtual void start_text() { }
+
+      /**
+       * Handle the the end of the text.
+       */
+      virtual void end_text() { }
+
+      /**
+       * Handle the start of an array.
+       */
+      virtual void start_array() { }
+
+      /**
+       * Handle the end of an array.
+       */
+      virtual void end_array() { }
+
+      /**
+       * Handle the start of an object.
+       */
+      virtual void start_object() { }
+
+      /**
+       * Handle the end of an object.
+       */
+      virtual void end_object() { }
+
+      /**
+       * Handle the null literal value.
+       */
+      virtual void null() { }
+
+      /**
+       * Handle the boolean literal value of the specified polarity.
+       *
+       * @param p polarity of boolean
+       */
+      virtual void boolean(bool p) { }
+
+      /**
+       * Handle a the specified double-precision floating point
+       * value.
+       *
+       * @param x Value to handle.
+       */
+      virtual void number_double(double x) { }
+
+      /**
+       * Handle a the specified long integer value.
+       *
+       * @param n Value to handle.
+       */
+      // NOLINTNEXTLINE(runtime/int)
+      virtual void number_long(long n) { }
+
+      /**
+       * Handle a the specified unsigned long integer value.
+       *
+       * @param n Value to handle.
+       */
+      // NOLINTNEXTLINE(runtime/int)
+      virtual void number_unsigned_long(unsigned long n) { }
+
+      /**
+       * Handle the specified string value.
+       *
+       * @param s String value to handle.
+       */
+      virtual void string(const std::string& s) { }
+
+      /**
+       * Handle the specified object key.
+       *
+       * @param s String object key to handle.
+       */
+      virtual void key(const std::string& s) { }
+    };
+
+  }
+}
+
+#endif

--- a/src/cmdstan/io/json/json_handler.hpp
+++ b/src/cmdstan/io/json/json_handler.hpp
@@ -1,9 +1,9 @@
-#ifndef STAN_IO_JSON_JSON_HANDLER_HPP
-#define STAN_IO_JSON_JSON_HANDLER_HPP
+#ifndef CMDSTAN_IO_JSON_JSON_HANDLER_HPP
+#define CMDSTAN_IO_JSON_JSON_HANDLER_HPP
 
 #include <string>
 
-namespace stan {
+namespace cmdstan {
 
   namespace json {
 

--- a/src/cmdstan/io/json/json_parser.hpp
+++ b/src/cmdstan/io/json/json_parser.hpp
@@ -1,0 +1,479 @@
+#ifndef STAN_IO_JSON_JSON_PARSER_HPP
+#define STAN_IO_JSON_JSON_PARSER_HPP
+
+#include <boost/lexical_cast.hpp>
+
+#include <stan/io/validate_zero_buf.hpp>
+#include <stan/io/json/json_error.hpp>
+
+#include <stdexcept>
+#include <iostream>
+#include <istream>
+#include <limits>
+#include <sstream>
+#include <string>
+
+namespace stan {
+
+  namespace json {
+
+    const unsigned int MIN_HIGH_SURROGATE = 0xD800;
+    const unsigned int MAX_HIGH_SURROGATE = 0xDBFF;
+    const unsigned int MIN_LOW_SURROGATE = 0xDC00;
+    const unsigned int MAX_LOW_SURROGATE = 0xDFFF;
+    const unsigned int MIN_SUPPLEMENTARY_CODE_POINT = 0x010000;
+
+    inline bool is_high_surrogate(unsigned int cp) {
+      return (cp >= MIN_HIGH_SURROGATE && cp <= MAX_HIGH_SURROGATE);
+    }
+
+    inline bool is_low_surrogate(unsigned int cp) {
+      return (cp >= MIN_LOW_SURROGATE && cp <= MAX_LOW_SURROGATE);
+    }
+
+    inline bool is_whitespace(char c) {
+      return c == ' ' || c == '\n' || c == '\t' || c == '\r';
+    }
+
+    /**
+     * A <code>json_parser</code> is a SAX-style streaming parser
+     * that enforces JSON syntax and parses JSON elements
+     * from an input stream, sending callbacks to a user-supplied
+     * <code>json_handler</code>.
+     */
+    template <typename Handler, bool Validate_UTF_8>
+    class parser {
+    public:
+      parser(Handler& h,
+             std::istream& in)
+        : h_(h),
+          in_(in),
+          next_char_(0),
+          line_(0),
+          column_(0)
+      {  }
+
+      ~parser() {
+      }
+
+      void parse() {
+        h_.start_text();
+        parse_text();
+        h_.end_text();
+      }
+
+    private:
+      json_error json_exception(const std::string& msg) const {
+        std::stringstream ss;
+        ss << "Error in JSON parsing at"
+           << " line=" << line_ << " column=" << column_
+           << std::endl
+           << msg
+           << std::endl;
+        return json_error(ss.str());
+      }
+
+      // JSON-text = object / array
+      void parse_text() {
+        char c = get_non_ws_char();
+        if (c == '{') {              // begin-object
+          h_.start_object();
+          parse_object_members_end_object();
+          h_.end_object();
+        } else if (c == '[') {      // begin-array
+          // array
+          h_.start_array();
+          parse_array_values_end_array();
+          h_.end_array();
+        } else {
+          throw json_exception("expecting start of object ({) or array ([)");
+        }
+      }
+
+      // value =  false / null / true / object / array / number / string
+      void parse_value() {
+        // value
+        char c = get_non_ws_char();
+        if (c == 'f') {
+          // false
+          parse_false_literal();
+        } else if (c == 'n') {
+          // null
+          parse_null_literal();
+        } else if (c == 't') {
+          // true
+          parse_true_literal();
+        } else if (c == '"') {
+          // string
+          h_.string(parse_string_chars_quotation_mark());
+        } else if (c == '{' || c == '[') {
+          // object / array
+          unget_char();
+          parse_text();
+        } else if (c == '-' ||
+                   (c >= '0' && c <= '9') ||
+                   c == 'I' || c == 'N') {
+          unget_char();
+          parse_number();
+        } else {
+          throw json_exception("illegal value, expecting object, array, "
+                               "number, string, or literal true/false/null");
+        }
+      }
+
+      void parse_number() {
+        bool is_positive = true;
+
+        std::stringstream ss;
+        char c = get_non_ws_char();
+        // minus
+        if (c == '-') {
+          is_positive = false;
+          ss << c;
+          c = get_char();
+        }
+
+        // Infinity
+        if ((is_positive && ss.str() == "I") ||
+            c == 'I') {
+            parse_infinity_literal(is_positive);
+            return;
+        }
+        // Nan
+        if (c == 'N') {
+          parse_nan_literal();
+          return;
+        }
+
+        // int
+        //   zero / digit1-9
+        if (c < '0' || c > '9')
+          throw json_exception("expecting int part of number");
+        ss << c;
+
+        //   *DIGIT
+        bool leading_zero = (c == '0');
+        c = get_char();
+        if (leading_zero && (c == '0'))
+          throw json_exception("zero padded numbers not allowed");
+        while (c >= '0' && c <= '9') {
+          ss << c;
+          c = get_char();
+        }
+
+        // frac
+        bool is_integer = true;
+        if (c == '.') {
+          is_integer = false;
+          ss << '.';
+          c = get_char();
+          if (c < '0' || c > '9')
+            throw json_exception("expected digit after decimal");
+          ss << c;
+          c = get_char();
+          while (c >= '0' && c <= '9') {
+            ss << c;
+            c = get_char();
+          }
+        }
+
+        // exp
+        if (c == 'e' || c == 'E') {
+          is_integer = false;
+          ss << c;
+          c = get_char();
+          // minus / plus
+          if (c == '+' || c == '-') {
+            ss << c;
+            c = get_char();
+          }
+          // 1*DIGIT
+          if (c < '0' || c > '9')
+            throw json_exception("expected digit after e/E");
+          while (c >= '0' && c <= '9') {
+            ss << c;
+            c = get_char();
+          }
+        }
+        unget_char();
+
+        if (is_integer) {
+          if (is_positive) {
+            unsigned long n;  // NOLINT(runtime/int)
+            try {
+              // NOLINTNEXTLINE(runtime/int)
+              n = boost::lexical_cast<unsigned long>(ss.str());
+            } catch (const boost::bad_lexical_cast & ) {
+              throw json_exception("number exceeds integer range");
+            }
+            ss >> n;
+            h_.number_unsigned_long(n);
+          } else {
+            long n;  // NOLINT(runtime/int)
+            try {
+              // NOLINTNEXTLINE(runtime/int)
+              n = boost::lexical_cast<unsigned long>(ss.str());
+            } catch (const boost::bad_lexical_cast & ) {
+              throw json_exception("number exceeds integer range");
+            }
+            ss >> n;
+            h_.number_long(n);
+          }
+        } else {
+          double x;
+          try {
+            std::string ss_str = ss.str();
+            x = boost::lexical_cast<double>(ss_str);
+            if (x == 0)
+              io::validate_zero_buf(ss_str);
+          } catch (const boost::bad_lexical_cast & ) {
+            throw json_exception("number exceeds double range");
+          }
+          ss >> x;
+          h_.number_double(x);
+        }
+      }
+
+      std::string parse_string_chars_quotation_mark() {
+        std::stringstream s;
+        while (true) {
+          char c = get_char();
+          if (c == '"') {
+            return s.str();
+          } else if (c == '\\') {
+            c = get_char();
+            if (c == '\\'  || c == '/' || c == '"') {
+              s << c;
+            } else if (c == 'b') {
+              s << '\b';
+            } else if (c == 'f') {
+              s << '\f';
+            } else if (c == 'n') {
+              s << '\n';
+            } else if (c == 'r') {
+              s << '\r';
+            } else if (c == 't') {
+              s << '\t';
+            } else if (c == 'u') {
+              get_escaped_unicode(s);
+            } else {
+              throw json_exception("expecting legal escape");
+            }
+            continue;
+          } else if (c > 0 && c < 0x20) {  // ASCII control characters
+            throw json_exception("found control character, char values less "
+                                 "than U+0020 must be \\u escaped");
+          }
+          s << c;
+        }
+      }
+
+      void parse_true_literal() {
+        get_chars("rue");
+        h_.boolean(true);
+      }
+
+      void parse_false_literal() {
+        get_chars("alse");
+        h_.boolean(false);
+      }
+
+      void parse_null_literal() {
+        get_chars("ull");
+        h_.null();
+      }
+
+      void parse_infinity_literal(bool is_positive) {
+        get_chars("nfinity");
+        if (is_positive)
+          h_.number_double(std::numeric_limits<double>::infinity());
+        else
+          h_.number_double(-std::numeric_limits<double>::infinity());
+      }
+
+      void parse_nan_literal() {
+        get_chars("aN");
+        h_.number_double(std::numeric_limits<double>::quiet_NaN());
+      }
+
+      void get_escaped_unicode(std::stringstream& s) {
+        unsigned int codepoint = get_int_as_hex_chars();
+        if (!(is_high_surrogate(codepoint) || is_low_surrogate(codepoint))) {
+          putCodepoint(s, codepoint);
+        } else if (!is_high_surrogate(codepoint)) {
+          throw json_exception("illegal unicode values, found "
+                               "low-surrogate, missing high-surrogate");
+        } else {
+          char c = get_char();
+          if (!(c == '\\'))
+            throw json_exception("illegal unicode values, found "
+                                 "high-surrogate, expecting low-surrogate");
+          c = get_char();
+          if (!(c == 'u'))
+            throw json_exception("illegal unicode values, found "
+                                 "high-surrogate, expecting low-surrogate");
+          unsigned int codepoint2 = get_int_as_hex_chars();
+          unsigned int supplemental
+            = ((codepoint - MIN_HIGH_SURROGATE) << 10)
+            + (codepoint2 - MIN_LOW_SURROGATE)
+            + MIN_SUPPLEMENTARY_CODE_POINT;
+          putCodepoint(s, supplemental);
+        }
+      }
+
+      unsigned int get_int_as_hex_chars() {
+        std::stringstream s;
+        s << std::hex;
+        for (int i = 0; i < 4; i++) {
+          char c = get_char();
+          if (!((c >= 'a' && c<= 'f')
+                || (c >= 'A' && c<= 'F')
+                || (c >= '0' && c<= '9')))
+            throw json_exception("illegal unicode code point");
+          s << c;
+        }
+        unsigned int hex;
+        s >> hex;
+        return hex;
+      }
+
+      void putCodepoint(std::stringstream& s, unsigned int codepoint) {
+        if (codepoint <= 0x7f) {
+          s.put(codepoint);
+        } else if (codepoint <= 0x7ff) {
+          s.put(0xc0 | ((codepoint >> 6) & 0x1f));
+          s.put(0x80 | (codepoint & 0x3f));
+        } else if (codepoint <= 0xffff) {
+          s.put(0xe0 | ((codepoint >> 12) & 0x0f));
+          s.put(0x80 | ((codepoint >> 6) & 0x3f));
+          s.put(0x80 | (codepoint & 0x3f));
+        } else {
+          s.put(0xf0 | ((codepoint >> 18) & 0x07));
+          s.put(0x80 | ((codepoint >> 12) & 0x3f));
+          s.put(0x80 | ((codepoint >> 6) & 0x3f));
+          s.put(0x80 | (codepoint & 0x3f));
+        }
+      }
+
+      void get_chars(const std::string& s) {
+        for (size_t i = 0; i < s.size(); ++i) {
+          char c = get_char();
+          if (c != s[i])
+            throw json_exception("expecting rest of literal: "
+                                 + s.substr(i));
+        }
+      }
+
+      void parse_array_values_end_array() {
+        char c = get_non_ws_char();
+        if (c == ']') return;
+        unget_char();
+        while (true) {
+          parse_value();
+          char c = get_non_ws_char();
+          if (c == ']') return;
+          if (c != ',') {
+            throw json_exception("in array, expecting ] or ,");
+          }
+          c = get_non_ws_char();
+          if (c == ']')
+            throw json_exception("in array, expecting value");
+          unget_char();
+        }
+      }
+
+      void parse_object_members_end_object() {
+        char c = get_non_ws_char();
+        if (c == '}') return;
+        while (true) {
+          // string (key)
+          if (c != '"')
+            throw json_exception("expecting member key"
+                                 " or end of object marker (})");
+          std::string key = parse_string_chars_quotation_mark();
+          h_.key(key);
+          // name-separator separator
+          c = get_non_ws_char();
+          if (c != ':')
+            throw json_exception("expecting key-value separator :");
+          // value
+          parse_value();
+
+          // continuation
+          c = get_non_ws_char();
+          if (c == '}')
+            return;
+          if (c != ',')
+            throw json_exception("expecting end of object } or separator ,");
+          c = get_non_ws_char();
+        }
+      }
+
+      char get_char() {
+        char c = in_.get();
+        if (!in_.good())
+          throw json_exception("unexpected end of stream");
+        if (c == '\n') {
+          ++line_;
+          column_ = 1;
+        } else {
+          ++column_;
+        }
+        return c;
+      }
+
+      char get_non_ws_char() {
+        while (true) {
+          char c = get_char();
+          if (is_whitespace(c)) continue;
+          return c;
+        }
+      }
+
+      void unget_char() {
+        in_.unget();
+        --column_;
+      }
+
+      Handler& h_;
+      std::istream& in_;
+      char next_char_;
+      size_t line_;
+      size_t column_;
+    };
+
+
+    /**
+     * Parse the JSON text represented by the specified input stream,
+     * sending events to the specified handler, and optionally
+     * validating the UTF-8 encoding.
+     *
+     * @tparam Validate_UTF_8
+     * @tparam Handler
+     * @param in Input stream from which to parse
+     * @param handler Handler for events from parser
+     */
+    template <bool Validate_UTF_8, typename Handler>
+    void parse(std::istream& in,
+               Handler& handler) {
+      parser<Handler, Validate_UTF_8>(handler, in).parse();
+    }
+
+    /**
+     * Parse the JSON text represented by the specified input stream,
+     * sending events to the specified handler, and optionally
+     * validating the UTF-8 encoding.
+     *
+     * @tparam Handler
+     * @param in Input stream from which to parse
+     * @param handler Handler for events from parser
+     */
+    template <typename Handler>
+    void parse(std::istream& in,
+               Handler& handler) {
+      parse<false>(in, handler);
+    }
+
+  }
+}
+#endif

--- a/src/cmdstan/io/json/json_parser.hpp
+++ b/src/cmdstan/io/json/json_parser.hpp
@@ -1,10 +1,10 @@
-#ifndef STAN_IO_JSON_JSON_PARSER_HPP
-#define STAN_IO_JSON_JSON_PARSER_HPP
+#ifndef CMDSTAN_IO_JSON_JSON_PARSER_HPP
+#define CMDSTAN_IO_JSON_JSON_PARSER_HPP
 
 #include <boost/lexical_cast.hpp>
 
 #include <stan/io/validate_zero_buf.hpp>
-#include <stan/io/json/json_error.hpp>
+#include <cmdstan/io/json/json_error.hpp>
 
 #include <stdexcept>
 #include <iostream>
@@ -13,7 +13,7 @@
 #include <sstream>
 #include <string>
 
-namespace stan {
+namespace cmdstan {
 
   namespace json {
 
@@ -225,7 +225,7 @@ namespace stan {
             std::string ss_str = ss.str();
             x = boost::lexical_cast<double>(ss_str);
             if (x == 0)
-              io::validate_zero_buf(ss_str);
+              stan::io::validate_zero_buf(ss_str);
           } catch (const boost::bad_lexical_cast & ) {
             throw json_exception("number exceeds double range");
           }

--- a/src/test/interface/io/json/json_data_handler_test.cpp
+++ b/src/test/interface/io/json/json_data_handler_test.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include <cmdstan/io/json//json_data.hpp>
+#include <cmdstan/io/json//json_data_handler.hpp>
+#include <cmdstan/io/json//json_error.hpp>
+#include <cmdstan/io/json//json_handler.hpp>
+#include <cmdstan/io/json//json_parser.hpp>
+
+void test_rtl_2_ltr(size_t idx_rtl,
+                    size_t idx_ltr,
+                    const std::vector<size_t>& dims) {
+  stan::json::vars_map_r vars_r;
+  stan::json::vars_map_i vars_i;
+  stan::json::json_data_handler handler(vars_r, vars_i);
+
+  size_t idx = handler.convert_offset_rtl_2_ltr(idx_rtl,dims);
+  EXPECT_EQ(idx, idx_ltr);
+}
+
+void test_exception(size_t idx_rtl,
+                    const std::string& exception_text,
+                    const std::vector<size_t>& dims) {
+  stan::json::vars_map_r vars_r;
+  stan::json::vars_map_i vars_i;
+  stan::json::json_data_handler handler(vars_r, vars_i);
+  try {
+    handler.convert_offset_rtl_2_ltr(idx_rtl,dims);
+  } catch (const std::exception& e) {
+    EXPECT_EQ(e.what(), exception_text);
+    return;
+  }
+  FAIL();  // didn't throw an exception as expected.
+}
+
+
+TEST(ioJson,rtl_2_ltr_1) {
+  std::vector<size_t> dims(1);
+  dims[0] = 7;
+  test_rtl_2_ltr(0,0,dims);
+  test_rtl_2_ltr(1,1,dims);
+  test_rtl_2_ltr(2,2,dims);
+  test_rtl_2_ltr(3,3,dims);
+  test_rtl_2_ltr(4,4,dims);
+  test_rtl_2_ltr(5,5,dims);
+  test_rtl_2_ltr(6,6,dims);
+}
+
+//  row major:
+//  11 12 13 14 21 22 23 24
+//  column major:
+//  11 21 12 22 13 23 14 24
+
+TEST(ioJson,rtl_2_ltr_2) {
+  std::vector<size_t> dims(2);
+  dims[0] = 2;
+  dims[1] = 4;
+  test_rtl_2_ltr(0,0,dims);
+  test_rtl_2_ltr(1,2,dims);
+  test_rtl_2_ltr(2,4,dims);
+  test_rtl_2_ltr(3,6,dims);
+  test_rtl_2_ltr(4,1,dims);
+  test_rtl_2_ltr(5,3,dims);
+  test_rtl_2_ltr(6,5,dims);
+  test_rtl_2_ltr(7,7,dims);
+}
+
+TEST(ioJson,rtl_2_ltr_err_1) {
+  std::vector<size_t> dims(1);
+  dims[0] = 7;
+  test_exception(7,"variable: , unexpected error",dims);
+}
+
+TEST(ioJson,rtl_2_ltr_err_2) {
+  std::vector<size_t> dims(2);
+  dims[0] = 2;
+  dims[1] = 4;
+  test_exception(8,"variable: , unexpected error",dims);
+}
+
+TEST(ioJson,rtl_2_ltr_err_3n) {
+  std::vector<size_t> dims(2);
+  dims[0] = 2;
+  dims[1] = 4;
+  test_exception(11,"variable: , unexpected error",dims);
+}

--- a/src/test/interface/io/json/json_data_handler_test.cpp
+++ b/src/test/interface/io/json/json_data_handler_test.cpp
@@ -9,9 +9,9 @@
 void test_rtl_2_ltr(size_t idx_rtl,
                     size_t idx_ltr,
                     const std::vector<size_t>& dims) {
-  stan::json::vars_map_r vars_r;
-  stan::json::vars_map_i vars_i;
-  stan::json::json_data_handler handler(vars_r, vars_i);
+  cmdstan::json::vars_map_r vars_r;
+  cmdstan::json::vars_map_i vars_i;
+  cmdstan::json::json_data_handler handler(vars_r, vars_i);
 
   size_t idx = handler.convert_offset_rtl_2_ltr(idx_rtl,dims);
   EXPECT_EQ(idx, idx_ltr);
@@ -20,9 +20,9 @@ void test_rtl_2_ltr(size_t idx_rtl,
 void test_exception(size_t idx_rtl,
                     const std::string& exception_text,
                     const std::vector<size_t>& dims) {
-  stan::json::vars_map_r vars_r;
-  stan::json::vars_map_i vars_i;
-  stan::json::json_data_handler handler(vars_r, vars_i);
+  cmdstan::json::vars_map_r vars_r;
+  cmdstan::json::vars_map_i vars_i;
+  cmdstan::json::json_data_handler handler(vars_r, vars_i);
   try {
     handler.convert_offset_rtl_2_ltr(idx_rtl,dims);
   } catch (const std::exception& e) {

--- a/src/test/interface/io/json/json_data_test.cpp
+++ b/src/test/interface/io/json/json_data_test.cpp
@@ -1,0 +1,505 @@
+#include <gtest/gtest.h>
+
+#include <cmdstan/io/json//json_data.hpp>
+#include <cmdstan/io/json//json_data_handler.hpp>
+#include <cmdstan/io/json//json_error.hpp>
+#include <cmdstan/io/json//json_handler.hpp>
+#include <cmdstan/io/json//json_parser.hpp>
+
+#include <boost/limits.hpp>
+#include <boost/math/concepts/real_concept.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+
+void test_int_var(stan::json::json_data& jdata,
+                  const std::string& text,
+                  const std::string& name,
+                  const std::vector<int>& expected_vals,
+                  const std::vector<size_t>& expected_dims) {
+  EXPECT_EQ(true,jdata.contains_i(name));
+  std::vector<size_t> dims = jdata.dims_i(name);
+  EXPECT_EQ(expected_dims.size(),dims.size());
+  for (size_t i = 0; i<dims.size(); i++) 
+    EXPECT_EQ(expected_dims[i],dims[i]);
+  std::vector<int> vals = jdata.vals_i(name);
+  EXPECT_EQ(expected_vals.size(),vals.size());
+  for (size_t i = 0; i<vals.size(); i++) 
+    EXPECT_EQ(expected_vals[i],vals[i]);
+}
+
+void test_real_var(stan::json::json_data& jdata,
+                  const std::string& text,
+                  const std::string& name,
+                  const std::vector<double>& expected_vals,
+                  const std::vector<size_t>& expected_dims) {
+  EXPECT_EQ(true,jdata.contains_r(name));
+  std::vector<size_t> dims = jdata.dims_r(name);
+  EXPECT_EQ(expected_dims.size(),dims.size());
+  for (size_t i = 0; i<dims.size(); i++) 
+    EXPECT_EQ(expected_dims[i],dims[i]);
+  std::vector<double> vals = jdata.vals_r(name);
+  EXPECT_EQ(expected_vals.size(),vals.size());
+  for (size_t i = 0; i<vals.size(); i++) 
+    EXPECT_EQ(expected_vals[i],vals[i]);
+}
+
+void test_exception(const std::string& input,
+                    const std::string& exception_text) {
+  try {
+    std::stringstream s(input);
+    stan::json::json_data jdata(s);
+  } catch (const std::exception& e) {
+    EXPECT_EQ(e.what(), exception_text);
+    return;
+  }
+  FAIL();  // didn't throw an exception as expected.
+}
+
+
+
+
+TEST(ioJson,jsonData_scalar_int) {
+  std::string txt = "{ \"foo\" : 1 }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<int> expected_vals;
+  expected_vals.push_back(1);
+  std::vector<size_t> expected_dims;
+  test_int_var(jdata,txt,"foo",expected_vals,expected_dims);
+}
+
+TEST(ioJson,jsonData_scalar_real) {
+  std::string txt = "{ \"foo\" : 1.1 }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals;
+  expected_vals.push_back(1.1);
+  std::vector<size_t> expected_dims;
+  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+}
+
+TEST(ioJson,jsonData_mult_vars) {
+  std::string txt = "{ \"foo\" : 1, \"bar\" : 0.1 }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<int> expected_vals_i;
+  expected_vals_i.push_back(1);
+  std::vector<size_t> expected_dims;
+  test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
+  std::vector<double> expected_vals_r;
+  expected_vals_r.push_back(0.1);
+  test_real_var(jdata,txt,"bar",expected_vals_r,expected_dims);
+}
+
+TEST(ioJson,jsonData_mult_vars2) {
+  std::string txt = "{ \"foo\" : \"-Inf\", \"bar\" : 0.1 }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals_r;
+  expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+  expected_vals_r.clear();
+  expected_vals_r.push_back(0.1);
+  test_real_var(jdata,txt,"bar",expected_vals_r,expected_dims);
+}
+
+
+TEST(ioJson,jsonData_mult_vars3) {
+  std::string txt = "{ \"foo\" : \"-Inf\", "
+    "                  \"bar\" : 0.1 ," 
+    "                  \"baz\" : [ \"-Inf\", 0.1 , 1 ] }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals_r;
+  expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+  expected_vals_r.clear();
+  expected_vals_r.push_back(0.1);
+  test_real_var(jdata,txt,"bar",expected_vals_r,expected_dims);
+  expected_vals_r.clear();
+  expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
+  expected_vals_r.push_back(0.1);
+  expected_vals_r.push_back(1);
+  expected_dims.push_back(3);
+  test_real_var(jdata,txt,"baz",expected_vals_r,expected_dims);
+}
+
+
+TEST(ioJson,jsonData_real_array_1D) {
+  std::string txt = "{ \"foo\" : [ 1.1, 2.2 ] }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals;
+  expected_vals.push_back(1.1);
+  expected_vals.push_back(2.2);
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(2);
+  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+}
+
+
+TEST(ioJson,jsonData_array_1D_inf) {
+  std::string txt = "{ \"foo\" : [ 1.1, \"Inf\" ] }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals;
+  expected_vals.push_back(1.1);
+  expected_vals.push_back(std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(2);
+  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+}
+
+TEST(ioJson,jsonData_array_1D_inf2) {
+  std::string txt = "{ \"foo\" : [ 1, \"Inf\" ] }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals;
+  expected_vals.push_back(1);
+  expected_vals.push_back(std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(2);
+  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+}
+
+TEST(ioJson,jsonData_array_1D_neg_inf) {
+  std::string txt = "{ \"foo\" : [ 1.1, \"-Inf\" ] }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals;
+  expected_vals.push_back(1.1);
+  expected_vals.push_back(-std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(2);
+  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+}
+
+TEST(ioJson,jsonData_real_array_2D) {
+  std::string txt = "{ \"foo\" : [ [ 1.1, 1.2 ], [ 2.1, 2.2 ], [ 3.1, 3.2] ]  }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals;
+  expected_vals.push_back(1.1);
+  expected_vals.push_back(2.1);
+  expected_vals.push_back(3.1);
+  expected_vals.push_back(1.2);
+  expected_vals.push_back(2.2);
+  expected_vals.push_back(3.2);
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(3);
+  expected_dims.push_back(2);
+  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+}
+
+
+TEST(ioJson,jsonData_real_array_3D) {
+  std::string txt = "{ \"foo\" : [ [ [ 11.1, 11.2, 11.3, 11.4 ], [ 12.1, 12.2, 12.3, 12.4 ], [ 13.1, 13.2, 13.3, 13.4] ],"
+    "                            [ [ 21.1, 21.2, 21.3, 21.4 ], [ 22.1, 22.2, 22.3, 22.4 ], [ 23.1, 23.2, 23.3, 23.4] ] ] }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals;
+  expected_vals.push_back(11.1);
+  expected_vals.push_back(21.1);
+  expected_vals.push_back(12.1);
+  expected_vals.push_back(22.1);
+  expected_vals.push_back(13.1);
+  expected_vals.push_back(23.1);
+  expected_vals.push_back(11.2);
+  expected_vals.push_back(21.2);
+  expected_vals.push_back(12.2);
+  expected_vals.push_back(22.2);
+  expected_vals.push_back(13.2);
+  expected_vals.push_back(23.2);
+  expected_vals.push_back(11.3);
+  expected_vals.push_back(21.3);
+  expected_vals.push_back(12.3);
+  expected_vals.push_back(22.3);
+  expected_vals.push_back(13.3);
+  expected_vals.push_back(23.3);
+  expected_vals.push_back(11.4);
+  expected_vals.push_back(21.4);
+  expected_vals.push_back(12.4);
+  expected_vals.push_back(22.4);
+  expected_vals.push_back(13.4);
+  expected_vals.push_back(23.4);
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(2);  // two rows
+  expected_dims.push_back(3);  // three cols
+  expected_dims.push_back(4);  // four shelves
+  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+}
+
+TEST(ioJson,jsonData_int_array_3D) {
+  std::string txt = "{ \"foo\" : [ [ [ 111, 112, 113, 114 ], [ 121, 122, 123, 124 ], [ 131, 132, 133, 134] ],"
+    "                            [ [ 211, 212, 213, 214 ], [ 221, 222, 223, 224 ], [ 231, 232, 233, 234] ] ] }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<int> expected_vals;
+  expected_vals.push_back(111);  
+  expected_vals.push_back(211);
+  expected_vals.push_back(121);
+  expected_vals.push_back(221);
+  expected_vals.push_back(131);
+  expected_vals.push_back(231);
+  expected_vals.push_back(112);
+  expected_vals.push_back(212);
+  expected_vals.push_back(122);
+  expected_vals.push_back(222);
+  expected_vals.push_back(132);
+  expected_vals.push_back(232);
+  expected_vals.push_back(113);
+  expected_vals.push_back(213);
+  expected_vals.push_back(123);
+  expected_vals.push_back(223);
+  expected_vals.push_back(133);
+  expected_vals.push_back(233);
+  expected_vals.push_back(114);
+  expected_vals.push_back(214);
+  expected_vals.push_back(124);
+  expected_vals.push_back(224);
+  expected_vals.push_back(134);
+  expected_vals.push_back(234);
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(2);  // two rows
+  expected_dims.push_back(3);  // three cols
+  expected_dims.push_back(4);  // four shelves
+  test_int_var(jdata,txt,"foo",expected_vals,expected_dims);
+}
+
+TEST(ioJson,jsonData_array_err1) {
+  std::string txt = "{ \"foo\" : [ [ [ 11.1, 11.2, 11.3, 11.4 ], [ 12.1, 12.2, 12.3, 12.4 ], [ 13.1, 13.2, 13.3, 13.4] ],"
+    "                            [ [ 21.1, 21.2, 21.3, 21.4 ], [ 666, 22.3, 22.4 ], [ 23.1, 23.2, 23.3, 23.4] ] ] }";
+  test_exception(txt,"variable: foo, error: non-rectangular array");
+}
+
+
+TEST(ioJson,jsonData_array_err2) {
+  std::string txt = "{ \"foo\" : [ [ [ 11.1, 11.2, 11.3, 11.4 ], [ 12.1, 12.2, 12.3, 12.4 ] ],"
+    "                            [ [ 21.1, 21.2, 21.3, 21.4 ], [ 666, 22.3, 22.4 ], [ 23.1, 23.2, 23.3, 23.4] ] ] }";
+  test_exception(txt,"variable: foo, error: non-rectangular array");
+}
+
+TEST(ioJson,jsonData_array_err3) {
+  std::string txt = "{ \"foo\" : [] }";
+  test_exception(txt,"variable: foo, error: empty array not allowed");
+}
+
+TEST(ioJson,jsonData_array_err4) {
+  std::string txt = "{ \"foo\" : [[[]]] }";
+  test_exception(txt,"variable: foo, error: empty array not allowed");
+}
+
+TEST(ioJson,jsonData_array_err5) {
+  std::string txt = "{ \"foo\" : [1, 2, 3, 4, [5], 6, 7] }";
+  test_exception(txt,"variable: foo, error: non-scalar array value");
+}
+
+TEST(ioJson,jsonData_array_err6) {
+  std::string txt = "{ \"foo\" : [[1], 2, 3, 4, 5, 6, 7] }";
+  test_exception(txt,"variable: foo, error: non-rectangular array");
+}
+
+TEST(ioJson,jsonData_array_err7) {
+  std::string txt = "{  \"foo\" : [1, 2, 3, 4, 5, 6, [7]] }";
+  test_exception(txt,"variable: foo, error: non-scalar array value");
+}
+
+
+TEST(ioJson,jsonData_array_err8) {
+  std::string txt = "{ \"baz\" : [[1.0,2.0,3.0],[4.0,5.0,6]],  \"foo\" : [1, 2, 3, 4, [5], 6, 7] }";
+  test_exception(txt,"variable: foo, error: non-scalar array value");
+}
+
+TEST(ioJson,jsonData_array_err9) {
+  std::string txt = "{ \"baz\":[[1,2],[3,4.0]],  \"foo\" : [[1], 2, 3, 4, 5, 6, 7] }";
+  test_exception(txt,"variable: foo, error: non-rectangular array");
+}
+
+TEST(ioJson,jsonData_array_err10) {
+  std::string txt = "{  \"baz\":[1,2,\"-Inf\"], \"foo\" : [1, 2, 3, 4, 5, 6, [7]] }";
+  test_exception(txt,"variable: foo, error: non-scalar array value");
+}
+
+TEST(ioJson,jsonData_array_err11) {
+  std::string txt = "{\"a\":1,  \"baz\":[1,2,\"-Inf\"], \"b\":2.0, "
+    "\"foo\" : [1, 2, 3, 4, 5, 6, [7]] }";
+  test_exception(txt,"variable: foo, error: non-scalar array value");
+}
+
+
+TEST(ioJson,jsonData_obj_err1) {
+  std::string txt = "{ \"foo\" : { \"bar\" : 1 } }";
+  test_exception(txt,"variable: foo, error: nested objects not allowed");
+}
+
+
+TEST(ioJson,jsonData_mult_vars_err1) {
+  std::string txt = "{ \"foo\" : 1, \"foo\" : 0.1 }";
+  test_exception(txt,"attempt to redefine variable: foo");
+}
+
+TEST(ioJson,jsonData_mult_vars_er2) {
+  std::string txt = "{ \"foo\" : 1.1, \"foo\" : 0.1 }";
+  test_exception(txt,"attempt to redefine variable: foo");
+}
+
+TEST(ioJson,jsonData_mult_vars_er3) {
+  std::string txt = "{ \"foo\" : [ 1.1, 1 ], \"foo\" : 0.1 }";
+  test_exception(txt,"attempt to redefine variable: foo");
+}
+
+TEST(ioJson,jsonData_null_value_err) {
+  std::string txt = "{ \"foo\" : [ 1.1, 1, null ] }";
+  test_exception(txt,"variable: foo, error: null values not allowed");
+}
+
+TEST(ioJson,jsonData_bool_value_err1) {
+  std::string txt = "{ \"foo\" : [ 1.1, 1, true ] }";
+  test_exception(txt,"variable: foo, error: boolean values not allowed");
+}
+
+TEST(ioJson,jsonData_bool_value_err2) {
+  std::string txt = "{ \"foo\" : [ 1.1, 1, false ] }";
+  test_exception(txt,"variable: foo, error: boolean values not allowed");
+}
+
+
+TEST(ioJson,jsonData_string_value_err) {
+  std::string txt = "{ \"foo\" : [ 1.1, 1, \"abc\" ] }";
+  test_exception(txt,"variable: foo, error: string values not allowed");
+}
+
+TEST(ioJson,jsonData_not_an_obj) {
+  std::string txt = "[ 1 ]";
+  test_exception(txt,"expecting JSON object, found array");
+}
+
+// don't allow array of objects 
+TEST(ioJson,jsonData_err_array_of_obj) {
+  std::string txt = "[ { \"foo\": 1}, { \"bar\": 1 } ]";
+  test_exception(txt,"expecting JSON object, found array");
+}
+
+
+TEST(ioJson,jsonData_parse_empty_obj) {
+  std::string txt = "{}";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<std::string> var_names;
+  jdata.names_r(var_names);
+  EXPECT_EQ(0U,var_names.size());
+  jdata.names_i(var_names);
+  EXPECT_EQ(0U,var_names.size());
+}
+
+
+// parser only reads one top-level object
+TEST(ioJson,jsonData_parse_mult_objects) {
+  std::string txt = "{ \"foo\": 1}{ \"bar\": 1 }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<std::string> var_names;
+  jdata.names_i(var_names);
+  EXPECT_EQ(1U,var_names.size());
+  EXPECT_EQ("foo",var_names[0]);
+}
+
+// R: strings "NaN", "Inf", "-Inf"
+TEST(ioJson,jsonData_NaN_str) {
+  std::string txt = "{ \"foo\" : \"NaN\" }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> vals = jdata.vals_r("foo");
+  EXPECT_TRUE(boost::math::isnan(vals[0]));
+}
+
+TEST(ioJson,jsonData_unsigned_Inf_str) {
+  std::string txt = "{ \"foo\" : \"Inf\" }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals_r;
+  expected_vals_r.push_back(std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+}
+
+TEST(ioJson,jsonData_signed_neg_Inf_str) {
+  std::string txt = "{ \"foo\" : \"-Inf\" }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals_r;
+  expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+}
+
+// python/js:  Infinity, -Infinity, NaN
+// test both bare and strings
+TEST(ioJson,jsonData_NaN_bare) {
+  std::string txt = "{ \"foo\" : NaN }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> vals = jdata.vals_r("foo");
+  EXPECT_TRUE(boost::math::isnan(vals[0]));
+}
+
+TEST(ioJson,jsonData_unsigned_Infinity_bare) {
+  std::string txt = "{ \"foo\" : Infinity }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals_r;
+  expected_vals_r.push_back(std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+}
+
+TEST(ioJson,jsonData_pos_Infinity_bare) {
+  std::string txt = "{ \"foo\" : Infinity }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals_r;
+  expected_vals_r.push_back(std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+}
+
+TEST(ioJson,jsonData_signed_neg_Infinity_bare) {
+  std::string txt = "{ \"foo\" : -Infinity }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals_r;
+  expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+}
+
+TEST(ioJson,jsonData_unsigned_Infinity_str) {
+  std::string txt = "{ \"foo\" : \"Infinity\" }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals_r;
+  expected_vals_r.push_back(std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+}
+
+TEST(ioJson,jsonData_pos_Infinity_str) {
+  std::string txt = "{ \"foo\" : \"Infinity\" }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals_r;
+  expected_vals_r.push_back(std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+}
+
+TEST(ioJson,jsonData_signed_neg_Infinity_str) {
+  std::string txt = "{ \"foo\" : \"-Infinity\" }";
+  std::stringstream in(txt);
+  stan::json::json_data jdata(in);
+  std::vector<double> expected_vals_r;
+  expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
+  std::vector<size_t> expected_dims;
+  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+}

--- a/src/test/interface/io/json/json_data_test.cpp
+++ b/src/test/interface/io/json/json_data_test.cpp
@@ -1,16 +1,16 @@
 #include <gtest/gtest.h>
 
-#include <cmdstan/io/json//json_data.hpp>
-#include <cmdstan/io/json//json_data_handler.hpp>
-#include <cmdstan/io/json//json_error.hpp>
-#include <cmdstan/io/json//json_handler.hpp>
-#include <cmdstan/io/json//json_parser.hpp>
+#include <cmdstan/io/json/json_data.hpp>
+#include <cmdstan/io/json/json_data_handler.hpp>
+#include <cmdstan/io/json/json_error.hpp>
+#include <cmdstan/io/json/json_handler.hpp>
+#include <cmdstan/io/json/json_parser.hpp>
 
 #include <boost/limits.hpp>
 #include <boost/math/concepts/real_concept.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 
-void test_int_var(stan::json::json_data& jdata,
+void test_int_var(cmdstan::json::json_data& jdata,
                   const std::string& text,
                   const std::string& name,
                   const std::vector<int>& expected_vals,
@@ -26,7 +26,7 @@ void test_int_var(stan::json::json_data& jdata,
     EXPECT_EQ(expected_vals[i],vals[i]);
 }
 
-void test_real_var(stan::json::json_data& jdata,
+void test_real_var(cmdstan::json::json_data& jdata,
                   const std::string& text,
                   const std::string& name,
                   const std::vector<double>& expected_vals,
@@ -46,7 +46,7 @@ void test_exception(const std::string& input,
                     const std::string& exception_text) {
   try {
     std::stringstream s(input);
-    stan::json::json_data jdata(s);
+    cmdstan::json::json_data jdata(s);
   } catch (const std::exception& e) {
     EXPECT_EQ(e.what(), exception_text);
     return;
@@ -60,7 +60,7 @@ void test_exception(const std::string& input,
 TEST(ioJson,jsonData_scalar_int) {
   std::string txt = "{ \"foo\" : 1 }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<int> expected_vals;
   expected_vals.push_back(1);
   std::vector<size_t> expected_dims;
@@ -70,7 +70,7 @@ TEST(ioJson,jsonData_scalar_int) {
 TEST(ioJson,jsonData_scalar_real) {
   std::string txt = "{ \"foo\" : 1.1 }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals;
   expected_vals.push_back(1.1);
   std::vector<size_t> expected_dims;
@@ -80,7 +80,7 @@ TEST(ioJson,jsonData_scalar_real) {
 TEST(ioJson,jsonData_mult_vars) {
   std::string txt = "{ \"foo\" : 1, \"bar\" : 0.1 }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<int> expected_vals_i;
   expected_vals_i.push_back(1);
   std::vector<size_t> expected_dims;
@@ -93,7 +93,7 @@ TEST(ioJson,jsonData_mult_vars) {
 TEST(ioJson,jsonData_mult_vars2) {
   std::string txt = "{ \"foo\" : \"-Inf\", \"bar\" : 0.1 }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
@@ -109,7 +109,7 @@ TEST(ioJson,jsonData_mult_vars3) {
     "                  \"bar\" : 0.1 ," 
     "                  \"baz\" : [ \"-Inf\", 0.1 , 1 ] }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
@@ -129,7 +129,7 @@ TEST(ioJson,jsonData_mult_vars3) {
 TEST(ioJson,jsonData_real_array_1D) {
   std::string txt = "{ \"foo\" : [ 1.1, 2.2 ] }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals;
   expected_vals.push_back(1.1);
   expected_vals.push_back(2.2);
@@ -142,7 +142,7 @@ TEST(ioJson,jsonData_real_array_1D) {
 TEST(ioJson,jsonData_array_1D_inf) {
   std::string txt = "{ \"foo\" : [ 1.1, \"Inf\" ] }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals;
   expected_vals.push_back(1.1);
   expected_vals.push_back(std::numeric_limits<double>::infinity());
@@ -154,7 +154,7 @@ TEST(ioJson,jsonData_array_1D_inf) {
 TEST(ioJson,jsonData_array_1D_inf2) {
   std::string txt = "{ \"foo\" : [ 1, \"Inf\" ] }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals;
   expected_vals.push_back(1);
   expected_vals.push_back(std::numeric_limits<double>::infinity());
@@ -166,7 +166,7 @@ TEST(ioJson,jsonData_array_1D_inf2) {
 TEST(ioJson,jsonData_array_1D_neg_inf) {
   std::string txt = "{ \"foo\" : [ 1.1, \"-Inf\" ] }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals;
   expected_vals.push_back(1.1);
   expected_vals.push_back(-std::numeric_limits<double>::infinity());
@@ -178,7 +178,7 @@ TEST(ioJson,jsonData_array_1D_neg_inf) {
 TEST(ioJson,jsonData_real_array_2D) {
   std::string txt = "{ \"foo\" : [ [ 1.1, 1.2 ], [ 2.1, 2.2 ], [ 3.1, 3.2] ]  }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals;
   expected_vals.push_back(1.1);
   expected_vals.push_back(2.1);
@@ -197,7 +197,7 @@ TEST(ioJson,jsonData_real_array_3D) {
   std::string txt = "{ \"foo\" : [ [ [ 11.1, 11.2, 11.3, 11.4 ], [ 12.1, 12.2, 12.3, 12.4 ], [ 13.1, 13.2, 13.3, 13.4] ],"
     "                            [ [ 21.1, 21.2, 21.3, 21.4 ], [ 22.1, 22.2, 22.3, 22.4 ], [ 23.1, 23.2, 23.3, 23.4] ] ] }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals;
   expected_vals.push_back(11.1);
   expected_vals.push_back(21.1);
@@ -234,7 +234,7 @@ TEST(ioJson,jsonData_int_array_3D) {
   std::string txt = "{ \"foo\" : [ [ [ 111, 112, 113, 114 ], [ 121, 122, 123, 124 ], [ 131, 132, 133, 134] ],"
     "                            [ [ 211, 212, 213, 214 ], [ 221, 222, 223, 224 ], [ 231, 232, 233, 234] ] ] }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<int> expected_vals;
   expected_vals.push_back(111);  
   expected_vals.push_back(211);
@@ -267,6 +267,40 @@ TEST(ioJson,jsonData_int_array_3D) {
   test_int_var(jdata,txt,"foo",expected_vals,expected_dims);
 }
 
+TEST(ioJson,jsonData_empty_1D_array) {
+  std::string txt = "{ \"foo\" : [] }";
+  std::stringstream in(txt);
+  cmdstan::json::json_data jdata(in);
+  std::vector<int> expected_vals_i;
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(0);
+  test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
+}
+
+TEST(ioJson,jsonData_empty_2D_array) {
+  std::string txt = "{ \"foo\" : [[]] }";
+  std::stringstream in(txt);
+  cmdstan::json::json_data jdata(in);
+  std::vector<int> expected_vals_i;
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(1);
+  expected_dims.push_back(0);
+  test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
+}
+
+TEST(ioJson,jsonData_empty_3D_array) {
+  std::string txt = "{ \"foo\" : [[[]]] }";
+  std::stringstream in(txt);
+  cmdstan::json::json_data jdata(in);
+  std::vector<int> expected_vals_i;
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(1);
+  expected_dims.push_back(1);
+  expected_dims.push_back(0);
+  test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
+}
+
+
 TEST(ioJson,jsonData_array_err1) {
   std::string txt = "{ \"foo\" : [ [ [ 11.1, 11.2, 11.3, 11.4 ], [ 12.1, 12.2, 12.3, 12.4 ], [ 13.1, 13.2, 13.3, 13.4] ],"
     "                            [ [ 21.1, 21.2, 21.3, 21.4 ], [ 666, 22.3, 22.4 ], [ 23.1, 23.2, 23.3, 23.4] ] ] }";
@@ -281,47 +315,37 @@ TEST(ioJson,jsonData_array_err2) {
 }
 
 TEST(ioJson,jsonData_array_err3) {
-  std::string txt = "{ \"foo\" : [] }";
-  test_exception(txt,"variable: foo, error: empty array not allowed");
-}
-
-TEST(ioJson,jsonData_array_err4) {
-  std::string txt = "{ \"foo\" : [[[]]] }";
-  test_exception(txt,"variable: foo, error: empty array not allowed");
-}
-
-TEST(ioJson,jsonData_array_err5) {
   std::string txt = "{ \"foo\" : [1, 2, 3, 4, [5], 6, 7] }";
   test_exception(txt,"variable: foo, error: non-scalar array value");
 }
 
-TEST(ioJson,jsonData_array_err6) {
+TEST(ioJson,jsonData_array_err4) {
   std::string txt = "{ \"foo\" : [[1], 2, 3, 4, 5, 6, 7] }";
   test_exception(txt,"variable: foo, error: non-rectangular array");
 }
 
-TEST(ioJson,jsonData_array_err7) {
+TEST(ioJson,jsonData_array_err5) {
   std::string txt = "{  \"foo\" : [1, 2, 3, 4, 5, 6, [7]] }";
   test_exception(txt,"variable: foo, error: non-scalar array value");
 }
 
 
-TEST(ioJson,jsonData_array_err8) {
+TEST(ioJson,jsonData_array_err6) {
   std::string txt = "{ \"baz\" : [[1.0,2.0,3.0],[4.0,5.0,6]],  \"foo\" : [1, 2, 3, 4, [5], 6, 7] }";
   test_exception(txt,"variable: foo, error: non-scalar array value");
 }
 
-TEST(ioJson,jsonData_array_err9) {
+TEST(ioJson,jsonData_array_err7) {
   std::string txt = "{ \"baz\":[[1,2],[3,4.0]],  \"foo\" : [[1], 2, 3, 4, 5, 6, 7] }";
   test_exception(txt,"variable: foo, error: non-rectangular array");
 }
 
-TEST(ioJson,jsonData_array_err10) {
+TEST(ioJson,jsonData_array_err8) {
   std::string txt = "{  \"baz\":[1,2,\"-Inf\"], \"foo\" : [1, 2, 3, 4, 5, 6, [7]] }";
   test_exception(txt,"variable: foo, error: non-scalar array value");
 }
 
-TEST(ioJson,jsonData_array_err11) {
+TEST(ioJson,jsonData_array_err9) {
   std::string txt = "{\"a\":1,  \"baz\":[1,2,\"-Inf\"], \"b\":2.0, "
     "\"foo\" : [1, 2, 3, 4, 5, 6, [7]] }";
   test_exception(txt,"variable: foo, error: non-scalar array value");
@@ -385,7 +409,7 @@ TEST(ioJson,jsonData_err_array_of_obj) {
 TEST(ioJson,jsonData_parse_empty_obj) {
   std::string txt = "{}";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<std::string> var_names;
   jdata.names_r(var_names);
   EXPECT_EQ(0U,var_names.size());
@@ -398,7 +422,7 @@ TEST(ioJson,jsonData_parse_empty_obj) {
 TEST(ioJson,jsonData_parse_mult_objects) {
   std::string txt = "{ \"foo\": 1}{ \"bar\": 1 }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<std::string> var_names;
   jdata.names_i(var_names);
   EXPECT_EQ(1U,var_names.size());
@@ -409,7 +433,7 @@ TEST(ioJson,jsonData_parse_mult_objects) {
 TEST(ioJson,jsonData_NaN_str) {
   std::string txt = "{ \"foo\" : \"NaN\" }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> vals = jdata.vals_r("foo");
   EXPECT_TRUE(boost::math::isnan(vals[0]));
 }
@@ -417,7 +441,7 @@ TEST(ioJson,jsonData_NaN_str) {
 TEST(ioJson,jsonData_unsigned_Inf_str) {
   std::string txt = "{ \"foo\" : \"Inf\" }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
@@ -427,7 +451,7 @@ TEST(ioJson,jsonData_unsigned_Inf_str) {
 TEST(ioJson,jsonData_signed_neg_Inf_str) {
   std::string txt = "{ \"foo\" : \"-Inf\" }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
@@ -439,7 +463,7 @@ TEST(ioJson,jsonData_signed_neg_Inf_str) {
 TEST(ioJson,jsonData_NaN_bare) {
   std::string txt = "{ \"foo\" : NaN }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> vals = jdata.vals_r("foo");
   EXPECT_TRUE(boost::math::isnan(vals[0]));
 }
@@ -447,7 +471,7 @@ TEST(ioJson,jsonData_NaN_bare) {
 TEST(ioJson,jsonData_unsigned_Infinity_bare) {
   std::string txt = "{ \"foo\" : Infinity }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
@@ -457,7 +481,7 @@ TEST(ioJson,jsonData_unsigned_Infinity_bare) {
 TEST(ioJson,jsonData_pos_Infinity_bare) {
   std::string txt = "{ \"foo\" : Infinity }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
@@ -467,7 +491,7 @@ TEST(ioJson,jsonData_pos_Infinity_bare) {
 TEST(ioJson,jsonData_signed_neg_Infinity_bare) {
   std::string txt = "{ \"foo\" : -Infinity }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
@@ -477,7 +501,7 @@ TEST(ioJson,jsonData_signed_neg_Infinity_bare) {
 TEST(ioJson,jsonData_unsigned_Infinity_str) {
   std::string txt = "{ \"foo\" : \"Infinity\" }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
@@ -487,7 +511,7 @@ TEST(ioJson,jsonData_unsigned_Infinity_str) {
 TEST(ioJson,jsonData_pos_Infinity_str) {
   std::string txt = "{ \"foo\" : \"Infinity\" }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
@@ -497,7 +521,7 @@ TEST(ioJson,jsonData_pos_Infinity_str) {
 TEST(ioJson,jsonData_signed_neg_Infinity_str) {
   std::string txt = "{ \"foo\" : \"-Infinity\" }";
   std::stringstream in(txt);
-  stan::json::json_data jdata(in);
+  cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;

--- a/src/test/interface/io/json/json_parser_test.cpp
+++ b/src/test/interface/io/json/json_parser_test.cpp
@@ -1,0 +1,593 @@
+#include <gtest/gtest.h>
+
+#include <cmdstan/io/json//json_data.hpp>
+#include <cmdstan/io/json//json_data_handler.hpp>
+#include <cmdstan/io/json//json_error.hpp>
+#include <cmdstan/io/json//json_handler.hpp>
+#include <cmdstan/io/json//json_parser.hpp>
+
+class recording_handler : public stan::json::json_handler {
+public:
+  std::stringstream os_;
+  recording_handler() : json_handler(), os_() {
+  }
+  void start_text() {
+    os_ << "S:text";
+  }
+  void end_text() {
+    os_ << "E:text";
+  }
+  void start_array() {
+    os_ << "S:arr";
+  }
+  void end_array() {
+    os_ << "E:arr";
+  }
+  void start_object() {
+    os_ << "S:obj";
+  }
+  void end_object() {
+    os_ << "E:obj";
+  }
+  void null() {
+    os_ << "NULL:null";
+  }
+  void boolean(bool p) {
+    os_ << "BOOL:" << p;
+  }
+  void string(const std::string& s) {
+    os_ << "STR:\"" << s << "\"";
+  }
+  void key(const std::string& key) {
+    os_ << "KEY:\"" << key << "\"";
+  }
+  void number_double(double x) { 
+    os_ << "D(REAL):" << x;
+  }
+  void number_long(long n) { 
+    os_ << "L(INT):" << n;
+  }
+  void number_unsigned_long(unsigned long n) { 
+    os_ << "UL(INT):" << n;
+  }
+};
+
+bool hasEnding(std::string const &fullString, std::string const &ending) {
+  if (fullString.length() >= ending.length()) {
+    return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
+  } else {
+    return false;
+  }
+}
+
+void test_parser(const std::string& input,
+                 const std::string& expected_output) {
+  recording_handler handler;
+  std::stringstream s(input);
+  stan::json::parse(s, handler);
+  EXPECT_EQ(expected_output, handler.os_.str());
+}
+
+void test_exception(const std::string& input,
+                    const std::string& exception_text) {
+  try {
+    recording_handler handler;
+    std::stringstream s(input);
+    stan::json::parse(s, handler);
+  } catch (const std::exception& e) {
+    EXPECT_TRUE(hasEnding(e.what(), exception_text));
+    return;
+  }
+  FAIL();  // didn't throw an exception as expected.
+}
+
+
+TEST(ioJson,jsonParserA0) {
+  test_parser("[0]",
+              "S:text" "S:arr" "UL(INT):0" "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserA1) {
+  test_parser("[5]",
+              "S:text" "S:arr" "UL(INT):5" "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserA2) {
+  test_parser("[5,10]",
+              "S:text" "S:arr" "UL(INT):5" "UL(INT):10" "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserA3) {
+  test_parser("[]",
+              "S:text" "S:arr" "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserA4) {
+  std::stringstream textReport;
+  textReport << "S:text" << "S:arr" << "D(REAL):" 
+             << 0.100019
+             << "E:arr" << "E:text";
+  test_parser("[ 0.100019 ]",
+              textReport.str());
+}
+
+TEST(ioJson,jsonParserA5) {
+  std::stringstream textReport;
+  textReport << "S:text" << "S:arr" << "D(REAL):" 
+             << 0.10001900
+             << "E:arr" << "E:text";
+  test_parser("[ 0.10001900 ]",
+              textReport.str());
+}
+
+TEST(ioJson,jsonParserA6) {
+  std::stringstream textReport;
+  textReport << "S:text" << "S:arr" << "D(REAL):" 
+             << -0.10001900
+             << "E:arr" << "E:text";
+  test_parser("[ -0.10001900 ]",
+              textReport.str());
+}
+
+TEST(ioJson,jsonParserA7) {
+  test_parser("[ -1, -2, \"-inf\"]",
+              "S:text" "S:arr" "L(INT):-1" "L(INT):-2"  
+              "STR:\"-inf\"" "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserA8) {
+  test_parser("[ [ -1, -2 ],[ 1, 2 ] ]",
+              "S:text" "S:arr" 
+              "S:arr" "L(INT):-1" "L(INT):-2"  "E:arr"
+              "S:arr" "UL(INT):1" "UL(INT):2"  "E:arr"
+              "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserA9) {
+  test_parser("[ [ [1, 2 ],[ 3, 4 ] ],[ [5, 6 ],[ 7, 8 ] ] ]",
+              "S:text" "S:arr" "S:arr"
+              "S:arr" "UL(INT):1" "UL(INT):2"  "E:arr"
+              "S:arr" "UL(INT):3" "UL(INT):4"  "E:arr"
+              "E:arr" "S:arr"
+              "S:arr" "UL(INT):5" "UL(INT):6"  "E:arr"
+              "S:arr" "UL(INT):7" "UL(INT):8"  "E:arr"
+              "E:arr" "E:arr" "E:text");
+}
+
+
+TEST(ioJson,jsonParserO1) {
+  test_parser("{  \"foo\" : 1  }   ",
+              "S:text" "S:obj" "KEY:\"foo\"" "UL(INT):1" "E:obj" "E:text");
+}
+
+TEST(ioJson,jsonParserO11) {
+  test_parser("{  \"foo\" : { \"bar\": 1 } }   ",
+              "S:text" "S:obj" "KEY:\"foo\"" "S:obj" "KEY:\"bar\"" 
+              "UL(INT):1" "E:obj" "E:obj" "E:text");
+}
+
+TEST(ioJson,jsonParserO12) {
+  test_parser("{  \"foo\" : { \"bar\": 1, \"baz\": 2 } }   ",
+              "S:text" "S:obj" "KEY:\"foo\"" "S:obj" 
+              "KEY:\"bar\""  "UL(INT):1" 
+              "KEY:\"baz\""  "UL(INT):2" 
+              "E:obj" "E:obj" "E:text");
+}
+
+
+TEST(ioJson,jsonParserO13) {
+  test_parser("{  \"foo\" : { \"bar\": { \"baz\": [ 1, 2]  } } }  ",
+              "S:text" "S:obj" "KEY:\"foo\"" "S:obj" 
+              "KEY:\"bar\""  "S:obj" "KEY:\"baz\""  
+              "S:arr" "UL(INT):1" "UL(INT):2" "E:arr" 
+              "E:obj" "E:obj" "E:obj" "E:text");
+}
+
+TEST(ioJson,jsonParserO14) {
+  test_parser("{  \"foo\" : [ { \"bar\": { \"baz\": [ 1, 2]  } }, -3, -4.44 ] }  ",
+              "S:text" "S:obj" "KEY:\"foo\"" "S:arr" "S:obj" 
+              "KEY:\"bar\""  "S:obj" "KEY:\"baz\""  
+              "S:arr" "UL(INT):1" "UL(INT):2" "E:arr" "E:obj" "E:obj" 
+              "L(INT):-3" "D(REAL):-4.44" "E:arr" "E:obj" "E:text");
+}
+
+TEST(ioJson,jsonParserO2) {
+  test_parser("{  \"foo\"  : 1 ,  \n   \"bar\" : 2 }",
+              "S:text" "S:obj" "KEY:\"foo\"" "UL(INT):1" 
+              "KEY:\"bar\"" "UL(INT):2" "E:obj" "E:text");
+}
+
+TEST(ioJson,jsonParserO3) {
+  test_parser("{\"foo\":1,\"bar\":2,\"baz\":[2]}",
+              "S:text" "S:obj" "KEY:\"foo\"" "UL(INT):1"
+              "KEY:\"bar\"" "UL(INT):2" 
+              "KEY:\"baz\"" "S:arr" "UL(INT):2" "E:arr"
+              "E:obj" "E:text"
+              );
+}
+
+TEST(ioJson,jsonParserO4) {
+  std::stringstream textReport;
+  textReport << "S:text" << "S:obj" 
+             << "KEY:\"foo\"" << "UL(INT):1"
+             << "KEY:\"baz\"" 
+             << "S:arr" << "UL(INT):2" << "UL(INT):3" << "D(REAL):" 
+             << 4.01001 
+             << "E:arr" 
+             << "E:obj" << "E:text";
+  test_parser("{ \"foo\" : 1, \n \"baz\" : [ 2, 3, 4.01001 ] };",
+              textReport.str());
+}
+
+TEST(ioJson,jsonParserO5) {
+  std::stringstream textReport;
+  textReport << "S:text" << "S:obj" << "KEY:\"foo\"" << "D(REAL):" 
+             << -0.10001900
+             << "E:obj" << "E:text";
+  test_parser("{ \"foo\": -0.10001900 }",
+              textReport.str());
+}
+
+TEST(ioJson,jsonParserO6) {
+  std::stringstream textReport;
+  textReport << "S:text" << "S:obj" << "KEY:\"foo\"" 
+             << "D(REAL):" 
+             << -1.0100e09
+             << "E:obj" << "E:text";
+  test_parser("{ \"foo\": -1.0100e09 }",
+              textReport.str());
+}
+
+TEST(ioJson,jsonParserO7) {
+  std::stringstream textReport;
+  textReport << "S:text" << "S:obj" << "KEY:\"foo\"" 
+             << "D(REAL):" 
+             << -1.0100e09
+             << "E:obj" << "E:text";
+  test_parser("{ \"foo\": -1.0100e09 }",
+              textReport.str());
+}
+
+
+TEST(ioJson,jsonParserStr0) {
+  test_parser("[ \"foo\" ]",
+              "S:text" "S:arr" "STR:\"foo\"" "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserStr1) {
+  test_parser("[ \"\\nfoo\" ]",
+              "S:text" "S:arr" "STR:\"\nfoo\"" "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserStr2) {
+  test_parser("[ \"\\nfoo\\bbar\" ]",
+              "S:text" "S:arr" "STR:\"\nfoo\bbar\"" "E:arr" "E:text");
+}
+
+
+TEST(ioJson,jsonParserStr3) {
+  test_parser("[ \"\\bfoo\\nbar\" ]",
+              "S:text" "S:arr" "STR:\"\bfoo\nbar\"" "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserStr4) {
+  test_parser("[ \"\\\"foo\\/bar\" ]",
+              "S:text" "S:arr" "STR:\"\"foo/bar\"" "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserStr5) {
+  test_parser("[ \"\\\"foo\\\\bar\" ]",
+              "S:text" "S:arr" "STR:\"\"foo\\bar\"" "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserStr6) {
+  test_parser("[ \"\\tfoo\\tbar\" ]",
+              "S:text" "S:arr" "STR:\"\tfoo\tbar\"" "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserStr7) {
+  test_parser("[ \"\\nfoo\\nbar\\n\" ]",
+              "S:text" "S:arr" "STR:\"\nfoo\nbar\n\"" "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserStr8) {
+  test_parser("[ \"\\nfoo\\nbar\\\"\" ]",
+              "S:text" "S:arr" "STR:\"\nfoo\nbar\"\"" "E:arr" "E:text");
+}
+
+
+TEST(ioJson,jsonParserStr9) {
+  test_parser("[ \"foo\\nbar\\\"\" , \"foo\\nbar\\\"\"  ]",
+              "S:text" "S:arr" 
+              "STR:\"foo\nbar\"\"" "STR:\"foo\nbar\"\"" 
+              "E:arr" "E:text");
+}
+
+TEST(ioJson,jsonParserStr10) {
+  test_parser("[ \"\\u0069\" ]",
+              "S:text" "S:arr" "STR:\"i\"" "E:arr" "E:text");
+}
+
+// surrogate pair for G clef character from extended multilingual plane:
+// specified here using hex values for non-ASCII UTF-8 bytes 
+TEST(ioJson,jsonParserStr11) {
+  test_parser("[ \"\\uD834\\uDD1E\" ]",
+              "S:text" "S:arr" "STR:\"\xf0\x9D\x84\x9E\"" "E:arr" "E:text");
+}
+
+
+// string w/ two non-ascii Latin 1 chars
+TEST(ioJson,jsonParserStr12) {
+  test_parser("[ \"D\\u00E9j\\u00E0 vu\" ]",
+              "S:text" "S:arr" "STR:\"D\xc3\xa9j\xc3\xa0 vu\"" "E:arr" "E:text");
+}
+
+// same string w/ non-ASCII chars not \u escaped (specified as hex byte values)
+TEST(ioJson,jsonParserStr13) {
+  test_parser("[ \"D\xc3\xa9j\xc3\xa0 vu\" ]",
+              "S:text" "S:arr" "STR:\"D\xc3\xa9j\xc3\xa0 vu\"" "E:arr" "E:text");
+}
+
+
+// surrogate pair boundary conditions
+TEST(ioJson,jsonParserStr14) {
+  test_parser("[ \"\\uD800\\uDC00\" ]",
+              "S:text" "S:arr" "STR:\"\xf0\x90\x80\x80\"" "E:arr" "E:text");
+}
+
+// surrogate pair boundary conditions
+TEST(ioJson,jsonParserStr15) {
+  test_parser("[ \"\\uD800\\uDFFF\" ]",
+              "S:text" "S:arr" "STR:\"\xf0\x90\x8F\xBF\"" "E:arr" "E:text");
+}
+
+// surrogate pair boundary conditions
+TEST(ioJson,jsonParserStr16) {
+  test_parser("[ \"\\uDBFF\\uDC00\" ]",
+              "S:text" "S:arr" "STR:\"\xf4\x8f\xb0\x80\"" "E:arr" "E:text");
+}
+
+// surrogate pair boundary conditions
+TEST(ioJson,jsonParserStr17) {
+  test_parser("[ \"a\\uE000\" ]",
+              "S:text" "S:arr" "STR:\"a\xEE\x80\x80\"" "E:arr" "E:text");
+}
+
+
+
+
+TEST(ioJson,jsonParserErr01) {
+  test_exception(" \n \n   5    ",
+                 "expecting start of object ({) or array ([)\n");
+}
+
+TEST(ioJson,jsonParserErr02) {
+  test_exception("[ .5 ]",
+                 "illegal value, expecting object, array, number, string, or literal true/false/null\n");
+}
+
+TEST(ioJson,jsonParserErr02a) {
+  test_exception("[ 0",
+                 "unexpected end of stream\n");
+}
+
+TEST(ioJson,jsonParserErr02b) {
+  test_exception("[ 0.",
+                 "unexpected end of stream\n");
+}
+
+
+TEST(ioJson,jsonParserErr02c) {
+  test_exception("[ 99.9",
+                 "unexpected end of stream\n");
+}
+
+
+TEST(ioJson,jsonParserErr03) {
+  test_exception("[ 000.005 ]",
+                 "zero padded numbers not allowed\n");
+}
+
+TEST(ioJson,jsonParserErr04) {
+  test_exception("[ 1. ]",
+                 "expected digit after decimal\n");
+}
+
+TEST(ioJson,jsonParserErr05) {
+  test_exception("[ 1.009e ]",
+                 "expected digit after e/E\n");
+}
+
+
+/*
+TEST(ioJson,jsonParserErr06) {
+  test_exception("[ \"\\uFFFF\" ]",
+                 "unicode escapes not supported\n");
+}
+*/
+
+TEST(ioJson,jsonParserErr06a) {
+  test_exception("[ \"\\uDD1Eabd \" ]",
+                 "illegal unicode values, found low-surrogate, missing high-surrogate\n");
+}
+
+TEST(ioJson,jsonParserErr06b) {
+  test_exception("[ \"\\uD834abc\" ]",
+                 "illegal unicode values, found high-surrogate, expecting low-surrogate\n");
+}
+
+
+// surrogate pair boundary conditions
+TEST(ioJson,jsonParserErr06c) {
+  test_exception("[ \"\\uDC00\\uDFFFF\" ]",
+              "illegal unicode values, found low-surrogate, missing high-surrogate\n");
+}
+
+
+// surrogate pair boundary conditions
+TEST(ioJson,jsonParserErr06d) {
+  test_exception("[ \"\\uE000\\uDFFF\" ]",
+                 "illegal unicode values, found low-surrogate, missing high-surrogate\n");
+}
+
+TEST(ioJson,jsonParserErr06e) {
+  test_exception("[ \"\\uD834",
+                 "unexpected end of stream\n");
+}
+
+TEST(ioJson,jsonParserErr06f) {
+  test_exception("[ \"\\uD8",
+                 "unexpected end of stream\n");
+}
+
+TEST(ioJson,jsonParserErr06g) {
+  test_exception("[ \"\\uE000\\uD",
+                 "unexpected end of stream\n");
+}
+
+
+TEST(ioJson,jsonParserErr07) {
+  test_exception("[ \"\\aFFFF\" ]",
+                 "expecting legal escape\n");
+}
+
+TEST(ioJson,jsonParserErr08) {
+  std::stringstream ss;
+  char c = 11;
+  ss << "[ \"" << c << "\" ]";
+  test_exception(ss.str(),
+                 "found control character, char values less than U+0020 must be \\u escaped\n");
+}
+
+TEST(ioJson,jsonParserErr09) {
+  test_exception("[ t ]",
+                 "expecting rest of literal: rue\n");
+}
+
+TEST(ioJson,jsonParserErr10) {
+  test_exception("[ f ]",
+                 "expecting rest of literal: alse\n");
+}
+
+TEST(ioJson,jsonParserErr11) {
+  test_exception("[ n ]",
+                 "expecting rest of literal: ull\n");
+}
+
+TEST(ioJson,jsonParserErr12) {
+  test_exception("[5}",
+                 "in array, expecting ] or ,\n");
+}
+
+TEST(ioJson,jsonParserErr12a) {
+  test_exception("[ a ]",
+                 "illegal value, expecting object, array, number, string, or literal true/false/null\n");
+}
+
+TEST(ioJson,jsonParserErr12b) {
+  test_exception("[ \"a\", a ]",
+                 "illegal value, expecting object, array, number, string, or literal true/false/null\n");
+}
+
+TEST(ioJson,jsonParserErr12c) {
+  test_exception("[ \"a\", ",
+                 "unexpected end of stream\n");
+}
+
+
+TEST(ioJson,jsonParserErr12d) {
+  test_exception("{ \"a\" : 5 ] }",
+                 "expecting end of object } or separator ,\n");
+}
+
+TEST(ioJson,jsonParserErr12e) {
+  test_exception("{ \"a\" : [ 5 ] ] }",
+                 "expecting end of object } or separator ,\n");
+}
+
+TEST(ioJson,jsonParserErr13) {
+  test_exception("{ hello }",
+                 "expecting member key or end of object marker (})\n");
+}
+
+
+TEST(ioJson,jsonParserErr14) {
+  test_exception("{ \"foo\": -1.0100e09 , }",
+              "expecting member key or end of object marker (})\n");
+}
+
+
+TEST(ioJson,jsonParserErr14a) {
+  test_exception("{ { \"foo\": -1.0100e09 , }",
+              "expecting member key or end of object marker (})\n");
+}
+
+
+TEST(ioJson,jsonParserErr14b) {
+  test_exception("{ \"bar\" : { \"foo\": -1.0100e09 , }",
+              "expecting member key or end of object marker (})\n");
+}
+
+
+TEST(ioJson,jsonParserErr14c) {
+  test_exception("{ \"bar\" : [ \"foo\": -1.0100e09 , }",
+                 "in array, expecting ] or ,\n");
+}
+
+TEST(ioJson,jsonParseErr14d) {
+  test_exception("{  \"foo\" : [ { \"bar\": { \"baz\": [ 1, 2]  } }, -3, -4.44  }  ",
+                 "in array, expecting ] or ,\n");
+}
+
+TEST(ioJson,jsonParseErr14e) {
+  test_exception("{  \"foo\" : [ { \"bar\": { \"baz\": [ 1, 2]  } }, -3, -4.44 } } } ] }  ",
+                 "in array, expecting ] or ,\n");
+}
+
+TEST(ioJson,jsonParserErr14f) {
+  test_exception("{ \"foo\": -1.0100e09 , ",
+              "unexpected end of stream\n");
+}
+
+
+TEST(ioJson,jsonParserErr15) {
+  test_exception("{ \"5\" 5 }",
+                 "expecting key-value separator :\n");
+}
+
+TEST(ioJson,jsonParserErr16) {
+  test_exception("{ \"5\" :  5  \"6\" : 6 }",
+                 "expecting end of object } or separator ,\n");
+}
+
+TEST(ioJson,jsonParserErr17) {
+  test_exception("{ \"5\" : ",
+                 "unexpected end of stream\n");
+}
+
+TEST(ioJson,jsonParserErr18) {
+  test_exception("[ -1, -2, \"-inf\", ]",
+                 "in array, expecting value\n");
+}
+
+
+TEST(ioJson,jsonParserErr19a) {
+  test_exception("[ 1111111111111111111111111111 ]",
+                 "number exceeds integer range\n");
+}
+
+TEST(ioJson,jsonParserErr19b) {
+  test_exception("[ -1111111111111111111111111111 ]",
+                 "number exceeds integer range\n");
+}
+
+
+TEST(ioJson,jsonParserErr19c) {
+  test_exception("[ 9.9999999e-1000000000000 ]",
+                 "number exceeds double range\n");
+}
+
+TEST(ioJson,jsonParserErr19d) {
+  test_exception("[ 9.19191919191919e1000000000000 ]",
+                 "number exceeds double range\n");
+}

--- a/src/test/interface/io/json/json_parser_test.cpp
+++ b/src/test/interface/io/json/json_parser_test.cpp
@@ -6,7 +6,7 @@
 #include <cmdstan/io/json//json_handler.hpp>
 #include <cmdstan/io/json//json_parser.hpp>
 
-class recording_handler : public stan::json::json_handler {
+class recording_handler : public cmdstan::json::json_handler {
 public:
   std::stringstream os_;
   recording_handler() : json_handler(), os_() {
@@ -64,7 +64,7 @@ void test_parser(const std::string& input,
                  const std::string& expected_output) {
   recording_handler handler;
   std::stringstream s(input);
-  stan::json::parse(s, handler);
+  cmdstan::json::parse(s, handler);
   EXPECT_EQ(expected_output, handler.os_.str());
 }
 
@@ -73,7 +73,7 @@ void test_exception(const std::string& input,
   try {
     recording_handler handler;
     std::stringstream s(input);
-    stan::json::parse(s, handler);
+    cmdstan::json::parse(s, handler);
   } catch (const std::exception& e) {
     EXPECT_TRUE(hasEnding(e.what(), exception_text));
     return;


### PR DESCRIPTION
#### Summary:

This PR addresses parts of #719 : 

- creates the directory `cmdstan/src/cmdstan/io/json` and moves all files under `stan/src/stan/io/json` to this created folder

- moves the corresponding tests to the add corresponding unit tests to `src/test/interface/io/json`

- updates cmdstan/src/command.hpp accordingly

After this gets merged, we can add the `RapidJSON` parser lib and replace the existing parser.

#### Intended Effect:

Move JSON IO code to Cmdstan as part of moving to the RapidJSON parser.

#### How to Verify:

Run `python runCmdStanTests.py src/test/interface/io/json/`

#### Side Effects:

/

#### Documentation:

/

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Rok Češnovar, University of Ljubljana