### PR TITLE
Add rule for cleaning up compiled stan programs

### DIFF
--- a/makefile
+++ b/makefile
@@ -205,7 +205,7 @@ endif
 ##
 # Clean up.
 ##
-.PHONY: clean clean-deps clean-manual clean-all
+.PHONY: clean clean-deps clean-manual clean-all clean-program
 
 clean: clean-manual
 	$(RM) -r test
@@ -226,6 +226,15 @@ clean-all: clean clean-deps clean-libraries clean-manual
 	$(RM) -r bin
 	$(RM) -r $(CMDSTAN_MAIN_O)
 	$(RM) $(wildcard $(STAN)src/stan/model/model_header.hpp.gch)
+
+clean-program:
+ifndef STANPROG
+	$(error STANPROG not set)
+endif
+	$(RM) $(wildcard $(patsubst %.stan,%.d,$(basename ${STANPROG}).stan))
+	$(RM) $(wildcard $(patsubst %.stan,%.hpp,$(basename ${STANPROG}).stan))
+	$(RM) $(wildcard $(patsubst %.stan,%.o,$(basename ${STANPROG}).stan))
+	$(RM) $(wildcard $(patsubst %.stan,%$(EXE),$(basename ${STANPROG}).stan))
 
 ##
 # Submodule related tasks


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Adds a make rule for cleaning up a compiled stan program and its associated files. Fixes #772 

#### Intended Effect:

The compiled binary, .o, .hpp, and .d files will be removed when the user runs `make STANPROG="path/to/stanprog" clean-program`.

#### How to Verify:

First compile the example program:

    make examples/bernoulli/bernoulli

Then you can remove the binary and it's associated files with:

    make STANPROG="examples/bernoulli/bernoulli" clean-program

It is also safe to specify the stan file instead (which a user might do on accident):

    make STANPROG="examples/bernoulli/bernoulli.stan" clean-program

In this example `bernoulli`, `bernoulli.d`, `bernoulli.o`, and `bernoulli.hpp` are removed.

#### Side Effects:

None

#### Documentation:

TBD

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): American Express

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
