### PR TITLE
Substitute backslashes with slashes for stanc arguments

### DIFF
--- a/make/program
+++ b/make/program
@@ -30,7 +30,7 @@ endif
 %.hpp : %.stan bin/stanc$(EXE)
 	@echo ''
 	@echo '--- Translating Stan model to C++ code ---'
-	$(WINE) bin/stanc$(EXE) $(STANCFLAGS) --o=$@ $<
+	$(WINE) bin/stanc$(EXE) $(STANCFLAGS) --o=$(subst  \,/,$@) $(subst  \,/,$<)
 
 
 .PRECIOUS: %.hpp


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes #720 by replacing \ with / in the path arguments to stanc. It will replace `\\` with `//` but that is not an issue. I am not sure how relevant the issue is given that Stanc3 is really really close and the issue might be solved there, but its still worth fixing I guess. Its better to have this fixed on the interface level anyways I think.

EDIT: Although a fix on the Stan compiler level is a solution for all interface so idk

#### Intended Effect:

Fix the backslash bug for Windows.

#### How to Verify:

Try to compile the bernoulli example on Windows with absolute paths and backslashes or double backslashes in the path to the .stan file.

#### Side Effects:

There should not be any side effects. A minor one is that we try a substitution even on linux and mac where \ or `\\` ar not valid path characters. If this is a problem I can add an if to only do this on Windows.

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar, University of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
