### PR TITLE
Add a way to use test stanc3 binaries

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -12,6 +12,7 @@ OS ?= missing-submodules
 CMDSTAN_SUBMODULES = 1
 STANC_DL_RETRY = 5
 STANC_DL_DELAY = 10
+STANC3_TEST_BIN_URL ?=
 
 ifeq ($(OS),Windows_NT)
   OS_TAG := windows
@@ -33,7 +34,17 @@ ifneq ($(STANC3),)
 	@mkdir -p $(dir $@)
 	cd $(STANC3) && echo "--- Rebuilding stanc ---\n" && dune build @install
 	cp $(STANC3)/_build/default/src/stanc/stanc.exe $@
-
+else ifneq ($(STANC3_TEST_BIN_URL),)
+ifeq ($(OS_TAG),windows)
+    bin/stanc$(EXE) :
+	@mkdir -p $(dir $@)
+	$(shell echo "curl -L $(STANC3_TEST_BIN_URL)/bin/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)")
+else
+    bin/stanc$(EXE) :
+	@mkdir -p $(dir $@)
+	curl -L $(STANC3_TEST_BIN_URL)/bin/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
+	chmod +x bin/stanc$(EXE)
+endif
 else ifneq (,$(wildcard bin/$(OS_TAG)-stanc))
     bin/stanc$(EXE) :
 	cp bin/$(OS_TAG)-stanc bin/stanc$(EXE)


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This adds the following: 

If you add something like
```
STANC3_TEST_BIN_URL=https://jenkins.mc-stan.org/job/stanc3-test-binaries/31/artifact
```
that will download
```
$(STANC3_TEST_BIN_URL)/bin/linux-stanc
$(STANC3_TEST_BIN_URL)/bin/mac-stanc
$(STANC3_TEST_BIN_URL)/bin/windows-stanc
```

The example URL is an URL that can be used if the binaries are made with https://github.com/stan-dev/ci-scripts/blob/refactor-jenkins-docs/docs/jobs/stanc3-test-binaries.md

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
