### PR TITLE
Display and write actual random seed value

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -127,6 +127,7 @@ namespace cmdstan {
     unsigned int random_seed;
     if (random_arg->is_default()) {
       random_seed = (boost::posix_time::microsec_clock::universal_time() - boost::posix_time::ptime(boost::posix_time::min_date_time)).total_milliseconds();
+      random_arg->set_value(random_seed);
     } else {
       random_seed = static_cast<unsigned int>(random_arg->value());
     }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes #803 by overwriting the default random seed with the actual pseudo-random value that is used.  There are no changes for when the random seed is not -1.

This also adds a test that will prevent from this change going unnoticed again.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
