### PR TITLE
Manual cleanup: cmdstan does not support = for rdump

### DIFF
--- a/src/docs/cmdstan-guide/dump-format.tex
+++ b/src/docs/cmdstan-guide/dump-format.tex
@@ -30,8 +30,7 @@ valid dump file defining a single scalar variable \code{y} with value
 %
 \begin{quote}
 \begin{Verbatim}
-y <- 
-17.2
+y <- 17.2
 \end{Verbatim}
 \end{quote}
 %
@@ -255,8 +254,7 @@ The following dump file declares an integer value for \code{y}.
 %
 \begin{quote}
 \begin{Verbatim} 
-y <- 
-2
+y <- 2
 \end{Verbatim}
 \end{quote}
 % 
@@ -270,8 +268,7 @@ explicit, is equivalent to the above.
 %
 \begin{quote}
 \begin{Verbatim} 
-y <- 
-2L
+y <- 2L
 \end{Verbatim}
 \end{quote}
 
@@ -279,8 +276,7 @@ The following dump file provides a real value for \code{y}.
 %
 \begin{quote}
 \begin{Verbatim}
-y <-
-2.0
+y <- 2.0
 \end{Verbatim}
 \end{quote}
 %
@@ -329,8 +325,7 @@ For instance, the following definition is legal in a dump file.
 %
 \begin{quote}
 \begin{Verbatim}
-"y" <-
-c(1,2,3)
+"y" <- c(1,2,3)
 \end{Verbatim}
 \end{quote}
 
@@ -387,7 +382,7 @@ by the following (mildly templated) Backus-Naur form grammar.
 \begin{verbatim}
  definitions ::= definition+
 
- definition ::= name ("<-" | '=') value optional_semicolon
+ definition ::= name <- value optional_semicolon
 
  name ::= char* 
         | ''' char* ''' 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Fixes #548 by removing "=" from 

`definition ::= name ("<-" | '=') value optional_semicolon` 

Also cleans up unnecessary newlines from verbatim text outside of the Line Breaks section.

#### Intended Effect:
/
#### How to Verify:
/
#### Side Effects:
/
#### Documentation:
/
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
