### PR TITLE
Revert "Merge pull request #814 from bugfix/display_actual_random_seed"

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -128,7 +128,6 @@ namespace cmdstan {
     unsigned int random_seed;
     if (random_arg->is_default()) {
       random_seed = (boost::posix_time::microsec_clock::universal_time() - boost::posix_time::ptime(boost::posix_time::min_date_time)).total_milliseconds();
-      random_arg->set_value(random_seed);
     } else {
       random_seed = static_cast<unsigned int>(random_arg->value());
     }

--- a/src/test/interface/command_test.cpp
+++ b/src/test/interface/command_test.cpp
@@ -404,38 +404,36 @@ TEST(StanUiCommand, random_seed_specified_different) {
     + " data file=src/test/test-models/transformed_data_rng_test.init.R"
     + " output refresh=0 file=test/output.csv";
   std::string cmd_output = run_command(command).output;
-
-}
-
-TEST(StanUiCommand, stored_random_seed_is_random) {
-  std::vector<std::string> model_path;
-  model_path.push_back("src");
-  model_path.push_back("test");
-  model_path.push_back("test-models");
-  model_path.push_back("transformed_data_rng_test");
-  
-  std::string command = convert_model_path(model_path)
+  EXPECT_EQ(1, count_matches("y values:", cmd_output));
+  std::vector<std::string> lines;
+  split(lines, cmd_output, boost::is_any_of("\n"));
+  std::string random1;
+  for (std::vector<std::string>::iterator it = lines.begin() ; it != lines.end(); ++it) {
+    if (boost::starts_with(*it,"y values:")) {
+      random1.assign(*it,9,std::string::npos);
+      EXPECT_EQ(1, count_matches("[", random1));
+      EXPECT_EQ(1, count_matches("]", random1));
+      break;
+    }
+  }
+  command = convert_model_path(model_path)
     + " sample num_samples=10 num_warmup=10 init=0 "
-    + " random seed=-1 "
+    + " random seed=45678 "
     + " data file=src/test/test-models/transformed_data_rng_test.init.R"
     + " output refresh=0 file=test/output.csv";
-  std::string cmd_output = run_command(command).output;
-  stan::io::stan_csv test_csv;
-  std::stringstream out;
-  std::ifstream csv_stream;
-  csv_stream.open("test/output.csv");
-  test_csv = stan::io::stan_csv_reader::parse(csv_stream, &out);
-  csv_stream.close();
-
-  std::string cmd_output_2 = run_command(command).output;
-  stan::io::stan_csv test_csv_2;
-  std::stringstream out_2;
-  std::ifstream csv_stream_2;
-  csv_stream_2.open("test/output.csv");
-  test_csv_2 = stan::io::stan_csv_reader::parse(csv_stream_2, &out);
-  csv_stream_2.close();
-
-  EXPECT_NE(test_csv.metadata.seed, test_csv_2.metadata.seed);
+  cmd_output = run_command(command).output;
+  EXPECT_EQ(1, count_matches("y values:", cmd_output));
+  split(lines, cmd_output, boost::is_any_of("\n"));
+  std::string random2;
+  for (std::vector<std::string>::iterator it = lines.begin() ; it != lines.end(); ++it) {
+    if (boost::starts_with(*it,"y values:")) {
+      random2.assign(*it,9,std::string::npos);
+      EXPECT_EQ(1, count_matches("[", random2));
+      EXPECT_EQ(1, count_matches("]", random2));
+      break;
+    }
+  }
+  EXPECT_NE(random1,random2);
 }
 
 TEST(StanUiCommand, random_seed_fail_1) {
@@ -499,8 +497,6 @@ TEST(StanUiCommand, random_seed_fail_3) {
   run_command_output out = run_command(command);
   EXPECT_EQ(1, count_matches(expected_message, out.body));
 }
-
-
 
 TEST(StanUiCommand, json_input) {
   std::vector<std::string> model_path;


### PR DESCRIPTION
This reverts commit 662d6ef6a6712960f658f7d1bfb16fd9763f70d7, reversing
changes made to 85dd76460a234d5554868f88cc4a157629606684.

#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

My solution done in #814 turned out to be invalid. 

```cpp
int_argument* random_arg = dynamic_cast<int_argument*>(parser.arg("random")->arg("seed"));
    unsigned int random_seed;
    if (random_arg->is_default()) {
      random_seed = (boost::posix_time::microsec_clock::universal_time() - boost::posix_time::ptime(boost::posix_time::min_date_time)).total_milliseconds();
      random_arg->set_value(random_seed);

```
The random seed is unsigned int, but the solution done in #814 set the value to the argument which is a int argument (because we want to support -1 as the default value and the value used to get random seeds). And a few hours ago the random_seed has gone outside the int value range, see https://jenkins.mc-stan.org/blue/organizations/jenkins/CmdStan/activity.

Luckily, the random seed used in sampling is still random, just the printed value in stdout and csv is is now again -1, hence I am reopening #803.

Set value ignored it because it tests if the value is valid: 
```cpp
    bool set_value(const T& value) {
      if (is_valid(value)) {
        _value = value;
        return true;
      }
      return false;
    }
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
