### PR TITLE
Make zero a valid chain id argument value

### DIFF
--- a/src/cmdstan/arguments/arg_id.hpp
+++ b/src/cmdstan/arguments/arg_id.hpp
@@ -10,7 +10,7 @@ namespace cmdstan {
     arg_id(): int_argument() {
       _name = "id";
       _description = "Unique process identifier";
-      _validity = "id > 0";
+      _validity = "id >= 0";
       _default = "0";
       _default_value = 0;
       _constrained = true;
@@ -19,7 +19,7 @@ namespace cmdstan {
       _value = _default_value;
     }
 
-    bool is_valid(int value) { return value > 0; }
+    bool is_valid(int value) { return value >= 0; }
   };
 
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes #531 

The default chain id is 0, but a user specified id must be larger than 0. We now make a user specified valid if (id >= 0). We could make the default id be 1, but my guess is this could break any scripts that rely on the default chain being 0.

This 
#### Intended Effect:

See summary.

#### How to Verify:

Running with id = 0 will not throw an error. Running a model executable with id=-1 should throw with the following message:

```
-1 is not a valid value for "id"
  Valid values: id >= 0
Failed to parse arguments, terminating Stan
```

#### Side Effects:
/
#### Documentation:
/
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar, University of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
