### PR TITLE
Fix the threading info output

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -134,13 +134,15 @@ namespace cmdstan {
     info();
   
 #ifdef STAN_THREADS
-#ifndef STAN_MPI
     std::stringstream msg_threads;
+#ifndef STAN_MPI
     msg_threads << "Threading is enabled. map_rect will run with at most ";
+#else
+    msg_threads << "MPI and threading is enabled. Nested map_rect will run with at most ";
+#endif
     msg_threads << stan::math::internal::get_num_threads();
     msg_threads << " thread(s)." << std::endl;
     info(msg_threads.str());
-#endif
 #endif
 
 #ifdef STAN_OPENCL

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -134,22 +134,23 @@ namespace cmdstan {
     info();
   
 #ifdef STAN_THREADS
+#ifndef STAN_MPI
     std::stringstream msg_threads;
-    msg_threads << "STAN_THREADS is enabled. map_rect will run with at most ";
+    msg_threads << "Threading is enabled. map_rect will run with at most ";
     msg_threads << stan::math::internal::get_num_threads();
     msg_threads << " thread(s)." << std::endl;
     info(msg_threads.str());
 #endif
+#endif
 
 #ifdef STAN_OPENCL
-    
     std::stringstream msg_opencl;
     if((stan::math::opencl_context.platform().size() > 0) && (stan::math::opencl_context.device().size() > 0)) {
       msg_opencl << "STAN_OPENCL is enabled. OpenCL supported functions will use:" << std::endl;
-      msg_opencl << "Platform: " << stan::math::opencl_context.platform()[0].getInfo<CL_PLATFORM_NAME>() << std::endl;    
+      msg_opencl << "Platform: " << stan::math::opencl_context.platform()[0].getInfo<CL_PLATFORM_NAME>() << std::endl;
       msg_opencl << "Device: " << stan::math::opencl_context.device()[0].getInfo<CL_DEVICE_NAME>();
       info(msg_opencl.str());
-    }    
+    }
 #endif
 
     stan::callbacks::writer init_writer;


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Addresses a part of #793, to handle the case of when both MPI and STAN_THREADS are used. After the release this will be refactored.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
