### PR TITLE
Add --use-opencl to stanc3 if STAN_OPENCL is defined

### DIFF
--- a/make/program
+++ b/make/program
@@ -27,6 +27,10 @@ ifneq ($(findstring allow_undefined,$(STANCFLAGS)),)
 $(STAN_TARGETS) examples/bernoulli/bernoulli$(EXE) $(patsubst %.stan,%$(EXE),$(wildcard src/test/test-models/*.stan)) : CXXFLAGS_PROGRAM += -include $(USER_HEADER)
 endif
 
+ifdef STAN_OPENCL
+STANCFLAGS+= --use-opencl
+endif
+
 %.hpp : %.stan bin/stanc$(EXE)
 	@echo ''
 	@echo '--- Translating Stan model to C++ code ---'


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes #748 

All there is to know is in the title. 

Whenever we set STAN_OPENCL we want to call stanc with --use-opencl in order to use the GLMs with matrix_cl overloads. See https://github.com/stan-dev/stanc3/pull/314

#### Intended Effect:

#### How to Verify:
set STAN_OPENCL=true in make/local and you should see something like the following: 
```
make examples/bernoulli/bernoulli

--- Translating Stan model to C++ code ---
bin/stanc --use-opencl --o=examples/bernoulli/bernoulli.hpp examples/bernoulli/bernoulli.stan
```
#### Side Effects:


#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
