### PR TITLE
Bugfix/make clean-all does not clean everything

### DIFF
--- a/makefile
+++ b/makefile
@@ -225,7 +225,7 @@ clean-manual:
 
 clean-all: clean clean-deps clean-libraries clean-manual
 	$(RM) bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE)
-	$(RM) -r $(CMDSTAN_MAIN_O)
+	$(RM) -r $(CMDSTAN_MAIN_O) bin/cmdstan
 	$(RM) $(wildcard $(STAN)src/stan/model/model_header.hpp.gch)
 
 

--- a/makefile
+++ b/makefile
@@ -227,6 +227,7 @@ clean-all: clean clean-deps clean-libraries clean-manual
 	$(RM) bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE)
 	$(RM) -r $(CMDSTAN_MAIN_O) bin/cmdstan
 	$(RM) $(wildcard $(STAN)src/stan/model/model_header.hpp.gch)
+	$(RM) examples/bernoulli/bernoulli$(EXE) examples/bernoulli/bernoulli.o examples/bernoulli/bernoulli.d examples/bernoulli/bernoulli.hpp
 
 
 clean-program:


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes #815 by removing bin/cmdstan entirely on `make clean-all`. This way we ensure everything is cleaned even if STANC2 is used.

It also cleans the files that are built if someone builds the example bernoulli model.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
