### PR TITLE
Get Linux and Mac working to download stanc3

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -1,29 +1,18 @@
 ################################################################################
-# libstanc build rules
+# stanc build rules
 
-STANC_TEMPLATE_INSTANTIATION_CPP := $(shell find $(STAN)src/stan/lang -type f -name '*_inst.cpp') $(shell find $(STAN)src/stan/lang -type f -name '*_def.cpp')
-STANC_TEMPLATE_INSTANTIATION := $(STANC_TEMPLATE_INSTANTIATION_CPP:$(STAN)src/stan/%.cpp=bin/cmdstan/%.o)
-
-bin/cmdstan/libstanc.a : $(STANC_TEMPLATE_INSTANTIATION)
-	@mkdir -p $(dir $@)
-	$(AR) -rs $@ $^
-
-$(STANC_TEMPLATE_INSTANTIATION) : O = $(O_STANC)
-$(STANC_TEMPLATE_INSTANTIATION) : bin/cmdstan/%.o : $(STAN)src/stan/%.cpp
-	@mkdir -p $(dir $@)
-	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
-
-bin/stanc$(EXE) : O = $(O_STANC)
-bin/stanc$(EXE) : CPPFLAGS_MPI =
-bin/stanc$(EXE) : LDFLAGS_MPI =
-bin/stanc$(EXE) : LDLIBS_MPI =
-bin/stanc$(EXE) : bin/cmdstan/libstanc.a
-bin/stanc$(EXE) : bin/cmdstan/stanc.o
-	@mkdir -p $(dir $@)
-	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
-
-$(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP)) : DEPTARGETS = -MT $(patsubst stan/src/stan/lang/%.d,bin/cmdstan/lang/%.o,$@) -MT $@
-
-ifneq ($(filter bin/stanc$(EXE) bin/stan/libstanc.a $(STANC_TEMPLATE_INSTANTIATION),$(MAKECMDGOALS)),)
--include $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP))
+ifeq ($(OS),Windows_NT)
+  OS_TAG := windows
+else ifeq ($(OS),Darwin)
+  OS_TAG := mac
+else ifeq ($(OS),Linux)
+  OS_TAG := linux
+else
+  $(error Can't detect OS properly. This will impede automatically downloading the correct stanc. Please visit https://github.com/stan-dev/stanc3/releases and download a stanc binary for your OS and place it in ./bin/stanc)
 endif
+
+
+bin/stanc$(EXE) :
+	@mkdir -p $(dir $@)
+	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc
+	chmod +x bin/stanc

--- a/make/stanc
+++ b/make/stanc
@@ -26,3 +26,23 @@ bin/stanc$(EXE) : $(shell find $(STANC3)/src/ -type f -name '*.ml*') $(STANC#)
 	cd $(STANC3) && echo "--- Rebuilding stanc ---\n" && dune build @install
 	cp $(STANC3)/_build/default/src/stanc/stanc.exe $@
 endif
+
+# libstanc build rules
+# just used by cmdstan tests and should soon be replaced with tests based on stanc$(EXE)
+STANC_TEMPLATE_INSTANTIATION_CPP := $(shell find $(STAN)src/stan/lang -type f -name '*_inst.cpp') $(shell find $(STAN)src/stan/lang -type f -name '*_def.cpp')
+STANC_TEMPLATE_INSTANTIATION := $(STANC_TEMPLATE_INSTANTIATION_CPP:$(STAN)src/stan/%.cpp=bin/cmdstan/%.o)
+
+bin/cmdstan/libstanc.a : $(STANC_TEMPLATE_INSTANTIATION)
+	@mkdir -p $(dir $@)
+	$(AR) -rs $@ $^
+
+$(STANC_TEMPLATE_INSTANTIATION) : O = $(O_STANC)
+$(STANC_TEMPLATE_INSTANTIATION) : bin/cmdstan/%.o : $(STAN)src/stan/%.cpp
+	@mkdir -p $(dir $@)
+	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
+
+$(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP)) : DEPTARGETS = -MT $(patsubst stan/src/stan/lang/%.d,bin/cmdstan/lang/%.o,$@) -MT $@
+
+ifneq ($(filter bin/stanc$(EXE) bin/stan/libstanc.a $(STANC_TEMPLATE_INSTANTIATION),$(MAKECMDGOALS)),)
+-include $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP))
+endif

--- a/make/stanc
+++ b/make/stanc
@@ -12,7 +12,13 @@ else
 endif
 
 
+ifeq ($(STANC3),)
 bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
 	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc
 	chmod +x bin/stanc
+else
+bin/stanc$(EXE) : $(shell find $(STANC3)/src/ -type f -name '*.ml*') $(STANC#)
+	cd $(STANC3) && echo "--- Rebuilding stanc ---\n" && dune build @install
+	cp $(STANC3)/_build/default/src/stanc/stanc.exe $@
+endif

--- a/makefile
+++ b/makefile
@@ -39,11 +39,6 @@ include make/program
 include make/tests
 include make/command
 
-ifneq ($(filter-out clean clean-% print-% help help-% manual stan-update/% stan-update stan-pr/%,$(MAKECMDGOALS)),)
--include $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP))
--include src/cmdstan/stanc.d
-endif
-
 CMDSTAN_VERSION := 2.20.0
 
 .PHONY: help
@@ -55,7 +50,7 @@ help:
 	@echo '    > make build'
 	@echo ''
 	@echo '    This target will:'
-	@echo '    1. Build the Stan compiler bin/stanc$(EXE).'
+	@echo '    1. Download the Stan compiler bin/stanc$(EXE).'
 	@echo '    2. Build the print utility bin/print$(EXE) (deprecated; will be removed in v3.0)'
 	@echo '    3. Build the stansummary utility bin/stansummary$(EXE)'
 	@echo '    4. Build the diagnose utility bin/diagnose$(EXE)'

--- a/makefile
+++ b/makefile
@@ -39,6 +39,11 @@ include make/program
 include make/tests
 include make/command
 
+ifneq ($(filter-out clean clean-% print-% help help-% manual stan-update/% stan-update stan-pr/%,$(MAKECMDGOALS)),)
+-include $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP))
+-include src/cmdstan/stanc.d
+endif
+
 CMDSTAN_VERSION := 2.20.0
 
 .PHONY: help


### PR DESCRIPTION
This is a PR to switch over CmdStan to stanc3. We discussed a few strategies in [the meeting last week](https://discourse.mc-stan.org/t/stan-general-meeting-september-19-2019-11am-edt/10959/2)

It seemed like the option everyone favored (including a bunch of CmdStan users and devs) was to switch it over all at once and basically be on call for the next month until the release with bugfixes to develop, and after that as well. CmdStan users will be able to help us iron out any remaining issues before being integrated into RStan for 2.21 a few months later.

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
