### PR TITLE
Feature/makefile stanc3 release

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -23,8 +23,8 @@ else
   $(error $n Can't detect OS properly. $n This will impede automatically downloading the correct stanc. $n Please visit https://github.com/stan-dev/stanc3/releases and download a stanc binary for your OS and place it in ./bin/stanc)
 endif
 
+# bin/stanc build rules - requires stan, stan_math submodules in place
 ifeq ($(CMDSTAN_SUBMODULES),1)
-# bin/stanc build rules
 ifneq ($(STANC2),)
 bin/stanc$(EXE) : O = $(O_STANC)
 bin/stanc$(EXE) : CPPFLAGS_MPI =
@@ -49,11 +49,10 @@ bin/stanc$(EXE) :
 else ifeq ($(OS_TAG),windows)
 bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
-https://github.com/stan-dev/stan/releases/latest
-	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/latest/$(OS_TAG)-stanc -o bin/stanc$(EXE)")
+	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE)")
 else
 bin/stanc$(EXE) :
-	curl -L https://github.com/stan-dev/stanc3/releases/download/latest/$(OS_TAG)-stanc -o bin/stanc
+	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc
 	chmod +x bin/stanc
 endif
 
@@ -75,7 +74,8 @@ $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP)) : DEPTARGETS = -MT $(p
 ifneq ($(filter bin/stanc$(EXE) bin/stan/libstanc.a $(STANC_TEMPLATE_INSTANTIATION),$(MAKECMDGOALS)),)
 -include $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP))
 endif
+# end libstanc build rules
 
-# end bin/stanc build rules
 endif
+# end bin/stanc build rules
 

--- a/make/stanc
+++ b/make/stanc
@@ -25,7 +25,7 @@ endif
 
 ifeq ($(CMDSTAN_SUBMODULES),1)
 # bin/stanc build rules
-ifneq (,$(STANC2))
+ifneq ($(STANC2),)
 bin/stanc$(EXE) : O = $(O_STANC)
 bin/stanc$(EXE) : CPPFLAGS_MPI =
 bin/stanc$(EXE) : LDFLAGS_MPI =

--- a/make/stanc
+++ b/make/stanc
@@ -1,13 +1,13 @@
 ################################################################################
 # stanc build rules
 
-# if nothing was set to $(OS) that means that the Stan Math submodule is missing
 # used to creat breaks in error messages
 define n
 
 
 endef
 
+# if nothing was set to $(OS) that means that the Stan Math submodule is missing
 OS ?= missing-submodules
 CMDSTAN_SUBMODULES = 1
 
@@ -24,24 +24,40 @@ else
 endif
 
 ifeq ($(CMDSTAN_SUBMODULES),1)
-ifeq ($(STANC3),)
-bin/stanc$(EXE) :
+# bin/stanc build rules
+ifneq (,$(STANC2))
+bin/stanc$(EXE) : O = $(O_STANC)
+bin/stanc$(EXE) : CPPFLAGS_MPI =
+bin/stanc$(EXE) : LDFLAGS_MPI =
+bin/stanc$(EXE) : LDLIBS_MPI =
+bin/stanc$(EXE) : bin/cmdstan/libstanc.a
+bin/stanc$(EXE) : bin/cmdstan/stanc.o
 	@mkdir -p $(dir $@)
-ifeq ($(OS_TAG),windows)
-	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE)")
-else
-	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc
-	chmod +x bin/stanc
-endif
-else
+	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
+
+else ifneq ($(STANC3),)
 bin/stanc$(EXE) : $(shell find $(STANC3)/src/ -type f -name '*.ml*') $(STANC#)
 	@mkdir -p $(dir $@)
 	cd $(STANC3) && echo "--- Rebuilding stanc ---\n" && dune build @install
 	cp $(STANC3)/_build/default/src/stanc/stanc.exe $@
+
+else ifneq (,$(wildcard bin/$(OS_TAG)-stanc))
+bin/stanc$(EXE) :
+	cp bin/$(OS_TAG)-stanc) bin/stanc$(EXE)
+	chmod +x bin/stanc
+
+else ifeq ($(OS_TAG),windows)
+bin/stanc$(EXE) :
+	@mkdir -p $(dir $@)
+https://github.com/stan-dev/stan/releases/latest
+	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/latest/$(OS_TAG)-stanc -o bin/stanc$(EXE)")
+else
+bin/stanc$(EXE) :
+	curl -L https://github.com/stan-dev/stanc3/releases/download/latest/$(OS_TAG)-stanc -o bin/stanc
+	chmod +x bin/stanc
 endif
 
 # libstanc build rules
-# just used by cmdstan tests and should soon be replaced with tests based on stanc$(EXE)
 STANC_TEMPLATE_INSTANTIATION_CPP := $(shell find $(STAN)src/stan/lang -type f -name '*_inst.cpp') $(shell find $(STAN)src/stan/lang -type f -name '*_def.cpp')
 STANC_TEMPLATE_INSTANTIATION := $(STANC_TEMPLATE_INSTANTIATION_CPP:$(STAN)src/stan/%.cpp=bin/cmdstan/%.o)
 
@@ -59,4 +75,7 @@ $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP)) : DEPTARGETS = -MT $(p
 ifneq ($(filter bin/stanc$(EXE) bin/stan/libstanc.a $(STANC_TEMPLATE_INSTANTIATION),$(MAKECMDGOALS)),)
 -include $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP))
 endif
+
+# end bin/stanc build rules
 endif
+

--- a/makefile
+++ b/makefile
@@ -225,9 +225,10 @@ clean-manual:
 	cd src/docs/cmdstan-guide; $(RM) *.brf *.aux *.bbl *.blg *.log *.toc *.pdf *.out *.idx *.ilg *.ind *.cb *.cb2 *.upa
 
 clean-all: clean clean-deps clean-libraries clean-manual
-	$(RM) -r bin
+	$(RM) bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE)
 	$(RM) -r $(CMDSTAN_MAIN_O)
 	$(RM) $(wildcard $(STAN)src/stan/model/model_header.hpp.gch)
+
 
 clean-program:
 ifndef STANPROG


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Change makefile logic to build `bin/stanc`:

- makefile variable `STANC2`, if set, builds old C++ compiler
- release tarball contains set of platform-specific stanc3 binaries; if present, copy to appropriate OS verson to `bin/stanc`
- makefile variable `STANC3`, if set, builds from local stanc3 repo
- otherwise, download appropriate platform-specific stanc3 binaries release.

#### Intended Effect:
For installation via release tarball , remove need for further downloads.

#### How to Verify:
Use `make -n` - test targets `build` and `bin/stanc`

#### Side Effects:

#### Documentation:
In progress

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Coumbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
