### PR TITLE
Print info on number of threads and OpenCL device used

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -132,6 +132,23 @@ namespace cmdstan {
     }
     parser.print(info);
     info();
+  
+#ifdef STAN_THREADS
+    std::stringstream msg_threads;
+    msg_threads << "STAN_THREADS is enabled. map_rect will run with at most ";
+    msg_threads << stan::math::internal::get_num_threads();
+    msg_threads << " thread(s)." << std::endl;
+    info(msg_threads.str());
+#endif
+
+#ifdef STAN_OPENCL
+    
+    std::stringstream msg_opencl;
+    msg_opencl << "STAN_OPENCL is enabled. OpenCL supported functions will use:" << std::endl;
+    msg_opencl << "Platform: " << stan::math::opencl_context.platform()[0].getInfo<CL_PLATFORM_NAME>() << std::endl;    
+    msg_opencl << "Device: " << stan::math::opencl_context.device()[0].getInfo<CL_DEVICE_NAME>();
+    info(msg_opencl.str());
+#endif
 
     stan::callbacks::writer init_writer;
     stan::callbacks::interrupt interrupt;

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -57,7 +57,6 @@
 #include <stan/math/prim/arr/functor/mpi_distributed_apply.hpp>
 #endif
 
-
 // forward declaration for function defined in another translation unit
 stan::model::model_base& new_model(stan::io::var_context& data_context,
                                    unsigned int seed,

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -144,10 +144,12 @@ namespace cmdstan {
 #ifdef STAN_OPENCL
     
     std::stringstream msg_opencl;
-    msg_opencl << "STAN_OPENCL is enabled. OpenCL supported functions will use:" << std::endl;
-    msg_opencl << "Platform: " << stan::math::opencl_context.platform()[0].getInfo<CL_PLATFORM_NAME>() << std::endl;    
-    msg_opencl << "Device: " << stan::math::opencl_context.device()[0].getInfo<CL_DEVICE_NAME>();
-    info(msg_opencl.str());
+    if((stan::math::opencl_context.platform() > 0) && (stan::math::opencl_context.device() > 0)) {
+      msg_opencl << "STAN_OPENCL is enabled. OpenCL supported functions will use:" << std::endl;
+      msg_opencl << "Platform: " << stan::math::opencl_context.platform()[0].getInfo<CL_PLATFORM_NAME>() << std::endl;    
+      msg_opencl << "Device: " << stan::math::opencl_context.device()[0].getInfo<CL_DEVICE_NAME>();
+      info(msg_opencl.str());
+    }    
 #endif
 
     stan::callbacks::writer init_writer;


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes #760

Adds a info print on the number of threads (if STAN_THREADS is set) and the OpenCL device used (if STAN_OPENCL is set).

Example: 

```
output
  file = output.csv (Default)
  diagnostic_file =  (Default)
  refresh = 100 (Default)

STAN_THREADS is enabled. map_rect will run with at most 2 thread(s).

STAN_OPENCL is enabled. OpenCL supported functions will use:
Platform: AMD Accelerated Parallel Processing
Device: gfx906

Gradient evaluation took 6e-06 seconds
1000 transitions using 10 leapfrog steps per transition would take 0.06 seconds.
Adjust your expectations accordingly!
```


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
