### PR TITLE
Fix includes for Stan Math /prim flatten

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -40,7 +40,7 @@
 #include <stan/services/experimental/advi/fullrank.hpp>
 #include <stan/services/experimental/advi/meanfield.hpp>
 #include <stan/math/opencl/opencl_context.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <fstream>
 #include <sstream>

--- a/src/test/interface/mpi_test.cpp
+++ b/src/test/interface/mpi_test.cpp
@@ -2,7 +2,7 @@
 
 #include <cmdstan/command.hpp>
 #include <gtest/gtest.h>
-#include <stan/math/prim/arr.hpp>
+#include <stan/math/prim.hpp>
 #include <test/test-models/proper.hpp>
 
 TEST(StanUiCommand, mpi_ready) {


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:

https://github.com/stan-dev/math/pull/1606 will remove mat, arr and scal from the Stan Math's /prim folder. This PR fixes one include in the Cmdstan repo.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
