### PR TITLE
Bugfix Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,8 @@ pipeline {
             post { always { deleteDir() }}
         }
         stage('Verify changes') {
-            script {         
+            steps {
+                script {         
 
                     def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)
                     def changeTarget = ""
@@ -116,6 +117,7 @@ pipeline {
                         println "There aren't any differences in the source code, CI/CD will not run."
                         skipRemainingStages = true
                     }
+                }
             }
         }
         stage('Parallel tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,8 @@ pipeline {
             steps {
                 script {         
 
-                    unstash 'CmdStanSetup'
+                    retry(3) { checkout scm }
+                    sh 'git clean -xffd'
 
                     def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)
                     def changeTarget = ""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,7 @@ pipeline {
         }
         stage('Verify changes') {
             steps {
+                agent { label 'linux' }
                 script {         
 
                     def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)
@@ -155,7 +156,7 @@ pipeline {
                 }
 
                 stage('Linux interface tests with MPI') {
-                    agent {label 'linux && mpi'}
+                    agent { label 'linux && mpi'}
                     steps {
                         setupCXX("${MPICXX}")
                         sh "echo STAN_MPI=true >> make/local"
@@ -185,7 +186,7 @@ pipeline {
                 }
 
                 stage('Mac interface tests') {
-                    agent {label 'osx'}
+                    agent { label 'osx'}
                     steps {
                         setupCXX()
                         sh runTests("./")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,9 +79,18 @@ pipeline {
                 script {         
 
                     def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)
-                    def changeTarget = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
+                    def changeTarget = ""
 
-                    sh(script: "git pull && git checkout ${changeTarget}", returnStdout: false)
+                    if (env.CHANGE_TARGET) {
+                        println "This build is a PR, checking out target branch to compare changes."
+                        changeTarget = env.CHANGE_TARGET
+                        sh(script: "git pull && git checkout ${changeTarget}", returnStdout: false)
+                    }
+                    else{
+                        println "This build is not PR, checking out current branch and extract HEAD^1 commit to compare changes."
+                        sh(script: "git pull && git checkout ${env.BRANCH_NAME}", returnStdout: false)
+                        changeTarget = sh(script: "git rev-parse HEAD^1 | tr '\\n' ' '", returnStdout: true)
+                    }
 
                     println "Comparing differences between current ${commitHash} and target ${changeTarget}"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,8 +79,8 @@ pipeline {
             post { always { deleteDir() }}
         }
         stage('Verify changes') {
+            agent { label 'linux' }
             steps {
-                agent { label 'linux' }
                 script {         
 
                     def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,12 +79,16 @@ pipeline {
                 script {         
 
                     def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)
-                    sh(script: "git pull && git checkout ${env.CHANGE_TARGET}", returnStdout: false)
+                    def changeTarget = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
+
+                    sh(script: "git pull && git checkout ${changeTarget}", returnStdout: false)
+
+                    println "Comparing differences between current ${commitHash} and target ${changeTarget}"
 
                     def bashScript = """
                         for i in ${env.scPaths};
                         do
-                            git diff ${commitHash} ${env.CHANGE_TARGET} -- \$i
+                            git diff ${commitHash} ${changeTarget} -- \$i
                         done
                     """
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,12 +79,12 @@ pipeline {
                 script {         
 
                     def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)
-                    sh(script: "git pull && git checkout ${CHANGE_TARGET}", returnStdout: false)
+                    sh(script: "git pull && git checkout ${env.CHANGE_TARGET}", returnStdout: false)
 
                     def bashScript = """
-                        for i in ${scPaths};
+                        for i in ${env.scPaths};
                         do
-                            git diff ${commitHash} ${CHANGE_TARGET} -- \$i
+                            git diff ${commitHash} ${env.CHANGE_TARGET} -- \$i
                         done
                     """
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,8 +75,11 @@ pipeline {
                 }
 
                 stash 'CmdStanSetup'
-
-                script {         
+            }
+            post { always { deleteDir() }}
+        }
+        stage('Verify changes') {
+            script {         
 
                     def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)
                     def changeTarget = ""
@@ -113,10 +116,7 @@ pipeline {
                         println "There aren't any differences in the source code, CI/CD will not run."
                         skipRemainingStages = true
                     }
-                }
-
             }
-            post { always { deleteDir() }}
         }
         stage('Parallel tests') {
             when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,6 +83,8 @@ pipeline {
             steps {
                 script {         
 
+                    unstash 'CmdStanSetup'
+
                     def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)
                     def changeTarget = ""
 


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:

When the build is not a PR, Jenkins would compare the changes with the same branch resulting in 0 changes. This is because on a merge when comparing current commit with develop, develop already contains the commit.
Jenkins will now use HEAD^1 commit to see what changed since last commit.

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
