### PR TITLE
Setting tbb path through with_env on windows tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def runTests(String prefix = "") {
 }
 
 def runWinTests(String prefix = "") {
-    withEnv(['PATH+TBB=' + ${WORKSPACE} + '/stan/lib/stan_math/lib/tbb']) {
+    withEnv(["PATH+TBB=${WORKSPACE}/stan/lib/stan_math/lib/tbb"]) {
        bat "echo %PATH%"
        bat "mingw32-make -j${env.PARALLEL} build"
        bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,8 +15,7 @@ def runTests(String prefix = "") {
 }
 
 def runWinTests(String prefix = "") {
-    withEnv(['PATH+TBB=${WORKSPACE}\\stan\\lib\\stan_math\\lib\\tbb']) {
-       bat "echo ${WORKSPACE}"
+    withEnv(['PATH+TBB=.\\stan\\lib\\stan_math\\lib\\tbb']) {
        bat "echo %PATH%"
        bat "mingw32-make -j${env.PARALLEL} build"
        bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,9 @@ def runTests(String prefix = "") {
 }
 
 def runWinTests(String prefix = "") {
-    withEnv(['PATH+TBB=./stan/lib/stan_math/lib/tbb']) {
+    withEnv(['PATH+TBB=${WORKSPACE}\\stan\\lib\\stan_math\\lib\\tbb']) {
+       bat "echo ${WORKSPACE}"
+       bat "echo ${PWD}"
        bat "echo %PATH%"
        bat "mingw32-make -j${env.PARALLEL} build"
        bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,8 +15,9 @@ def runTests(String prefix = "") {
 }
 
 def runWinTests(String prefix = "") {
-    withEnv(['PATH+TBB=.\\stan\\lib\\stan_math\\lib\\tbb']) {
+    withEnv(['PATH+TBB=./stan/lib/stan_math/lib/tbb']) {
        bat "echo %PATH%"
+       bat "echo $PATH"
        bat "mingw32-make -j${env.PARALLEL} build"
        bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ def runTests(String prefix = "") {
 
 def runWinTests(String prefix = "") {
     withEnv(['PATH+TBB=./stan/lib/stan_math/lib/tbb']) {
+       bat "echo %PATH%"
        bat "mingw32-make -j${env.PARALLEL} build"
        bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def runTests(String prefix = "") {
 }
 
 def runWinTests(String prefix = "") {
-    withEnv(["PATH+TBB=${WORKSPACE}/stan/lib/stan_math/lib/tbb"]) {
+    withEnv(["PATH+TBB=${WORKSPACE}\\stan\\lib\\stan_math\\lib\\tbb"]) {
        bat "echo %PATH%"
        bat "mingw32-make -j${env.PARALLEL} build"
        bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@ def runTests(String prefix = "") {
 def runWinTests(String prefix = "") {
     withEnv(['PATH+TBB=${WORKSPACE}\\stan\\lib\\stan_math\\lib\\tbb']) {
        bat "echo ${WORKSPACE}"
-       bat "echo ${PWD}"
        bat "echo %PATH%"
        bat "mingw32-make -j${env.PARALLEL} build"
        bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def runTests(String prefix = "") {
 }
 
 def runWinTests(String prefix = "") {
-    withEnv(['PATH+TBB=./stan/lib/stan_math/lib/tbb']) {
+    withEnv(['PATH+TBB=' + ${WORKSPACE} + '/stan/lib/stan_math/lib/tbb']) {
        bat "echo %PATH%"
        bat "echo $PATH"
        bat "mingw32-make -j${env.PARALLEL} build"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,9 +15,10 @@ def runTests(String prefix = "") {
 }
 
 def runWinTests(String prefix = "") {
-    """ mingw32-make -j${env.PARALLEL} build
-     ${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface
-    """
+    withEnv(['PATH+TBB=./stan/lib/stan_math/lib/tbb']) {
+       bat "mingw32-make -j${env.PARALLEL} build"
+       bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"
+    }
 }
 
 def deleteDirWin() {
@@ -64,7 +65,7 @@ pipeline {
                     agent { label 'windows' }
                     steps {
                         setupCXX()
-                        bat runWinTests()
+                        runWinTests()
                     }
                     post {
                         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@ def runTests(String prefix = "") {
 def runWinTests(String prefix = "") {
     withEnv(['PATH+TBB=' + ${WORKSPACE} + '/stan/lib/stan_math/lib/tbb']) {
        bat "echo %PATH%"
-       bat "echo $PATH"
        bat "mingw32-make -j${env.PARALLEL} build"
        bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"
     }


### PR DESCRIPTION
This pull request is changing Jenkinsfile to use `with_env` and set `tbb` properly in path on windows when running tests.

Issue reported [here](https://discourse.mc-stan.org/t/jenkins-updates-issues-requests/12426/4?u=serban-nicusor)