### PR TITLE
cleanup of gnu find

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -29,7 +29,7 @@ endif
 ifeq ($(CMDSTAN_SUBMODULES),1)
 
 ifneq ($(STANC3),)
-    bin/stanc$(EXE) : $(shell find $(STANC3)/src/ -type f -name '*.ml*') $(STANC#)
+    bin/stanc$(EXE) : $(call findfiles,$(STANC3)/src/,*.ml*) $(STANC#)
 	@mkdir -p $(dir $@)
 	cd $(STANC3) && echo "--- Rebuilding stanc ---\n" && dune build @install
 	cp $(STANC3)/_build/default/src/stanc/stanc.exe $@
@@ -65,7 +65,7 @@ bin/stanc2$(EXE) : bin/cmdstan/stanc.o
 
 
 # libstanc build rules
-STANC_TEMPLATE_INSTANTIATION_CPP := $(shell find $(STAN)src/stan/lang -type f -name '*_inst.cpp') $(shell find $(STAN)src/stan/lang -type f -name '*_def.cpp')
+STANC_TEMPLATE_INSTANTIATION_CPP := $(call findfiles,$(STAN)src/stan/lang,*_inst.cpp) $(call findfiles,$(STAN)src/stan/lang,*_def.cpp)
 STANC_TEMPLATE_INSTANTIATION := $(STANC_TEMPLATE_INSTANTIATION_CPP:$(STAN)src/stan/%.cpp=bin/cmdstan/%.o)
 
 bin/cmdstan/libstanc.a : $(STANC_TEMPLATE_INSTANTIATION)

--- a/make/tests
+++ b/make/tests
@@ -44,7 +44,7 @@ endif
 # Target to verify header files within CmdStan has
 # enough include calls
 ##
-HEADER_TESTS := $(addsuffix -test,$(shell find src/cmdstan -name '*.hpp' -type f))
+HEADER_TESTS := $(addsuffix -test,$(call findfiles,src/cmdstan,*.hpp))
 
 ifeq ($(OS),Windows_NT)
   DEV_NULL = nul

--- a/makefile
+++ b/makefile
@@ -218,9 +218,9 @@ clean: clean-manual
 
 clean-deps:
 	@echo '  removing dependency files'
-	$(shell find src $(STAN)src/stan $(MATH)stan -type f -name '*.d' -exec rm {} +)
-	$(shell find src $(STAN)src/stan $(MATH)stan -type f -name '*.d.*' -exec rm {} +)
-	$(shell find src $(STAN)src/stan $(MATH)stan -type f -name '*.dSYM' -exec rm {} +)
+	$(RM) $(call findfiles,src,*.d) $(call findfiles,src/stan,*.d) $(call findfiles,$(MATH)/stan,*.d)
+	$(RM) $(call findfiles,src,*.d.*) $(call findfiles,src/stan,*.d.*) $(call findfiles,$(MATH)/stan,*.d.*)
+	$(RM) $(call findfiles,src,*.dSYM) $(call findfiles,src/stan,*.dSYM) $(call findfiles,$(MATH)/stan,*.dSYM)
 
 clean-manual:
 	$(RM) -r doc


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Continuing the work in stan-dev/math#1567 to close stan-dev/cmdstan#786

The issue is that our makefiles rely on the gnu find command that is not available on Windows.

stan-dev/math#1567 introduced a findfiles function that is a recursive version of the makefiles wildcard function.

This PR uses that in stan-dev/cmdstan

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
