### PR TITLE
copy tbb.dll in case this is needed on Windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,11 +15,9 @@ def runTests(String prefix = "") {
 }
 
 def runWinTests(String prefix = "") {
-    withEnv(['PATH+TBB=./stan/lib/stan_math/lib/tbb']) {
-       """ mingw32-make -j${env.PARALLEL} build
-         ${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface
-       """
-    }
+    """ mingw32-make -j${env.PARALLEL} build
+     ${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface
+    """
 }
 
 def deleteDirWin() {

--- a/make/program
+++ b/make/program
@@ -40,7 +40,7 @@ endif
 	$(LINK.cpp) $(subst \,/,$*.o) $(CMDSTAN_MAIN_O) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(subst \,/,$(OUTPUT_OPTION))
 ifeq ($(OS),Windows_NT)
 ifneq ($(notdir $(shell where tbb.dll)),tbb.dll)
-	@echo 'WARNING: Intel TBB is not in PATH. Consider calling '
+	@echo 'Intel TBB is not in PATH. Consider calling '
 	@echo 'make install-tbb'
 	@echo 'to avoid copying Intel TBB library files.'
 	cp -v $(TBB_TARGETS) $(@D)

--- a/make/program
+++ b/make/program
@@ -32,6 +32,7 @@ endif
 	@echo '--- Translating Stan model to C++ code ---'
 	$(WINE) bin/stanc$(EXE) $(STANCFLAGS) --o=$(subst  \,/,$@) $(subst  \,/,$<)
 
+TBB_FOUND=$(notdir $(shell where tbb2.dll))
 
 .PRECIOUS: %.hpp
 %$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
@@ -39,6 +40,14 @@ endif
 	@echo '--- Compiling, linking C++ code ---'
 	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)
 	$(LINK.cpp) $(subst \,/,$*.o) $(CMDSTAN_MAIN_O) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(subst \,/,$(OUTPUT_OPTION))
+ifeq ($(OS),Windows_NT)
+ifneq ($(notdir $(shell where tbb.dll)),tbb.dll)
+	@echo 'WARNING: Intel TBB is not in PATH. Consider calling '
+	@echo 'make install-tbb'
+	@echo 'to avoid copying Intel TBB library files.'
+	cp -v $(TBB_TARGETS) $(@D)
+endif
+endif
 
 ##
 # Dependencies file

--- a/make/program
+++ b/make/program
@@ -32,8 +32,6 @@ endif
 	@echo '--- Translating Stan model to C++ code ---'
 	$(WINE) bin/stanc$(EXE) $(STANCFLAGS) --o=$(subst  \,/,$@) $(subst  \,/,$<)
 
-TBB_FOUND=$(notdir $(shell where tbb2.dll))
-
 .PRECIOUS: %.hpp
 %$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
 	@echo ''

--- a/make/tests
+++ b/make/tests
@@ -9,7 +9,7 @@ test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(LI
 	$(LINK.cpp) $(filter-out src/test/test-models/% src/%.csv bin/% test/%.hpp %.hpp-test,$^) $(LDLIBS) $(OUTPUT_OPTION)
 ifeq ($(OS),Windows_NT)
 ifneq ($(notdir $(shell where tbb.dll)),tbb.dll)
-	@echo 'WARNING: Intel TBB is not in PATH. Consider calling '
+	@echo 'Intel TBB is not in PATH. Consider calling '
 	@echo 'make install-tbb'
 	@echo 'to avoid copying Intel TBB library files.'
 	cp -v $(TBB_TARGETS) $(@D)

--- a/make/tests
+++ b/make/tests
@@ -7,6 +7,14 @@ test/%$(EXE) : CPPFLAGS += $(CPPFLAGS_GTEST)
 test/%$(EXE) : INC += $(INC_GTEST) -I $(RAPIDJSON)
 test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
 	$(LINK.cpp) $(filter-out src/test/test-models/% src/%.csv bin/% test/%.hpp %.hpp-test,$^) $(LDLIBS) $(OUTPUT_OPTION)
+ifeq ($(OS),Windows_NT)
+ifneq ($(notdir $(shell where tbb.dll)),tbb.dll)
+	@echo 'WARNING: Intel TBB is not in PATH. Consider calling '
+	@echo 'make install-tbb'
+	@echo 'to avoid copying Intel TBB library files.'
+	cp -v $(TBB_TARGETS) $(@D)
+endif
+endif
 
 test/%.o : src/test/%.cpp
 	@mkdir -p $(dir $@)


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run tests: `./runCmdStanTests.py src/test` (done on a Windows virtual machine...and all is OK)
- [X] Declare copyright holder and open-source license: see below

#### Summary:

This change ensures that on Windows the tbb.dll is copied into the model executable directory whenever PATH does not include the tbb.dll library.

#### Intended Effect:

Make things more robust under Windows.

#### How to Verify:

Do not setup the PATH as advised and just compile the example bernoulli model (or any other). The resulting model can be run as the tbb.dll resides along with the model.

#### Side Effects:

More disk space needed when PATH is not setup.

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
