### PR TITLE
Run CI/CD only on Source Code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,8 @@ pipeline {
                         #!/bin/bash
                         for i in \$SCPATHS;
                         do
-                            differences=`git diff \${GIT_COMMIT} develop -- \$i`
+                            commit_hash=`git rev-parse HEAD`
+                            differences=`git diff \${commit_hash} develop -- \$i`
                             if [ -n "\$differences" ]
                             then
                                 echo "\$differences"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
                         #!/bin/bash
                         for i in \$SCPATHS;
                         do
-                            differences=`git diff ${GIT_COMMIT} develop -- \$i`
+                            differences=`git diff \${GIT_COMMIT} develop -- \$i`
                             if [ -n "\$differences" ]
                             then
                                 echo "\$differences"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,12 +79,12 @@ pipeline {
                 script {         
 
                     def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)
-                    sh(script: "git pull && git checkout develop", returnStdout: false)
+                    sh(script: "git pull && git checkout ${CHANGE_TARGET}", returnStdout: false)
 
                     def bashScript = """
                         for i in ${scPaths};
                         do
-                            git diff ${commitHash}develop -- \$i
+                            git diff ${commitHash} ${CHANGE_TARGET} -- \$i
                         done
                     """
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
                         #!/bin/bash
                         for i in \$SCPATHS;
                         do
-                            differences=`git diff \$i`
+                            differences=`git diff ${GIT_COMMIT} develop -- \$i`
                             if [ -n "\$differences" ]
                             then
                                 echo "\$differences"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ def deleteDirWin() {
 def sourceCodePaths(){
     // These paths will be passed to git diff
     // If there are changes to them, CI/CD will continue else skip
-    def paths = ['src', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile']
+    def paths = ['src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile']
     def bashArray = ""
 
     for(path in paths){


### PR DESCRIPTION
Jenkins will now skip ci/cd pipeline if source code file paths defied in the Jenkinsfile do not have changes.

#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
