### PR TITLE
Add quotes to rm commands in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -231,10 +231,10 @@ clean-program:
 ifndef STANPROG
 	$(error STANPROG not set)
 endif
-	$(RM) $(wildcard $(patsubst %.stan,%.d,$(basename ${STANPROG}).stan))
-	$(RM) $(wildcard $(patsubst %.stan,%.hpp,$(basename ${STANPROG}).stan))
-	$(RM) $(wildcard $(patsubst %.stan,%.o,$(basename ${STANPROG}).stan))
-	$(RM) $(wildcard $(patsubst %.stan,%$(EXE),$(basename ${STANPROG}).stan))
+	$(RM) "$(wildcard $(patsubst %.stan,%.d,$(basename ${STANPROG}).stan))"
+	$(RM) "$(wildcard $(patsubst %.stan,%.hpp,$(basename ${STANPROG}).stan))"
+	$(RM) "$(wildcard $(patsubst %.stan,%.o,$(basename ${STANPROG}).stan))"
+	$(RM) "$(wildcard $(patsubst %.stan,%$(EXE),$(basename ${STANPROG}).stan))"
 
 ##
 # Submodule related tasks


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:

Add quotes around around `rm` commands in makefile. Required to properly remove programs with spaces in them.

#### Intended Effect:

Properly removes programs with spaces in them

#### How to Verify:

Run `make STANPROG="path/to/program\ with\ space" clean-program`. Note that it is still required to escape the make argument `STANPROG`.

#### Side Effects:

None

#### Documentation:

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
