### PR TITLE
Fix include paths after Stan Math flattening

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -52,9 +52,9 @@
 #include <stan/math/prim/core/init_threadpool_tbb.hpp>
 
 #ifdef STAN_MPI
-#include <stan/math/prim/arr/functor/mpi_cluster.hpp>
-#include <stan/math/prim/arr/functor/mpi_command.hpp>
-#include <stan/math/prim/arr/functor/mpi_distributed_apply.hpp>
+#include <stan/math/prim/functor/mpi_cluster.hpp>
+#include <stan/math/prim/functor/mpi_command.hpp>
+#include <stan/math/prim/functor/mpi_distributed_apply.hpp>
 #endif
 
 // forward declaration for function defined in another translation unit


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Stan Math PR https://github.com/stan-dev/math/pull/1576 will remove the `scal, mat, arr` folders for the `/functor` folder. This PR fixes the includes from `/functor` in Cmdstan.

This PR should not be merged before the Stan Math PR gets in.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
