### PR TITLE
Use mingw32-make instead of make for tests on Windows

### DIFF
--- a/runCmdStanTests.py
+++ b/runCmdStanTests.py
@@ -54,6 +54,8 @@ def mungeName(name):
 
 def doCommand(command):
     print("------------------------------------------------------------")
+    if command.startswith("make "):
+      command = command.replace("make ", "mingw32-make ")
     print("%s" % command)
     p1 = subprocess.Popen(command,shell=True)
     p1.wait()

--- a/runCmdStanTests.py
+++ b/runCmdStanTests.py
@@ -54,7 +54,7 @@ def mungeName(name):
 
 def doCommand(command):
     print("------------------------------------------------------------")
-    if command.startswith("make "):
+    if isWin() and command.startswith("make "):
       command = command.replace("make ", "mingw32-make ")
     print("%s" % command)
     p1 = subprocess.Popen(command,shell=True)


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

In order to build TBB for tests, we should use mingw32-make not make on Windows. 

#### Intended Effect:

Fix windows tests.

#### How to Verify:
Run Jenkins tests or run runCmdStanTests.py locally on Windows.

#### Side Effects:

/

#### Documentation:
/
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
