### PR TITLE
better handling of the random value

### DIFF
--- a/src/cmdstan/arguments/arg_seed.hpp
+++ b/src/cmdstan/arguments/arg_seed.hpp
@@ -2,12 +2,14 @@
 #define CMDSTAN_ARGUMENTS_ARG_SEED_HPP
 
 #include <cmdstan/arguments/singleton_argument.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
 
 namespace cmdstan {
 
 
   class arg_seed: public int_argument {
   public:
+    unsigned int _random_value;
     arg_seed(): int_argument() {
       _name = "seed";
       _description = "Random number generator seed";
@@ -18,10 +20,27 @@ namespace cmdstan {
       _good_value = 18383;
       _bad_value = -2;
       _value = _default_value;
+      _random_value =  (boost::posix_time::microsec_clock::universal_time() - boost::posix_time::ptime(boost::posix_time::min_date_time)).total_milliseconds();
     }
 
     bool is_valid(int value) {
       return value > 0 || value == _default_value;
+    }
+
+    unsigned int random_value() {
+      if(_value == _default_value) {
+        return _random_value;
+      } else {
+        return _value;
+      }
+    }
+
+    std::string print_value() {
+      if(_value == _default_value) {
+        return boost::lexical_cast<std::string>(_random_value);
+      } else {
+        return boost::lexical_cast<std::string>(_value);
+      }
     }
   };
 

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -42,7 +42,6 @@
 #include <stan/services/experimental/advi/fullrank.hpp>
 #include <stan/services/experimental/advi/meanfield.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
@@ -124,13 +123,9 @@ namespace cmdstan {
     if (parser.help_printed())
       return err_code;
 
-    int_argument* random_arg = dynamic_cast<int_argument*>(parser.arg("random")->arg("seed"));
-    unsigned int random_seed;
-    if (random_arg->is_default()) {
-      random_seed = (boost::posix_time::microsec_clock::universal_time() - boost::posix_time::ptime(boost::posix_time::min_date_time)).total_milliseconds();
-    } else {
-      random_seed = static_cast<unsigned int>(random_arg->value());
-    }
+    arg_seed* random_arg = dynamic_cast<arg_seed*>(parser.arg("random")->arg("seed"));
+    unsigned int random_seed = random_arg->random_value();
+
     parser.print(info);
     write_parallel_info(info);
     write_opencl_device(info);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes #803 with a more general solution. This PR modifies the arg_seed class by adding `_random_value` variable.

In case of using the default value of -1,  value() would still return -1, while random_value would return the time dependant generated pseudo-random number. This circumvents the issue that we want the seed to be an unsigned int while also allowing -1 as a valid value.

The previous solution wrote the psedu-random number to directly to `value` which was a signed integer and that led to issues.

The alternative is to only use the non-negative values and stay with signed integer. But I dont think that was the intention when refactoring pseudo random generation awhile back.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
