### PR TITLE
Bugfix/784 makefile run cmd stan py

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -39,11 +39,6 @@ ifneq ($(filter test/%,$(MAKECMDGOALS)),)
 -include $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP))
 endif
 
-TEST_MODELS_EXE := $(patsubst %.stan,%$(EXE),$(wildcard src/test/test-models/*.stan))
-
-.PHONY: test-models-exe
-test-models-exe: $(TEST_MODELS_EXE)
-
 ############################################################
 #
 # Target to verify header files within CmdStan has
@@ -67,3 +62,32 @@ test/dummy.cpp:
 
 .PHONY: test-headers
 test-headers: $(HEADER_TESTS)
+
+############################################################
+#
+# Target to generate C++ code for all test-models
+##
+TEST_MODELS := $(wildcard src/test/test-models/*.stan)
+TEST_MODELS_DEPS := $(patsubst %.stan,%.d,$(TEST_MODELS))
+
+.PHONY: test-models-hpp
+test-models-hpp:  $(TEST_MODELS_DEPS)
+
+##
+# Tests that depend on compiled models
+##
+test/interface/generated_quantities_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, gq_model test_model))
+test/interface/command_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, printer domain_fail proper value_fail transformed_data_rng_test ndim_array))
+test/interface/metric_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, test_model proper))
+test/interface/csv_header_consistency_test$(EXE): src/test/test-models/csv_header_consistency$(EXE)
+test/interface/diagnose_test$(EXE): bin/diagnose$(EXE)
+test/interface/elapsed_time_test$(EXE): src/test/test-models/test_model$(EXE)
+test/interface/fixed_param_sampler_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, empty proper))
+test/interface/mpi_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, proper))
+test/interface/model_output_test$(EXE): src/test/test-models/printer$(EXE)
+test/interface/optimization_output_test$(EXE): src/test/test-models/optimization_output$(EXE)
+test/interface/print_test$(EXE): bin/print$(EXE)
+test/interface/print_uninitialized_test$(EXE): src/test/test-models/print_uninitialized$(EXE)
+test/interface/arguments/argument_configuration_test$(EXE): src/test/test-models/test_model$(EXE)
+test/interface/stansummary_test$(EXE): bin/stansummary$(EXE)
+test/interface/variational_output_test$(EXE): src/test/test-models/variational_output$(EXE)

--- a/makefile
+++ b/makefile
@@ -209,7 +209,9 @@ endif
 
 clean: clean-manual
 	$(RM) -r test
+	$(RM) $(wildcard $(patsubst %.stan,%.d,$(TEST_MODELS)))
 	$(RM) $(wildcard $(patsubst %.stan,%.hpp,$(TEST_MODELS)))
+	$(RM) $(wildcard $(patsubst %.stan,%.o,$(TEST_MODELS)))
 	$(RM) $(wildcard $(patsubst %.stan,%$(EXE),$(TEST_MODELS)))
 
 clean-deps:

--- a/runCmdStanTests.py
+++ b/runCmdStanTests.py
@@ -14,7 +14,7 @@ import time
 
 WIN_SFX = '.exe'
 TEST_SFX = '_test.cpp'
-DEBUG = True
+DEBUG = False
 BATCH_SIZE = 25
 
 def usage():

--- a/runCmdStanTests.py
+++ b/runCmdStanTests.py
@@ -12,10 +12,10 @@ import sys
 import subprocess
 import time
 
-winsfx = ".exe"
-testsfx = "_test.cpp"
-debug = False
-batchSize = 25
+WIN_SFX = '.exe'
+TEST_SFX = '_test.cpp'
+DEBUG = True
+BATCH_SIZE = 25
 
 def usage():
     sys.stdout.write('usage: %s <path/test/dir(/files)>\n' % sys.argv[0])
@@ -29,49 +29,49 @@ def stopErr(msg, returncode):
     sys.exit(returncode)
 
 def isWin():
-    if (platform.system().lower().startswith("windows")
-        or os.name.lower().startswith("windows")):
+    if (platform.system().lower().startswith('windows')
+            or os.name.lower().startswith('windows')):
         return True
     return False
 
-# set up good makefile target name
+# edit filename into makefile target name
 def mungeName(name):
-    if (debug):
-        print("munge input: %s" % name)
-    if (name.startswith("src")):
-        name = name.replace("src/","",1)
-    if (name.endswith(testsfx)):
-        name = name.replace(testsfx,"_test")
-        if (isWin()):
-            name += winsfx
-            name = name.replace("\\","/")
+    if DEBUG:
+        print('munge input: %s' % name)
+    if name.startswith('src/test/interface'):
+        name = name.replace('src/','',1)
+    if name.endswith(TEST_SFX):
+        name, _ = os.path.splitext(name)
+    if isWin():
+        name += WIN_SFX
+        name = name.replace('\\','/')
 
-    name = name.replace(" ", "\\ ").replace("(","\\(").replace(")","\\)")
-    if (debug):
-        print("munge return: %s" % name)
+    name = name.replace(' ', '\\ ').replace('(','\\(').replace(')','\\)')
+    if DEBUG:
+        print('munge return: %s' % name)
     return name
 
 
 def doCommand(command):
-    print("------------------------------------------------------------")
-    if isWin() and command.startswith("make "):
-      command = command.replace("make ", "mingw32-make ")
-    print("%s" % command)
+    print('------------------------------------------------------------')
+    if isWin() and command.startswith('make '):
+      command = command.replace('make ', 'mingw32-make ')
+    print('%s' % command)
     p1 = subprocess.Popen(command,shell=True)
     p1.wait()
-    if (not(p1.returncode == None) and not(p1.returncode == 0)):
+    if not (p1.returncode == None or p1.returncode == 0):
         stopErr('%s failed' % command, p1.returncode)
 
 def makeTest(name, j):
     target = mungeName(name)
-    if (j == None):
+    if j == None:
         command = 'make %s' % target
     else:
         command = 'make -j%d %s' % (j,target)
     doCommand(command)
 
 def makeBuild(j):
-    if (j == None):
+    if j == None:
         command = 'make build'
     else:
         command = 'make -j%d build' % j
@@ -79,46 +79,37 @@ def makeBuild(j):
 
 
 def makeTestModels(j):
-    if (j == None):
-        command = 'make test-models-exe'
+    if j == None:
+        command = 'make test-models-hpp'
     else:
-        command = 'make -j%d test-models-exe' % j
+        command = 'make -j%d test-models-hpp' % j
     doCommand(command)
-
-
-def makeTestModel(target, j):
-    if (j == None):
-        command = 'make %s' % target
-    else:
-        command = 'make -j%d %s' % (j,target)
-    doCommand(command)
-
 
 def makeTests(dirname, filenames, j):
     targets = list()
     for name in filenames:
-        if (not name.endswith(testsfx)):
+        if not name.endswith(TEST_SFX):
             continue
-        target = "/".join([dirname,name])
+        target = '/'.join([dirname,name])
         target = mungeName(target)
         targets.append(target)
-    if (len(targets) > 0):
-        if (debug):
+    if len(targets) > 0:
+        if DEBUG:
             print('# targets: %d' % len(targets))
         startIdx = 0
-        endIdx = batchSize
+        endIdx = BATCH_SIZE
         while (startIdx < len(targets)):
-            if (j == None):
+            if j == None:
                 command = 'make %s' % ' '.join(targets[startIdx:endIdx])
             else:
                 command = 'make -j%d %s' % (j,' '.join(targets[startIdx:endIdx]))
-            if (debug):
+            if DEBUG:
                 print('start %d, end %d' % (startIdx,endIdx))
                 print(command)
             doCommand(command)
             startIdx = endIdx
-            endIdx = startIdx + batchSize
-            if (endIdx > len(targets)):
+            endIdx = startIdx + BATCH_SIZE
+            if endIdx > len(targets):
                 endIdx = len(targets)
 
 def commandExists(command):
@@ -129,82 +120,82 @@ def commandExists(command):
     return p.returncode != 127
 
 def runTest(name, mpi=False, j=1):
-    executable = mungeName(name).replace("/",os.sep)
-    xml = mungeName(name).replace(winsfx, "")
+    executable = mungeName(name).replace('/',os.sep)
+    xml = mungeName(name).replace(WIN_SFX, '')
     command = '%s --gtest_output="xml:%s.xml"' % (executable, xml)
     if mpi:
-        if not commandExists("mpirun"):
-            stopErr("Error: need to have mpi (and mpirun) installed to run mpi tests"
-                    + "\nCheck https://github.com/stan-dev/stan/wiki/Parallelism-using-MPI-in-Stan for more details."
+        if not commandExists('mpirun'):
+            stopErr('Error: need to have mpi (and mpirun) installed to run mpi tests'
+                    + '\nCheck https://github.com/stan-dev/stan/wiki/Parallelism-using-MPI-in-Stan for more details.'
                     , -1)
-        if "mpi_" in name:
+        if 'mpi_' in name:
             j = j > 2 and j or 2
-            command = "mpirun -np {} {}".format(j, command)
+            command = 'mpirun -np {} {}'.format(j, command)
     doCommand(command)
 
 def main():
-    if (len(sys.argv) < 2):
+    if len(sys.argv) < 2:
         usage()
 
     try:
-        with open("make/local") as f:
-            stan_mpi =  "STAN_MPI" in f.read()
+        with open('make/local') as f:
+            stan_mpi =  'STAN_MPI' in f.read()
     except IOError:
         stan_mpi = False
 
     argsIdx = 1
     j = None
-    if (sys.argv[1].startswith("-j")):
+    if sys.argv[1].startswith('-j'):
         argsIdx = 2
-        if (len(sys.argv) < 3):
+        if len(sys.argv) < 3:
             usage()
         else:
-            j = sys.argv[1].replace("-j","")
+            j = sys.argv[1].replace('-j','')
             try:
                 jprime = int(j)
-                if (jprime < 1):
-                    stopErr("bad value for -j flag",-1)
+                if jprime < 1:
+                    stopErr('bad value for -j flag',-1)
                 j = jprime
             except ValueError:
-                stopErr("bad value for -j flag",-1)
+                stopErr('bad value for -j flag',-1)
 
 
-    # pass 0:  make build
+    # pass 0:  make build, compile all test models
     makeBuild(j)
     makeTestModels(j)
 
     # pass 1:  call make to compile test targets
     for i in range(argsIdx,len(sys.argv)):
         testname = sys.argv[i]
-        if (debug):
-            print("testname: %s" % testname)
-        if (not(os.path.exists(testname))):
+        if DEBUG:
+            print('testname: %s' % testname)
+        if not os.path.exists(testname):
             stopErr('%s: no such file or directory' % testname,-1)
-        if (not(os.path.isdir(testname))):
-            if (not(testname.endswith(testsfx))):
+        if not os.path.isdir(testname):
+            if not testname.endswith(TEST_SFX):
                 stopErr('%s: not a testfile' % testname,-1)
-            if (debug):
-                print("make single test: %s" % testname)
+            if DEBUG:
+                print('make single test: %s' % testname)
             makeTest(testname,j)
         else:
             for root, dirs, files in os.walk(testname):
-                if (debug):
-                    print("make root: %s" % root)
+                if DEBUG:
+                    print('make root: %s' % root)
                 makeTests(root,files,j)
 
     # pass 2:  run test targets
     for i in range(argsIdx,len(sys.argv)):
         testname = sys.argv[i]
-        if (not(os.path.isdir(testname))):
-            if (debug):
-                print("run single test: %s" % testname)
+        if not os.path.isdir(testname):
+            if DEBUG:
+                print('run single test: %s' % testname)
             runTest(testname, mpi = stan_mpi, j = j)
         else:
             for root, dirs, files in os.walk(testname):
                 for name in files:
-                    if (name.endswith(testsfx)):
-                        if (debug):
-                            print("run dir,test: %s,%s" % (root,name))
+                    if name.endswith(TEST_SFX):
+                        if DEBUG:
+                            print('run dir,test: %s,%s' % (root,name))
                         runTest(os.sep.join([root,name]), mpi = stan_mpi, j = j)
 
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Fix  makefile rules for unit tests; on OSX, unit tests fail because make cannot find correct rule to compile Stan programs in test/test-models.  see discussion in issue #784 - unit tests are running OK on Jenkins.

- modified targets in `make/tests` so that makefile generates `.d` and `.hpp` files for all test models
- added rule to `make/tests` to populate variable `TEST_MODELS`; this variable is used in e CmdStan's `makefile` target `clean` - also added more statements to this target to insure that test model `.d`, `.hpp`, `.o` and EXEs are removed as part of cleanup.
- added list of per-test dependencies on compiled test-models to `make/tests`
- edited `runCmdStanTests.py` to make code more Pythonic - use correct punctuation, capitalization, and remove unneeded parens around tests in `if` stmts.

#### Intended Effect:
Be able to run entire unit test suite via single invocation of  `runCmdStanTests.py`.

#### How to Verify:
```
make clean-all
./runCmdStanTests.py src/test/interface
```
#### Side Effects:
N/A

#### Documentation:
N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
