### PR TITLE
Moved verify changes from Jenkinsfile to Shared Libraries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@
 import org.stan.Utils
 
 def utils = new org.stan.Utils()
+def skipRemainingStages = false
 
 def setupCXX(CXX = env.CXX) {
     unstash 'CmdStanSetup'
@@ -26,21 +27,6 @@ def deleteDirWin() {
     bat "attrib -r -s /s /d"
     deleteDir()
 }
-
-def sourceCodePaths(){
-    // These paths will be passed to git diff
-    // If there are changes to them, CI/CD will continue else skip
-    def paths = ['src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile']
-    def bashArray = ""
-
-    for(path in paths){
-        bashArray += path + (path != paths[paths.size() - 1] ? " " : "")
-    }
-
-    return bashArray
-}
-
-def skipRemainingStages = true
 
 pipeline {
     agent none
@@ -86,48 +72,8 @@ pipeline {
                     retry(3) { checkout scm }
                     sh 'git clean -xffd'
 
-                    def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)
-                    def changeTarget = ""
-
-                    if (env.CHANGE_TARGET) {
-                        println "This build is a PR, checking out target branch to compare changes."
-                        changeTarget = env.CHANGE_TARGET
-                        sh(script: "git pull && git checkout ${changeTarget}", returnStdout: false)
-                    }
-                    else{
-                        println "This build is not PR, checking out current branch and extract HEAD^1 commit to compare changes or develop when downstream_tests."
-                        if (env.BRANCH_NAME == "downstream_tests"){
-                            sh(script: "git checkout develop && git pull", returnStdout: false)
-                            changeTarget = sh(script: "git rev-parse HEAD^1 | tr '\\n' ' '", returnStdout: true)
-                            sh(script: "git checkout ${commitHash}", returnStdout: false)
-                        }
-                        else{
-                            sh(script: "git pull && git checkout ${env.BRANCH_NAME}", returnStdout: false)
-                            changeTarget = sh(script: "git rev-parse HEAD^1 | tr '\\n' ' '", returnStdout: true)
-                        }
-                    }
-
-                    println "Comparing differences between current ${commitHash} and target ${changeTarget}."
-
-                    def bashScript = """
-                        for i in ${env.scPaths};
-                        do
-                            git diff ${commitHash} ${changeTarget} -- \$i
-                        done
-                    """
-
-                    def differences = sh(script: bashScript, returnStdout: true)
-
-                    println differences
-
-                    if (differences?.trim()) {
-                        println "There are differences in the source code, CI/CD will run."
-                        skipRemainingStages = false
-                    }
-                    else{
-                        println "There aren't any differences in the source code, CI/CD will not run."
-                        skipRemainingStages = true
-                    }
+                    def paths = ['src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile'].join(" ")
+                    skipRemainingStages = utils.verifyChanges(paths)
                 }
             }
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,9 +31,6 @@ def deleteDirWin() {
 pipeline {
     agent none
     options { skipDefaultCheckout() }
-    environment {
-        scPaths = sourceCodePaths()
-    }
     parameters {
         string(defaultValue: '', name: 'stan_pr',
                description: "Stan PR to test against. Will check out this PR in the downstream Stan repo.")


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:

This PR removes code that was moved into the Shared Libraries while also fixing a bug reported in 
https://github.com/stan-dev/math/issues/1773

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
