### PR TITLE
Bugfix/775 var context json size 0 dims

### DIFF
--- a/src/cmdstan/io/json/json_data.hpp
+++ b/src/cmdstan/io/json/json_data.hpp
@@ -207,6 +207,7 @@ namespace cmdstan {
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
                      const std::vector<size_t>& dims_declared) const {
+    std::cout << "validate dims" << std::endl;
     bool is_int_type = base_type == "int";
     if (is_int_type) {
       if (!contains_i(name)) {
@@ -234,6 +235,7 @@ namespace cmdstan {
     for (size_t i = 0; i < dims.size(); ++i) {
       num_elements *= dims[i];
     }
+    std::cout << "num_elements: " << num_elements << std::endl;
     if (num_elements == 0)
       return;
 

--- a/src/cmdstan/io/json/json_data.hpp
+++ b/src/cmdstan/io/json/json_data.hpp
@@ -207,7 +207,6 @@ namespace cmdstan {
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
                      const std::vector<size_t>& dims_declared) const {
-    std::cout << "validate dims" << std::endl;
     bool is_int_type = base_type == "int";
     if (is_int_type) {
       if (!contains_i(name)) {
@@ -235,7 +234,6 @@ namespace cmdstan {
     for (size_t i = 0; i < dims.size(); ++i) {
       num_elements *= dims[i];
     }
-    std::cout << "num_elements: " << num_elements << std::endl;
     if (num_elements == 0)
       return;
 

--- a/src/docs/cmdstan-guide/json-format.tex
+++ b/src/docs/cmdstan-guide/json-format.tex
@@ -62,7 +62,7 @@ data {
 \end{Verbatim}
 \end{quote}
 \noindent
-the following JSON input file would be valid
+the following JSON input would be valid
 \begin{quote}
 \begin{Verbatim}
 { "d1" : 2,
@@ -102,6 +102,50 @@ and the right column contains valid JSON data inputs.
 \code{matrix[2,3] a;} & \code{"a" : [ [ 1, 2, 3 ], [ 4, 5, 6] ]} \\
 \end{tabular}
 \end{center}
+
+\subsection{Empty arrays in JSON}
+
+JSON notation is not able to distinguish between multi-dimensional arrays
+where any dimension is 0, e.g., 
+a 2-D array with dimensions (1, 0), i.e., one row, zero columns, has JSON representation \code{ [ ] }.
+
+To see how this works, consider the following Stan program data block:
+\begin{quote}
+\begin{Verbatim}
+data {
+  int d;
+  int ar_1d[d];
+  int ar_2d[d,d];
+  int ar_3d[d,d,d];
+}
+\end{Verbatim}
+\end{quote}
+In the case where variable \code{d} is \code{1},  all arrays will contain 1 value.
+If where variable \code{ar\_d1} contains value \code{7},
+variable \code{ar\_d2} contains value \code{8}, and
+variable \code{ar\_d3} contains value \code{9}, 
+the JSON representation is:
+\begin{quote}
+\begin{Verbatim}
+{ "d" : 1,
+  "ar_d1" : [7],
+  "ar_d2" : [[8]],
+  "ar_d3" : [[[9]]]
+}
+\end{Verbatim}
+\end{quote}
+However, in the case where variable  \code{d} is \code{0},
+all arrays contain 0 values, and the JSON representation is:
+\begin{quote}
+\begin{Verbatim}
+{ "d" : 0,
+  "ar_d1" : [ ],
+  "ar_d2" : [ ],
+  "ar_d3" : [ ]
+}
+\end{Verbatim}
+\end{quote}
+
 %
 
 

--- a/src/test/interface/io/json/json_data_test.cpp
+++ b/src/test/interface/io/json/json_data_test.cpp
@@ -10,123 +10,128 @@
 #include <boost/math/concepts/real_concept.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 
-void test_int_var(cmdstan::json::json_data& jdata,
-                  const std::string& text,
-                  const std::string& name,
-                  const std::vector<int>& expected_vals,
-                  const std::vector<size_t>& expected_dims) {
-  EXPECT_EQ(true,jdata.contains_i(name));
+void test_int_var(cmdstan::json::json_data &jdata, const std::string &text,
+                  const std::string &name,
+                  const std::vector<int> &expected_vals,
+                  const std::vector<size_t> &expected_dims) {
+  EXPECT_EQ(true, jdata.contains_i(name));
   std::vector<size_t> dims = jdata.dims_i(name);
-  EXPECT_EQ(expected_dims.size(),dims.size());
-  for (size_t i = 0; i<dims.size(); i++) 
-    EXPECT_EQ(expected_dims[i],dims[i]);
+  EXPECT_EQ(expected_dims.size(), dims.size());
+  for (size_t i = 0; i < dims.size(); i++)
+    EXPECT_EQ(expected_dims[i], dims[i]);
   std::vector<int> vals = jdata.vals_i(name);
-  EXPECT_EQ(expected_vals.size(),vals.size());
-  for (size_t i = 0; i<vals.size(); i++) 
-    EXPECT_EQ(expected_vals[i],vals[i]);
+  EXPECT_EQ(expected_vals.size(), vals.size());
+  for (size_t i = 0; i < vals.size(); i++)
+    EXPECT_EQ(expected_vals[i], vals[i]);
 }
 
-void test_real_var(cmdstan::json::json_data& jdata,
-                  const std::string& text,
-                  const std::string& name,
-                  const std::vector<double>& expected_vals,
-                  const std::vector<size_t>& expected_dims) {
-  EXPECT_EQ(true,jdata.contains_r(name));
+void test_empty_int_arr(cmdstan::json::json_data &jdata,
+                        const std::string &text, const std::string &name,
+                        const std::vector<int> &expected_vals) {
+  EXPECT_EQ(true, jdata.contains_i(name));
+  std::vector<size_t> dims = jdata.dims_i(name);
+  EXPECT_EQ(1, dims.size());
+  std::vector<int> vals = jdata.vals_i(name);
+  EXPECT_EQ(expected_vals.size(), vals.size());
+  for (size_t i = 0; i < vals.size(); i++)
+    EXPECT_EQ(expected_vals[i], vals[i]);
+}
+
+void test_real_var(cmdstan::json::json_data &jdata, const std::string &text,
+                   const std::string &name,
+                   const std::vector<double> &expected_vals,
+                   const std::vector<size_t> &expected_dims) {
+  EXPECT_EQ(true, jdata.contains_r(name));
   std::vector<size_t> dims = jdata.dims_r(name);
-  EXPECT_EQ(expected_dims.size(),dims.size());
-  for (size_t i = 0; i<dims.size(); i++) 
-    EXPECT_EQ(expected_dims[i],dims[i]);
+  EXPECT_EQ(expected_dims.size(), dims.size());
+  for (size_t i = 0; i < dims.size(); i++)
+    EXPECT_EQ(expected_dims[i], dims[i]);
   std::vector<double> vals = jdata.vals_r(name);
-  EXPECT_EQ(expected_vals.size(),vals.size());
-  for (size_t i = 0; i<vals.size(); i++) 
-    EXPECT_EQ(expected_vals[i],vals[i]);
+  EXPECT_EQ(expected_vals.size(), vals.size());
+  for (size_t i = 0; i < vals.size(); i++)
+    EXPECT_EQ(expected_vals[i], vals[i]);
 }
 
-void test_exception(const std::string& input,
-                    const std::string& exception_text) {
+void test_exception(const std::string &input,
+                    const std::string &exception_text) {
   try {
     std::stringstream s(input);
     cmdstan::json::json_data jdata(s);
-  } catch (const std::exception& e) {
+  } catch (const std::exception &e) {
     EXPECT_EQ(e.what(), exception_text);
     return;
   }
-  FAIL();  // didn't throw an exception as expected.
+  FAIL(); // didn't throw an exception as expected.
 }
 
-
-
-
-TEST(ioJson,jsonData_scalar_int) {
+TEST(ioJson, jsonData_scalar_int) {
   std::string txt = "{ \"foo\" : 1 }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<int> expected_vals;
   expected_vals.push_back(1);
   std::vector<size_t> expected_dims;
-  test_int_var(jdata,txt,"foo",expected_vals,expected_dims);
+  test_int_var(jdata, txt, "foo", expected_vals, expected_dims);
 }
 
-TEST(ioJson,jsonData_scalar_real) {
+TEST(ioJson, jsonData_scalar_real) {
   std::string txt = "{ \"foo\" : 1.1 }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals;
   expected_vals.push_back(1.1);
   std::vector<size_t> expected_dims;
-  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals, expected_dims);
 }
 
-TEST(ioJson,jsonData_mult_vars) {
+TEST(ioJson, jsonData_mult_vars) {
   std::string txt = "{ \"foo\" : 1, \"bar\" : 0.1 }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<int> expected_vals_i;
   expected_vals_i.push_back(1);
   std::vector<size_t> expected_dims;
-  test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
+  test_int_var(jdata, txt, "foo", expected_vals_i, expected_dims);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(0.1);
-  test_real_var(jdata,txt,"bar",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "bar", expected_vals_r, expected_dims);
 }
 
-TEST(ioJson,jsonData_mult_vars2) {
+TEST(ioJson, jsonData_mult_vars2) {
   std::string txt = "{ \"foo\" : \"-Inf\", \"bar\" : 0.1 }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
-  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals_r, expected_dims);
   expected_vals_r.clear();
   expected_vals_r.push_back(0.1);
-  test_real_var(jdata,txt,"bar",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "bar", expected_vals_r, expected_dims);
 }
 
-
-TEST(ioJson,jsonData_mult_vars3) {
+TEST(ioJson, jsonData_mult_vars3) {
   std::string txt = "{ \"foo\" : \"-Inf\", "
-    "                  \"bar\" : 0.1 ," 
-    "                  \"baz\" : [ \"-Inf\", 0.1 , 1 ] }";
+                    "                  \"bar\" : 0.1 ,"
+                    "                  \"baz\" : [ \"-Inf\", 0.1 , 1 ] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
-  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals_r, expected_dims);
   expected_vals_r.clear();
   expected_vals_r.push_back(0.1);
-  test_real_var(jdata,txt,"bar",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "bar", expected_vals_r, expected_dims);
   expected_vals_r.clear();
   expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
   expected_vals_r.push_back(0.1);
   expected_vals_r.push_back(1);
   expected_dims.push_back(3);
-  test_real_var(jdata,txt,"baz",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "baz", expected_vals_r, expected_dims);
 }
 
-
-TEST(ioJson,jsonData_real_array_1D) {
+TEST(ioJson, jsonData_real_array_1D) {
   std::string txt = "{ \"foo\" : [ 1.1, 2.2 ] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
@@ -135,11 +140,10 @@ TEST(ioJson,jsonData_real_array_1D) {
   expected_vals.push_back(2.2);
   std::vector<size_t> expected_dims;
   expected_dims.push_back(2);
-  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals, expected_dims);
 }
 
-
-TEST(ioJson,jsonData_array_1D_inf) {
+TEST(ioJson, jsonData_array_1D_inf) {
   std::string txt = "{ \"foo\" : [ 1.1, \"Inf\" ] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
@@ -148,10 +152,10 @@ TEST(ioJson,jsonData_array_1D_inf) {
   expected_vals.push_back(std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
   expected_dims.push_back(2);
-  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals, expected_dims);
 }
 
-TEST(ioJson,jsonData_array_1D_inf2) {
+TEST(ioJson, jsonData_array_1D_inf2) {
   std::string txt = "{ \"foo\" : [ 1, \"Inf\" ] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
@@ -160,10 +164,10 @@ TEST(ioJson,jsonData_array_1D_inf2) {
   expected_vals.push_back(std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
   expected_dims.push_back(2);
-  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals, expected_dims);
 }
 
-TEST(ioJson,jsonData_array_1D_neg_inf) {
+TEST(ioJson, jsonData_array_1D_neg_inf) {
   std::string txt = "{ \"foo\" : [ 1.1, \"-Inf\" ] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
@@ -172,11 +176,12 @@ TEST(ioJson,jsonData_array_1D_neg_inf) {
   expected_vals.push_back(-std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
   expected_dims.push_back(2);
-  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals, expected_dims);
 }
 
-TEST(ioJson,jsonData_real_array_2D) {
-  std::string txt = "{ \"foo\" : [ [ 1.1, 1.2 ], [ 2.1, 2.2 ], [ 3.1, 3.2] ]  }";
+TEST(ioJson, jsonData_real_array_2D) {
+  std::string txt =
+      "{ \"foo\" : [ [ 1.1, 1.2 ], [ 2.1, 2.2 ], [ 3.1, 3.2] ]  }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals;
@@ -189,13 +194,15 @@ TEST(ioJson,jsonData_real_array_2D) {
   std::vector<size_t> expected_dims;
   expected_dims.push_back(3);
   expected_dims.push_back(2);
-  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals, expected_dims);
 }
 
-
-TEST(ioJson,jsonData_real_array_3D) {
-  std::string txt = "{ \"foo\" : [ [ [ 11.1, 11.2, 11.3, 11.4 ], [ 12.1, 12.2, 12.3, 12.4 ], [ 13.1, 13.2, 13.3, 13.4] ],"
-    "                            [ [ 21.1, 21.2, 21.3, 21.4 ], [ 22.1, 22.2, 22.3, 22.4 ], [ 23.1, 23.2, 23.3, 23.4] ] ] }";
+TEST(ioJson, jsonData_real_array_3D) {
+  std::string txt =
+      "{ \"foo\" : [ [ [ 11.1, 11.2, 11.3, 11.4 ], [ 12.1, 12.2, 12.3, 12.4 ], "
+      "[ 13.1, 13.2, 13.3, 13.4] ],"
+      "                            [ [ 21.1, 21.2, 21.3, 21.4 ], [ 22.1, 22.2, "
+      "22.3, 22.4 ], [ 23.1, 23.2, 23.3, 23.4] ] ] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals;
@@ -224,19 +231,21 @@ TEST(ioJson,jsonData_real_array_3D) {
   expected_vals.push_back(13.4);
   expected_vals.push_back(23.4);
   std::vector<size_t> expected_dims;
-  expected_dims.push_back(2);  // two rows
-  expected_dims.push_back(3);  // three cols
-  expected_dims.push_back(4);  // four shelves
-  test_real_var(jdata,txt,"foo",expected_vals,expected_dims);
+  expected_dims.push_back(2); // two rows
+  expected_dims.push_back(3); // three cols
+  expected_dims.push_back(4); // four shelves
+  test_real_var(jdata, txt, "foo", expected_vals, expected_dims);
 }
 
-TEST(ioJson,jsonData_int_array_3D) {
-  std::string txt = "{ \"foo\" : [ [ [ 111, 112, 113, 114 ], [ 121, 122, 123, 124 ], [ 131, 132, 133, 134] ],"
-    "                            [ [ 211, 212, 213, 214 ], [ 221, 222, 223, 224 ], [ 231, 232, 233, 234] ] ] }";
+TEST(ioJson, jsonData_int_array_3D) {
+  std::string txt = "{ \"foo\" : [ [ [ 111, 112, 113, 114 ], [ 121, 122, 123, "
+                    "124 ], [ 131, 132, 133, 134] ],"
+                    "                            [ [ 211, 212, 213, 214 ], [ "
+                    "221, 222, 223, 224 ], [ 231, 232, 233, 234] ] ] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<int> expected_vals;
-  expected_vals.push_back(111);  
+  expected_vals.push_back(111);
   expected_vals.push_back(211);
   expected_vals.push_back(121);
   expected_vals.push_back(221);
@@ -261,23 +270,23 @@ TEST(ioJson,jsonData_int_array_3D) {
   expected_vals.push_back(134);
   expected_vals.push_back(234);
   std::vector<size_t> expected_dims;
-  expected_dims.push_back(2);  // two rows
-  expected_dims.push_back(3);  // three cols
-  expected_dims.push_back(4);  // four shelves
-  test_int_var(jdata,txt,"foo",expected_vals,expected_dims);
+  expected_dims.push_back(2); // two rows
+  expected_dims.push_back(3); // three cols
+  expected_dims.push_back(4); // four shelves
+  test_int_var(jdata, txt, "foo", expected_vals, expected_dims);
 }
 
-TEST(ioJson,jsonData_empty_1D_array) {
+TEST(ioJson, jsonData_empty_1D_array) {
   std::string txt = "{ \"foo\" : [] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<int> expected_vals_i;
   std::vector<size_t> expected_dims;
   expected_dims.push_back(0);
-  test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
+  test_int_var(jdata, txt, "foo", expected_vals_i, expected_dims);
 }
 
-TEST(ioJson,jsonData_empty_2D_array_0_0) {
+TEST(ioJson, jsonData_empty_2D_array_0_0) {
   std::string txt = "{ \"foo\" : [] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
@@ -285,10 +294,15 @@ TEST(ioJson,jsonData_empty_2D_array_0_0) {
   std::vector<size_t> expected_dims;
   expected_dims.push_back(0);
   expected_dims.push_back(0);
-  test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
+  test_empty_int_arr(jdata, txt, "foo", expected_vals_i);
+  try {
+    jdata.validate_dims("test", "foo", "int", expected_dims);
+  } catch (const std::exception &e) {
+    FAIL();
+  }
 }
 
-TEST(ioJson,jsonData_empty_2D_array_1_0) {
+TEST(ioJson, jsonData_empty_2D_array_1_0) {
   std::string txt = "{ \"foo\" : [] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
@@ -296,10 +310,15 @@ TEST(ioJson,jsonData_empty_2D_array_1_0) {
   std::vector<size_t> expected_dims;
   expected_dims.push_back(1);
   expected_dims.push_back(0);
-  test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
+  test_empty_int_arr(jdata, txt, "foo", expected_vals_i);
+  try {
+    jdata.validate_dims("test", "foo", "int", expected_dims);
+  } catch (const std::exception &e) {
+    FAIL();
+  }
 }
 
-TEST(ioJson,jsonData_empty_3D_array_0_0_0) {
+TEST(ioJson, jsonData_empty_3D_array_0_0_0) {
   std::string txt = "{ \"foo\" : [] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
@@ -308,10 +327,15 @@ TEST(ioJson,jsonData_empty_3D_array_0_0_0) {
   expected_dims.push_back(0);
   expected_dims.push_back(0);
   expected_dims.push_back(0);
-  test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
+  test_empty_int_arr(jdata, txt, "foo", expected_vals_i);
+  try {
+    jdata.validate_dims("test", "foo", "int", expected_dims);
+  } catch (const std::exception &e) {
+    FAIL();
+  }
 }
 
-TEST(ioJson,jsonData_empty_3D_array_2_1_0) {
+TEST(ioJson, jsonData_empty_3D_array_2_1_0) {
   std::string txt = "{ \"foo\" : [] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
@@ -320,132 +344,139 @@ TEST(ioJson,jsonData_empty_3D_array_2_1_0) {
   expected_dims.push_back(2);
   expected_dims.push_back(1);
   expected_dims.push_back(0);
-  test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
+  test_empty_int_arr(jdata, txt, "foo", expected_vals_i);
+  try {
+    jdata.validate_dims("test", "foo", "int", expected_dims);
+  } catch (const std::exception &e) {
+    FAIL();
+  }
 }
 
-
-TEST(ioJson,jsonData_array_err1) {
-  std::string txt = "{ \"foo\" : [ [ [ 11.1, 11.2, 11.3, 11.4 ], [ 12.1, 12.2, 12.3, 12.4 ], [ 13.1, 13.2, 13.3, 13.4] ],"
-    "                            [ [ 21.1, 21.2, 21.3, 21.4 ], [ 666, 22.3, 22.4 ], [ 23.1, 23.2, 23.3, 23.4] ] ] }";
-  test_exception(txt,"variable: foo, error: non-rectangular array");
+TEST(ioJson, jsonData_array_err1) {
+  std::string txt = "{ \"foo\" : [ [ [ 11.1, 11.2, 11.3, 11.4 ], [ 12.1, 12.2, "
+                    "12.3, 12.4 ], [ 13.1, 13.2, 13.3, 13.4] ],"
+                    "                            [ [ 21.1, 21.2, 21.3, 21.4 ], "
+                    "[ 666, 22.3, 22.4 ], [ 23.1, 23.2, 23.3, 23.4] ] ] }";
+  test_exception(txt, "variable: foo, error: non-rectangular array");
 }
 
-
-TEST(ioJson,jsonData_array_err2) {
-  std::string txt = "{ \"foo\" : [ [ [ 11.1, 11.2, 11.3, 11.4 ], [ 12.1, 12.2, 12.3, 12.4 ] ],"
-    "                            [ [ 21.1, 21.2, 21.3, 21.4 ], [ 666, 22.3, 22.4 ], [ 23.1, 23.2, 23.3, 23.4] ] ] }";
-  test_exception(txt,"variable: foo, error: non-rectangular array");
+TEST(ioJson, jsonData_array_err2) {
+  std::string txt = "{ \"foo\" : [ [ [ 11.1, 11.2, 11.3, 11.4 ], [ 12.1, 12.2, "
+                    "12.3, 12.4 ] ],"
+                    "                            [ [ 21.1, 21.2, 21.3, 21.4 ], "
+                    "[ 666, 22.3, 22.4 ], [ 23.1, 23.2, 23.3, 23.4] ] ] }";
+  test_exception(txt, "variable: foo, error: non-rectangular array");
 }
 
-TEST(ioJson,jsonData_array_err3) {
+TEST(ioJson, jsonData_array_err3) {
   std::string txt = "{ \"foo\" : [1, 2, 3, 4, [5], 6, 7] }";
-  test_exception(txt,"variable: foo, error: non-scalar array value");
+  test_exception(txt, "variable: foo, error: non-scalar array value");
 }
 
-TEST(ioJson,jsonData_array_err4) {
+TEST(ioJson, jsonData_array_err4) {
   std::string txt = "{ \"foo\" : [[1], 2, 3, 4, 5, 6, 7] }";
-  test_exception(txt,"variable: foo, error: non-rectangular array");
+  test_exception(txt, "variable: foo, error: non-rectangular array");
 }
 
-TEST(ioJson,jsonData_array_err5) {
+TEST(ioJson, jsonData_array_err5) {
   std::string txt = "{  \"foo\" : [1, 2, 3, 4, 5, 6, [7]] }";
-  test_exception(txt,"variable: foo, error: non-scalar array value");
+  test_exception(txt, "variable: foo, error: non-scalar array value");
 }
 
-
-TEST(ioJson,jsonData_array_err6) {
-  std::string txt = "{ \"baz\" : [[1.0,2.0,3.0],[4.0,5.0,6]],  \"foo\" : [1, 2, 3, 4, [5], 6, 7] }";
-  test_exception(txt,"variable: foo, error: non-scalar array value");
+TEST(ioJson, jsonData_array_err6) {
+  std::string txt = "{ \"baz\" : [[1.0,2.0,3.0],[4.0,5.0,6]],  \"foo\" : [1, "
+                    "2, 3, 4, [5], 6, 7] }";
+  test_exception(txt, "variable: foo, error: non-scalar array value");
 }
 
-TEST(ioJson,jsonData_array_err7) {
-  std::string txt = "{ \"baz\":[[1,2],[3,4.0]],  \"foo\" : [[1], 2, 3, 4, 5, 6, 7] }";
-  test_exception(txt,"variable: foo, error: non-rectangular array");
+TEST(ioJson, jsonData_array_err7) {
+  std::string txt =
+      "{ \"baz\":[[1,2],[3,4.0]],  \"foo\" : [[1], 2, 3, 4, 5, 6, 7] }";
+  test_exception(txt, "variable: foo, error: non-rectangular array");
 }
 
-TEST(ioJson,jsonData_array_err8) {
-  std::string txt = "{  \"baz\":[1,2,\"-Inf\"], \"foo\" : [1, 2, 3, 4, 5, 6, [7]] }";
-  test_exception(txt,"variable: foo, error: non-scalar array value");
+TEST(ioJson, jsonData_array_err8) {
+  std::string txt =
+      "{  \"baz\":[1,2,\"-Inf\"], \"foo\" : [1, 2, 3, 4, 5, 6, [7]] }";
+  test_exception(txt, "variable: foo, error: non-scalar array value");
 }
 
-TEST(ioJson,jsonData_array_err9) {
+TEST(ioJson, jsonData_array_err9) {
   std::string txt = "{\"a\":1,  \"baz\":[1,2,\"-Inf\"], \"b\":2.0, "
-    "\"foo\" : [1, 2, 3, 4, 5, 6, [7]] }";
-  test_exception(txt,"variable: foo, error: non-scalar array value");
+                    "\"foo\" : [1, 2, 3, 4, 5, 6, [7]] }";
+  test_exception(txt, "variable: foo, error: non-scalar array value");
 }
 
-
-TEST(ioJson,jsonData_obj_err1) {
+TEST(ioJson, jsonData_obj_err1) {
   std::string txt = "{ \"foo\" : { \"bar\" : 1 } }";
-  test_exception(txt,"variable: foo, error: nested objects not allowed");
+  test_exception(txt, "variable: foo, error: nested objects not allowed");
 }
 
-
-TEST(ioJson,jsonData_mult_vars_err1) {
+TEST(ioJson, jsonData_mult_vars_err1) {
   std::string txt = "{ \"foo\" : 1, \"foo\" : 0.1 }";
-  test_exception(txt,"attempt to redefine variable: foo");
+  test_exception(txt, "attempt to redefine variable: foo");
 }
 
-TEST(ioJson,jsonData_mult_vars_er2) {
+TEST(ioJson, jsonData_mult_vars_er2) {
   std::string txt = "{ \"foo\" : 1.1, \"foo\" : 0.1 }";
-  test_exception(txt,"attempt to redefine variable: foo");
+  test_exception(txt, "attempt to redefine variable: foo");
 }
 
-TEST(ioJson,jsonData_mult_vars_er3) {
+TEST(ioJson, jsonData_mult_vars_er3) {
   std::string txt = "{ \"foo\" : [ 1.1, 1 ], \"foo\" : 0.1 }";
-  test_exception(txt,"attempt to redefine variable: foo");
+  test_exception(txt, "attempt to redefine variable: foo");
 }
 
-TEST(ioJson,jsonData_null_value_err) {
+TEST(ioJson, jsonData_null_value_err) {
   std::string txt = "{ \"foo\" : [ 1.1, 1, null ] }";
-  test_exception(txt,"variable: foo, error: null values not allowed");
+  test_exception(txt, "variable: foo, error: null values not allowed");
 }
 
-TEST(ioJson,jsonData_bool_value_err1) {
+TEST(ioJson, jsonData_bool_value_err1) {
   std::string txt = "{ \"foo\" : [ 1.1, 1, true ] }";
-  test_exception(txt,"variable: foo, error: boolean values not allowed");
+  test_exception(txt, "variable: foo, error: boolean values not allowed");
 }
 
-TEST(ioJson,jsonData_bool_value_err2) {
+TEST(ioJson, jsonData_bool_value_err2) {
   std::string txt = "{ \"foo\" : [ 1.1, 1, false ] }";
-  test_exception(txt,"variable: foo, error: boolean values not allowed");
+  test_exception(txt, "variable: foo, error: boolean values not allowed");
 }
 
-
-TEST(ioJson,jsonData_string_value_err) {
+TEST(ioJson, jsonData_string_value_err) {
   std::string txt = "{ \"foo\" : [ 1.1, 1, \"abc\" ] }";
-  test_exception(txt,"variable: foo, error: string values not allowed");
+  test_exception(txt, "variable: foo, error: string values not allowed");
 }
 
-TEST(ioJson,jsonData_not_an_obj) {
+TEST(ioJson, jsonData_not_an_obj) {
   std::string txt = "[ 1 ]";
-  test_exception(txt,"expecting JSON object, found array");
+  test_exception(txt, "expecting JSON object, found array");
 }
 
-// don't allow array of objects 
-TEST(ioJson,jsonData_err_array_of_obj) {
+// don't allow array of objects
+TEST(ioJson, jsonData_err_array_of_obj) {
   std::string txt = "[ { \"foo\": 1}, { \"bar\": 1 } ]";
-  test_exception(txt,"expecting JSON object, found array");
+  test_exception(txt, "expecting JSON object, found array");
 }
 
-TEST(ioJson,jsonData_parse_mult_objects_err) {
+TEST(ioJson, jsonData_parse_mult_objects_err) {
   std::string txt = "{ \"foo\": 1}{ \"bar\": 1 }";
-  test_exception(txt,"Error in JSON parsing \nat offset 11: \nThe document root must not be followed by other values.\n");
+  test_exception(txt, "Error in JSON parsing \nat offset 11: \nThe document "
+                      "root must not be followed by other values.\n");
 }
 
-TEST(ioJson,jsonData_parse_empty_obj) {
+TEST(ioJson, jsonData_parse_empty_obj) {
   std::string txt = "{}";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<std::string> var_names;
   jdata.names_r(var_names);
-  EXPECT_EQ(0U,var_names.size());
+  EXPECT_EQ(0U, var_names.size());
   jdata.names_i(var_names);
-  EXPECT_EQ(0U,var_names.size());
+  EXPECT_EQ(0U, var_names.size());
 }
 
 // R: strings "NaN", "Inf", "-Inf"
-TEST(ioJson,jsonData_NaN_str) {
+TEST(ioJson, jsonData_NaN_str) {
   std::string txt = "{ \"foo\" : \"NaN\" }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
@@ -453,29 +484,29 @@ TEST(ioJson,jsonData_NaN_str) {
   EXPECT_TRUE(boost::math::isnan(vals[0]));
 }
 
-TEST(ioJson,jsonData_unsigned_Inf_str) {
+TEST(ioJson, jsonData_unsigned_Inf_str) {
   std::string txt = "{ \"foo\" : \"Inf\" }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
-  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals_r, expected_dims);
 }
 
-TEST(ioJson,jsonData_signed_neg_Inf_str) {
+TEST(ioJson, jsonData_signed_neg_Inf_str) {
   std::string txt = "{ \"foo\" : \"-Inf\" }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
-  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals_r, expected_dims);
 }
 
 // python/js:  Infinity, -Infinity, NaN
 // test both bare and strings
-TEST(ioJson,jsonData_NaN_bare) {
+TEST(ioJson, jsonData_NaN_bare) {
   std::string txt = "{ \"foo\" : NaN }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
@@ -483,62 +514,62 @@ TEST(ioJson,jsonData_NaN_bare) {
   EXPECT_TRUE(boost::math::isnan(vals[0]));
 }
 
-TEST(ioJson,jsonData_unsigned_Infinity_bare) {
+TEST(ioJson, jsonData_unsigned_Infinity_bare) {
   std::string txt = "{ \"foo\" : Infinity }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
-  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals_r, expected_dims);
 }
 
-TEST(ioJson,jsonData_pos_Infinity_bare) {
+TEST(ioJson, jsonData_pos_Infinity_bare) {
   std::string txt = "{ \"foo\" : Infinity }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
-  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals_r, expected_dims);
 }
 
-TEST(ioJson,jsonData_signed_neg_Infinity_bare) {
+TEST(ioJson, jsonData_signed_neg_Infinity_bare) {
   std::string txt = "{ \"foo\" : -Infinity }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
-  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals_r, expected_dims);
 }
 
-TEST(ioJson,jsonData_unsigned_Infinity_str) {
+TEST(ioJson, jsonData_unsigned_Infinity_str) {
   std::string txt = "{ \"foo\" : \"Infinity\" }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
-  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals_r, expected_dims);
 }
 
-TEST(ioJson,jsonData_pos_Infinity_str) {
+TEST(ioJson, jsonData_pos_Infinity_str) {
   std::string txt = "{ \"foo\" : \"Infinity\" }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
-  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals_r, expected_dims);
 }
 
-TEST(ioJson,jsonData_signed_neg_Infinity_str) {
+TEST(ioJson, jsonData_signed_neg_Infinity_str) {
   std::string txt = "{ \"foo\" : \"-Infinity\" }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<double> expected_vals_r;
   expected_vals_r.push_back(-std::numeric_limits<double>::infinity());
   std::vector<size_t> expected_dims;
-  test_real_var(jdata,txt,"foo",expected_vals_r,expected_dims);
+  test_real_var(jdata, txt, "foo", expected_vals_r, expected_dims);
 }

--- a/src/test/interface/io/json/json_data_test.cpp
+++ b/src/test/interface/io/json/json_data_test.cpp
@@ -277,8 +277,19 @@ TEST(ioJson,jsonData_empty_1D_array) {
   test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
 }
 
-TEST(ioJson,jsonData_empty_2D_array) {
-  std::string txt = "{ \"foo\" : [[]] }";
+TEST(ioJson,jsonData_empty_2D_array_0_0) {
+  std::string txt = "{ \"foo\" : [] }";
+  std::stringstream in(txt);
+  cmdstan::json::json_data jdata(in);
+  std::vector<int> expected_vals_i;
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(0);
+  expected_dims.push_back(0);
+  test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
+}
+
+TEST(ioJson,jsonData_empty_2D_array_1_0) {
+  std::string txt = "{ \"foo\" : [] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<int> expected_vals_i;
@@ -288,13 +299,25 @@ TEST(ioJson,jsonData_empty_2D_array) {
   test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
 }
 
-TEST(ioJson,jsonData_empty_3D_array) {
-  std::string txt = "{ \"foo\" : [[[]]] }";
+TEST(ioJson,jsonData_empty_3D_array_0_0_0) {
+  std::string txt = "{ \"foo\" : [] }";
   std::stringstream in(txt);
   cmdstan::json::json_data jdata(in);
   std::vector<int> expected_vals_i;
   std::vector<size_t> expected_dims;
-  expected_dims.push_back(1);
+  expected_dims.push_back(0);
+  expected_dims.push_back(0);
+  expected_dims.push_back(0);
+  test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);
+}
+
+TEST(ioJson,jsonData_empty_3D_array_2_1_0) {
+  std::string txt = "{ \"foo\" : [] }";
+  std::stringstream in(txt);
+  cmdstan::json::json_data jdata(in);
+  std::vector<int> expected_vals_i;
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(2);
   expected_dims.push_back(1);
   expected_dims.push_back(0);
   test_int_var(jdata,txt,"foo",expected_vals_i,expected_dims);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Given that changes to class `stan::io::var_context` in branch https://github.com/stan-dev/stan/tree/feature/2687-var-context-validate-dims, PR https://github.com/stan-dev/stan/pull/2869 have been merged into Stan, this PR adds implementation of `var_context` virtual function `validate_dims` to  class `cmdstan::json`.

#### Intended Effect:
Given Stan program with data block:

```
data { 
  int d;
  vector[d] d_v1;
  vector[d] d_v2;
  row_vector[d] d_rv1;
  row_vector[d] d_rv2;
  vector[3] d_v_ar[d];
  row_vector[3] d_rv_ar[d];
  matrix[0, 3] d_m;
} 
```

accept as valid JSON input:

```
{
    "d" : 0,
    "d_v1" : [],
    "d_v2" : [],
    "d_rv1" : [],
    "d_rv2" : [],
    "d_v_ar" : [],
    "d_rv_ar" : [],
    "d_m" : [],
    "d_m_ar" : []
}
```

#### How to Verify:
unit tests

#### Side Effects:
none

#### Documentation:
added subsection to CmdStan manual illustrating JSON notation for arrays where any dimension is size 0.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
