### PR TITLE
Replace backslashes with slashes in make/program

### DIFF
--- a/make/program
+++ b/make/program
@@ -1,5 +1,5 @@
 ##
-# Models (to be passed through stanc)
+#Models(to be passed through stanc)
 ##
 CMDSTAN_MAIN ?= src/cmdstan/main.cpp
 CMDSTAN_MAIN_O = $(patsubst %.cpp,%.o,$(CMDSTAN_MAIN))
@@ -7,7 +7,7 @@ CMDSTAN_MAIN_O = $(patsubst %.cpp,%.o,$(CMDSTAN_MAIN))
 STAN_TARGETS = $(patsubst %.stan,%$(EXE),$(wildcard $(patsubst %$(EXE),%.stan,$(MAKECMDGOALS))))
 
 ##
-# Precompiled model header
+#Precompiled model header
 ##
 
 $(STAN)src/stan/model/model_header.d : $(STAN)src/stan/model/model_header.hpp

--- a/make/program
+++ b/make/program
@@ -38,8 +38,7 @@ endif
 	@echo ''
 	@echo '--- Compiling, linking C++ code ---'
 	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)
-    $(LINK.cpp) $(subst \,/,$*).o $(CMDSTAN_MAIN_O) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(subst \,/,$(OUTPUT_OPTION))
-
+	$(LINK.cpp) $(subst \,/,$*.o) $(CMDSTAN_MAIN_O) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(subst \,/,$(OUTPUT_OPTION))
 
 ##
 # Dependencies file

--- a/make/program
+++ b/make/program
@@ -1,5 +1,5 @@
 ##
-#Models(to be passed through stanc)
+# Models (to be passed through stanc)
 ##
 CMDSTAN_MAIN ?= src/cmdstan/main.cpp
 CMDSTAN_MAIN_O = $(patsubst %.cpp,%.o,$(CMDSTAN_MAIN))
@@ -7,7 +7,7 @@ CMDSTAN_MAIN_O = $(patsubst %.cpp,%.o,$(CMDSTAN_MAIN))
 STAN_TARGETS = $(patsubst %.stan,%$(EXE),$(wildcard $(patsubst %$(EXE),%.stan,$(MAKECMDGOALS))))
 
 ##
-#Precompiled model header
+# Precompiled model header
 ##
 
 $(STAN)src/stan/model/model_header.d : $(STAN)src/stan/model/model_header.hpp

--- a/make/program
+++ b/make/program
@@ -37,8 +37,8 @@ endif
 %$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS)
 	@echo ''
 	@echo '--- Compiling, linking C++ code ---'
-	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $*.o $<
-	$(LINK.cpp) $*.o $(CMDSTAN_MAIN_O) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(OUTPUT_OPTION)
+	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)
+    $(LINK.cpp) $(subst \,/,$*).o $(CMDSTAN_MAIN_O) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(subst \,/,$(OUTPUT_OPTION))
 
 
 ##


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This PR adds backslashes with slashes in the compile and link call. This error came up in https://github.com/stan-dev/cmdstan/pull/737#issuecomment-535863714

This issue only comes up if other compiler flags are set in make/local, for example with STAN_OPENCL.

#### Intended Effect:
Fix windows compiling with backslashes.

#### How to Verify:
/
#### Side Effects:
/
#### Documentation:
/
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar, Tadej Ciglarič

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
