### PR TITLE
Remove hardcoded version number in path to stan_math

### DIFF
--- a/test-all.sh
+++ b/test-all.sh
@@ -21,7 +21,7 @@ popd
 echo ''
 echo '------------------------------------------------------------'
 echo 'Stan Math Library tests'
-pushd stan/lib/stan_math_2.15.0/
+pushd stan/lib/stan_math/
 ./runTests.py test/unit
 ./runTests.py test/prob
 popd


### PR DESCRIPTION
#### Submisison Checklist

- [X] Declare copyright holder and open-source license: see below

#### Summary:
Fixes #777 by correcting the path to the `stan_math` directory.

#### Intended Effect:
Running `test-all.sh` should not fail when attempting to run the Stan Math library tests.

#### How to Verify:
Run `test-all.sh` and wait till it finishes.

#### Side Effects:
Running `test-all.sh` is going to take a lot longer.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
