### PR TITLE
Pull stanc3 out of develop before 2.21 release

### DIFF
--- a/make/program
+++ b/make/program
@@ -27,10 +27,6 @@ ifneq ($(findstring allow_undefined,$(STANCFLAGS)),)
 $(STAN_TARGETS) examples/bernoulli/bernoulli$(EXE) $(patsubst %.stan,%$(EXE),$(wildcard src/test/test-models/*.stan)) : CXXFLAGS_PROGRAM += -include $(USER_HEADER)
 endif
 
-ifdef STAN_OPENCL
-STANCFLAGS+= --use-opencl
-endif
-
 %.hpp : %.stan bin/stanc$(EXE)
 	@echo ''
 	@echo '--- Translating Stan model to C++ code ---'

--- a/make/stanc
+++ b/make/stanc
@@ -23,7 +23,6 @@ else
 endif
 else
 bin/stanc$(EXE) : $(shell find $(STANC3)/src/ -type f -name '*.ml*') $(STANC#)
-	@mkdir -p $(dir $@)
 	cd $(STANC3) && echo "--- Rebuilding stanc ---\n" && dune build @install
 	cp $(STANC3)/_build/default/src/stanc/stanc.exe $@
 endif

--- a/make/stanc
+++ b/make/stanc
@@ -1,34 +1,6 @@
 ################################################################################
-# stanc build rules
-
-ifeq ($(OS),Windows_NT)
-  OS_TAG := windows
-else ifeq ($(OS),Darwin)
-  OS_TAG := mac
-else ifeq ($(OS),Linux)
-  OS_TAG := linux
-else
-  $(error Can't detect OS properly. This will impede automatically downloading the correct stanc. Please visit https://github.com/stan-dev/stanc3/releases and download a stanc binary for your OS and place it in ./bin/stanc)
-endif
-
-
-ifeq ($(STANC3),)
-bin/stanc$(EXE) :
-	@mkdir -p $(dir $@)
-ifeq ($(OS_TAG),windows)
-	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE)")
-else
-	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc
-	chmod +x bin/stanc
-endif
-else
-bin/stanc$(EXE) : $(shell find $(STANC3)/src/ -type f -name '*.ml*') $(STANC#)
-	cd $(STANC3) && echo "--- Rebuilding stanc ---\n" && dune build @install
-	cp $(STANC3)/_build/default/src/stanc/stanc.exe $@
-endif
-
 # libstanc build rules
-# just used by cmdstan tests and should soon be replaced with tests based on stanc$(EXE)
+
 STANC_TEMPLATE_INSTANTIATION_CPP := $(shell find $(STAN)src/stan/lang -type f -name '*_inst.cpp') $(shell find $(STAN)src/stan/lang -type f -name '*_def.cpp')
 STANC_TEMPLATE_INSTANTIATION := $(STANC_TEMPLATE_INSTANTIATION_CPP:$(STAN)src/stan/%.cpp=bin/cmdstan/%.o)
 
@@ -40,6 +12,15 @@ $(STANC_TEMPLATE_INSTANTIATION) : O = $(O_STANC)
 $(STANC_TEMPLATE_INSTANTIATION) : bin/cmdstan/%.o : $(STAN)src/stan/%.cpp
 	@mkdir -p $(dir $@)
 	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
+
+bin/stanc$(EXE) : O = $(O_STANC)
+bin/stanc$(EXE) : CPPFLAGS_MPI =
+bin/stanc$(EXE) : LDFLAGS_MPI =
+bin/stanc$(EXE) : LDLIBS_MPI =
+bin/stanc$(EXE) : bin/cmdstan/libstanc.a
+bin/stanc$(EXE) : bin/cmdstan/stanc.o
+	@mkdir -p $(dir $@)
+	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
 
 $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP)) : DEPTARGETS = -MT $(patsubst stan/src/stan/lang/%.d,bin/cmdstan/lang/%.o,$@) -MT $@
 

--- a/makefile
+++ b/makefile
@@ -59,7 +59,7 @@ else
 endif
 	@echo ''
 	@echo '    This target will:'
-	@echo '    1. Download the Stan compiler bin/stanc$(EXE).'
+	@echo '    1. Build the Stan compiler bin/stanc$(EXE).'
 	@echo '    2. Build the print utility bin/print$(EXE) (deprecated; will be removed in v3.0)'
 	@echo '    3. Build the stansummary utility bin/stansummary$(EXE)'
 	@echo '    4. Build the diagnose utility bin/diagnose$(EXE)'


### PR DESCRIPTION
We still have some known bugs, and while we have less known bugs than the old compiler, at the meeting we all decided we should squash the known bugs and get more testing before releasing in 2.22.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
