### PR TITLE
ensure that tbb.dll only gets copied once per directory

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -2,19 +2,22 @@
 # Build test executables
 ##
 
+LIB_DIRS_FULL=$(filter %/, $(wildcard src/test/interface/*/) src/test/interface/)
+LIB_DIRS_TBB=$(LIB_DIRS_FULL:src/%/=%/tbb-lib)
+LIB_DIRS_TBB_TARGETS=$(foreach subdir, $(LIB_DIRS_TBB), tests-tbb-install/$(subdir))
+
+tests-tbb-install/% : 
+	@mkdir -p $(dir $*)
+ifeq ($(OS),Windows_NT)
+	cp -v $(TBB_TARGETS) $(dir $*)
+endif
+	@touch $*
+
 test/%$(EXE) : CXXFLAGS += $(CXXFLAGS_GTEST)
 test/%$(EXE) : CPPFLAGS += $(CPPFLAGS_GTEST)
 test/%$(EXE) : INC += $(INC_GTEST) -I $(RAPIDJSON)
-test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
-	$(LINK.cpp) $(filter-out src/test/test-models/% src/%.csv bin/% test/%.hpp %.hpp-test,$^) $(LDLIBS) $(OUTPUT_OPTION)
-ifeq ($(OS),Windows_NT)
-ifneq ($(notdir $(shell where tbb.dll)),tbb.dll)
-	@echo 'Intel TBB is not in PATH. Consider calling '
-	@echo 'make install-tbb'
-	@echo 'to avoid copying Intel TBB library files.'
-	cp -v $(TBB_TARGETS) $(@D)
-endif
-endif
+test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(LIB_DIRS_TBB_TARGETS)
+	$(LINK.cpp) $(filter-out src/test/test-models/% src/%.csv bin/% test/%.hpp %.hpp-test %/tbb-lib,$^) $(LDLIBS) $(OUTPUT_OPTION)
 
 test/%.o : src/test/%.cpp
 	@mkdir -p $(dir $@)


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run tests: `./runCmdStanTests.py src/test`
- [X] Declare copyright holder and open-source license: see below

#### Summary:

Avoids copying of tbb.dll on Windows for every test and instead copies once per directory.

#### Intended Effect:

Avoid concurrency problems during make on Windows.

#### How to Verify:

Run on Windows with -jLARGE the tests

#### Side Effects:

make develop stable again.

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
