### PR TITLE
Add info on threading, mpi and opencl to the csv and stdout

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -8,6 +8,8 @@
 #include <cmdstan/arguments/arg_output.hpp>
 #include <cmdstan/arguments/arg_random.hpp>
 #include <cmdstan/write_model.hpp>
+#include <cmdstan/write_opencl_device.hpp>
+#include <cmdstan/write_parallel_info.hpp>
 #include <cmdstan/write_stan.hpp>
 #include <cmdstan/io/json/json_data.hpp>
 #include <stan/callbacks/interrupt.hpp>
@@ -39,7 +41,6 @@
 #include <stan/services/sample/standalone_gqs.hpp>
 #include <stan/services/experimental/advi/fullrank.hpp>
 #include <stan/services/experimental/advi/meanfield.hpp>
-#include <stan/math/opencl/opencl_context.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <fstream>
@@ -132,30 +133,10 @@ namespace cmdstan {
       random_seed = static_cast<unsigned int>(random_arg->value());
     }
     parser.print(info);
+    write_parallel_info(info);
+    write_opencl_device(info);
     info();
   
-#ifdef STAN_THREADS
-    std::stringstream msg_threads;
-#ifndef STAN_MPI
-    msg_threads << "Threading is enabled. map_rect will run with at most ";
-#else
-    msg_threads << "MPI and threading is enabled. Nested map_rect will run with at most ";
-#endif
-    msg_threads << stan::math::internal::get_num_threads();
-    msg_threads << " thread(s)." << std::endl;
-    info(msg_threads.str());
-#endif
-
-#ifdef STAN_OPENCL
-    std::stringstream msg_opencl;
-    if((stan::math::opencl_context.platform().size() > 0) && (stan::math::opencl_context.device().size() > 0)) {
-      msg_opencl << "STAN_OPENCL is enabled. OpenCL supported functions will use:" << std::endl;
-      msg_opencl << "Platform: " << stan::math::opencl_context.platform()[0].getInfo<CL_PLATFORM_NAME>() << std::endl;
-      msg_opencl << "Device: " << stan::math::opencl_context.device()[0].getInfo<CL_DEVICE_NAME>();
-      info(msg_opencl.str());
-    }
-#endif
-
     stan::callbacks::writer init_writer;
     stan::callbacks::interrupt interrupt;
 
@@ -181,6 +162,8 @@ namespace cmdstan {
     write_stan(sample_writer);
     write_model(sample_writer, model.model_name());
     parser.print(sample_writer);
+    write_parallel_info(sample_writer);
+    write_opencl_device(sample_writer);
 
     write_stan(diagnostic_writer);
     write_model(diagnostic_writer, model.model_name());

--- a/src/cmdstan/write_opencl_device.hpp
+++ b/src/cmdstan/write_opencl_device.hpp
@@ -1,0 +1,26 @@
+#ifndef CMDSTAN_WRITE_OPENCL_DEVICE_HPP
+#define CMDSTAN_WRITE_OPENCL_DEVICE_HPP
+
+#include <stan/callbacks/writer.hpp>
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/opencl_context.hpp>
+#endif
+#include <string>
+
+namespace cmdstan {
+
+  void write_opencl_device(stan::callbacks::writer& writer) {
+#ifdef STAN_OPENCL    
+    if((stan::math::opencl_context.platform().size() > 0) && (stan::math::opencl_context.device().size() > 0)) {
+        std::stringstream msg_opencl_platform;
+        msg_opencl_platform << "opencl_platform = " << stan::math::opencl_context.platform()[0].getInfo<CL_PLATFORM_NAME>();
+        writer(msg_opencl_platform.str());
+        std::stringstream msg_opencl_device;
+        msg_opencl_device << "opencl_platform = " << stan::math::opencl_context.device()[0].getInfo<CL_DEVICE_NAME>();
+        writer(msg_opencl_device.str());
+    }
+#endif
+  }
+
+}
+#endif

--- a/src/cmdstan/write_parallel_info.hpp
+++ b/src/cmdstan/write_parallel_info.hpp
@@ -1,0 +1,24 @@
+#ifndef CMDSTAN_WRITE_PARALLEL_INFO_HPP
+#define CMDSTAN_WRITE_PARALLEL_INFO_HPP
+
+#include <stan/callbacks/writer.hpp>
+#include <stan/math/prim/core/init_threadpool_tbb.hpp>
+#include <string>
+
+namespace cmdstan {
+
+  void write_parallel_info(stan::callbacks::writer& writer) {
+#ifdef STAN_MPI
+    writer("mpi_enabled = 1");
+#else
+#ifdef STAN_THREADS
+    std::stringstream msg_threads;
+    msg_threads << "num_threads = ";
+    msg_threads << stan::math::internal::get_num_threads();
+    writer(msg_threads.str());
+#endif
+#endif
+  }
+
+}
+#endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Closes #793 by adding the following info to the stdout and the csv file: 
- number of threads used (STAN_NUM_THREADS if STAN_THREADS is on and STAN_MPI isnt on)
- mpi_enabled = 1 if STAN_MPI is used
- opencl device and platform info if STAN_OPENCL is on

Examples from csv files (it displays the same info in the stdout): 
threads:
```
# output
#   file = output.csv (Default)
#   diagnostic_file =  (Default)
#   refresh = 100 (Default)
# num_threads = 4
```
opencl:
```
# output
#   file = output.csv (Default)
#   diagnostic_file =  (Default)
#   refresh = 100 (Default)
# num_threads = 4
# opencl_platform = AMD Accelerated Parallel Processing
# opencl_platform = gfx906+sram-ecc
```
MPI: 
```
# output
#   file = output.csv (Default)
#   diagnostic_file =  (Default)
#   refresh = 100 (Default)
# mpi_enabled = 1
```

It also removes the stdout info printed in 2.22.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
