### PR TITLE
fix missing $(exe) in  bin/windows-stanc copy

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -44,7 +44,7 @@ bin/stanc$(EXE) : $(shell find $(STANC3)/src/ -type f -name '*.ml*') $(STANC#)
 else ifneq (,$(wildcard bin/$(OS_TAG)-stanc))
 bin/stanc$(EXE) :
 	cp bin/$(OS_TAG)-stanc bin/stanc$(EXE)
-	chmod +x bin/stanc
+	chmod +x bin/stanc$(EXE)
 
 else ifeq ($(OS_TAG),windows)
 bin/stanc$(EXE) :
@@ -53,8 +53,8 @@ bin/stanc$(EXE) :
 else
 bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
-	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc
-	chmod +x bin/stanc
+	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE)
+	chmod +x bin/stanc$(EXE)
 endif
 
 # libstanc build rules


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Adds missing $(EXE) to the makefiles that causes issues on Windows if the release tarball has bin/windows-stanc.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
