### PR TITLE
Feature/845 makefile macos

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -1,7 +1,7 @@
 ################################################################################
 # stanc build rules
 
-# used to creat breaks in error messages
+# used to create breaks in error messages
 define n
 
 
@@ -10,6 +10,9 @@ endef
 # if nothing was set to $(OS) that means that the Stan Math submodule is missing
 OS ?= missing-submodules
 CMDSTAN_SUBMODULES = 1
+STANC_DL_RETRY = 5
+STANC_DL_DELAY = 10
+STANC3_TEST_BIN_URL ?=
 
 ifeq ($(OS),Windows_NT)
   OS_TAG := windows
@@ -25,51 +28,63 @@ endif
 
 # bin/stanc build rules - requires stan, stan_math submodules in place
 ifeq ($(CMDSTAN_SUBMODULES),1)
-ifneq ($(STANC2),)
-bin/stanc$(EXE) : O = $(O_STANC)
-bin/stanc$(EXE) : CPPFLAGS_MPI =
-bin/stanc$(EXE) : LDFLAGS_MPI =
-bin/stanc$(EXE) : LDLIBS_MPI =
-bin/stanc$(EXE) : bin/cmdstan/libstanc.a
-bin/stanc$(EXE) : bin/cmdstan/stanc.o
-	@mkdir -p $(dir $@)
-	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
 
-else ifneq ($(STANC3),)
-bin/stanc$(EXE) : $(shell find $(STANC3)/src/ -type f -name '*.ml*') $(STANC#)
+STANC_XATTR =
+ifeq ($(OS_TAG),mac)
+STANC_XATTR = $(shell xattr bin/mac-stanc)
+endif
+
+ifneq ($(STANC3),)
+    bin/stanc$(EXE) : $(shell find $(STANC3)/src/ -type f -name '*.ml*') $(STANC#)
 	@mkdir -p $(dir $@)
 	cd $(STANC3) && echo "--- Rebuilding stanc ---\n" && dune build @install
 	cp $(STANC3)/_build/default/src/stanc/stanc.exe $@
-
-else ifneq (,$(wildcard bin/mac-stanc))
-STANC_XATTR = $(shell xattr bin/mac-stanc)
-ifneq (,$(STANC_XATTR))
-bin/stanc$(EXE) :
-	cp bin/mac-stanc bin/stanc$(EXE)
-	chmod +x bin/stanc
-	xattr -d com.apple.quarantine bin/stanc
+else ifneq ($(STANC3_TEST_BIN_URL),)
+ifeq ($(OS_TAG),windows)
+    bin/stanc$(EXE) :
+	@mkdir -p $(dir $@)
+	$(shell echo "curl -L $(STANC3_TEST_BIN_URL)/bin/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)")
 else
-bin/stanc$(EXE) :
-	cp bin/mac-stanc bin/stanc$(EXE)
-	chmod +x bin/stanc
+    bin/stanc$(EXE) :
+	@mkdir -p $(dir $@)
+	curl -L $(STANC3_TEST_BIN_URL)/bin/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
+	chmod +x bin/stanc$(EXE)
 endif
 
-else ifneq (,$(wildcard bin/linux-stanc))
-bin/stanc$(EXE) :
+else ifneq (,$(wildcard bin/$(OS_TAG)-stanc))
+ifneq (,$(STANC_XATTR))
+	bin/stanc$(EXE) :
+		cp bin/mac-stanc bin/stanc$(EXE)
+		chmod +x bin/stanc
+		xattr -d com.apple.quarantine bin/stanc
+else
+    bin/stanc$(EXE) :
 	cp bin/$(OS_TAG)-stanc bin/stanc$(EXE)
-	chmod +x bin/stanc
+	chmod +x bin/stanc$(EXE)
+endif
 
 else ifeq ($(OS_TAG),windows)
-bin/stanc$(EXE) :
+    bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
-	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE)")
+	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)")
 else
-bin/stanc$(EXE) :
-	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc
-	chmod +x bin/stanc
+    bin/stanc$(EXE) :
+	@mkdir -p $(dir $@)
+	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
+	chmod +x bin/stanc$(EXE)
 endif
 
 
+# bin/stanc2 build rules
+bin/stanc2$(EXE) : $(TBB_TARGETS)
+bin/stanc2$(EXE) : O = $(O_STANC)
+bin/stanc2$(EXE) : CPPFLAGS_MPI =
+bin/stanc2$(EXE) : LDFLAGS_MPI =
+bin/stanc2$(EXE) : LDLIBS_MPI =
+bin/stanc2$(EXE) : bin/cmdstan/libstanc.a
+bin/stanc2$(EXE) : bin/cmdstan/stanc.o
+	@mkdir -p $(dir $@)
+	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
 
 
 
@@ -95,4 +110,3 @@ endif
 
 endif
 # end bin/stanc build rules
-

--- a/make/stanc
+++ b/make/stanc
@@ -15,31 +15,28 @@ STANC_DL_DELAY = 10
 STANC3_TEST_BIN_URL ?=
 
 ifeq ($(OS),Windows_NT)
-  OS_TAG := windows
+ OS_TAG := windows
 else ifeq ($(OS),Darwin)
-  OS_TAG := mac
+ OS_TAG := mac
+ STANC_XATTR := $(shell xattr bin/mac-stanc)
 else ifeq ($(OS),Linux)
-  OS_TAG := linux
+ OS_TAG := linux
 else ifeq ($(OS),missing-submodules)
-  CMDSTAN_SUBMODULES = 0
+ CMDSTAN_SUBMODULES = 0
 else
-  $(error $n Can't detect OS properly. $n This will impede automatically downloading the correct stanc. $n Please visit https://github.com/stan-dev/stanc3/releases and download a stanc binary for your OS and place it in ./bin/stanc)
+  $(error  Cannot detect OS properly. $n This will impede automatically downloading the correct stanc. $n Please visit https://github.com/stan-dev/stanc3/releases and download a stanc binary for your OS and place it in ./bin/stanc. $n )
 endif
 
 # bin/stanc build rules - requires stan, stan_math submodules in place
 ifeq ($(CMDSTAN_SUBMODULES),1)
-
-STANC_XATTR =
-ifeq ($(OS_TAG),mac)
-STANC_XATTR = $(shell xattr bin/mac-stanc)
-endif
-
 ifneq ($(STANC3),)
+# build stanc3 from local installation
     bin/stanc$(EXE) : $(shell find $(STANC3)/src/ -type f -name '*.ml*') $(STANC#)
 	@mkdir -p $(dir $@)
 	cd $(STANC3) && echo "--- Rebuilding stanc ---\n" && dune build @install
 	cp $(STANC3)/_build/default/src/stanc/stanc.exe $@
 else ifneq ($(STANC3_TEST_BIN_URL),)
+# download stanc3 build from specific branch
 ifeq ($(OS_TAG),windows)
     bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
@@ -51,23 +48,27 @@ else
 	chmod +x bin/stanc$(EXE)
 endif
 
+else ifneq ($(STANC_XATTR),)
+# unquarantine release stanc3 binary (MacOS Catalina)
+    bin/stanc$(EXE) :
+	cp bin/mac-stanc bin/stanc$(EXE)
+	chmod +x bin/stanc
+	xattr -d com.apple.quarantine bin/stanc
+
 else ifneq (,$(wildcard bin/$(OS_TAG)-stanc))
-ifneq (,$(STANC_XATTR))
-	bin/stanc$(EXE) :
-		cp bin/mac-stanc bin/stanc$(EXE)
-		chmod +x bin/stanc
-		xattr -d com.apple.quarantine bin/stanc
-else
+# use release stanc3 binary (linux, MacOS before Catalina)
     bin/stanc$(EXE) :
 	cp bin/$(OS_TAG)-stanc bin/stanc$(EXE)
 	chmod +x bin/stanc$(EXE)
-endif
 
 else ifeq ($(OS_TAG),windows)
+# Windows binary not included with 2.22 release - remove for 2.23?
     bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
 	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)")
+
 else
+# get latest stanc3
     bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
 	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)

--- a/make/stanc
+++ b/make/stanc
@@ -1,7 +1,7 @@
 ################################################################################
 # stanc build rules
 
-# used to create breaks in error messages
+# used to creat breaks in error messages
 define n
 
 
@@ -10,9 +10,6 @@ endef
 # if nothing was set to $(OS) that means that the Stan Math submodule is missing
 OS ?= missing-submodules
 CMDSTAN_SUBMODULES = 1
-STANC_DL_RETRY = 5
-STANC_DL_DELAY = 10
-STANC3_TEST_BIN_URL ?=
 
 ifeq ($(OS),Windows_NT)
   OS_TAG := windows
@@ -28,50 +25,51 @@ endif
 
 # bin/stanc build rules - requires stan, stan_math submodules in place
 ifeq ($(CMDSTAN_SUBMODULES),1)
+ifneq ($(STANC2),)
+bin/stanc$(EXE) : O = $(O_STANC)
+bin/stanc$(EXE) : CPPFLAGS_MPI =
+bin/stanc$(EXE) : LDFLAGS_MPI =
+bin/stanc$(EXE) : LDLIBS_MPI =
+bin/stanc$(EXE) : bin/cmdstan/libstanc.a
+bin/stanc$(EXE) : bin/cmdstan/stanc.o
+	@mkdir -p $(dir $@)
+	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
 
-ifneq ($(STANC3),)
-    bin/stanc$(EXE) : $(shell find $(STANC3)/src/ -type f -name '*.ml*') $(STANC#)
+else ifneq ($(STANC3),)
+bin/stanc$(EXE) : $(shell find $(STANC3)/src/ -type f -name '*.ml*') $(STANC#)
 	@mkdir -p $(dir $@)
 	cd $(STANC3) && echo "--- Rebuilding stanc ---\n" && dune build @install
 	cp $(STANC3)/_build/default/src/stanc/stanc.exe $@
-else ifneq ($(STANC3_TEST_BIN_URL),)
-ifeq ($(OS_TAG),windows)
-    bin/stanc$(EXE) :
-	@mkdir -p $(dir $@)
-	$(shell echo "curl -L $(STANC3_TEST_BIN_URL)/bin/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)")
+
+else ifneq (,$(wildcard bin/mac-stanc))
+STANC_XATTR = $(shell xattr bin/mac-stanc)
+ifneq (,$(STANC_XATTR))
+bin/stanc$(EXE) :
+	cp bin/mac-stanc bin/stanc$(EXE)
+	chmod +x bin/stanc
+	xattr -d com.apple.quarantine bin/stanc
 else
-    bin/stanc$(EXE) :
-	@mkdir -p $(dir $@)
-	curl -L $(STANC3_TEST_BIN_URL)/bin/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
-	chmod +x bin/stanc$(EXE)
+bin/stanc$(EXE) :
+	cp bin/mac-stanc bin/stanc$(EXE)
+	chmod +x bin/stanc
 endif
-else ifneq (,$(wildcard bin/$(OS_TAG)-stanc))
-    bin/stanc$(EXE) :
+
+else ifneq (,$(wildcard bin/linux-stanc))
+bin/stanc$(EXE) :
 	cp bin/$(OS_TAG)-stanc bin/stanc$(EXE)
-	chmod +x bin/stanc$(EXE)
+	chmod +x bin/stanc
 
 else ifeq ($(OS_TAG),windows)
-    bin/stanc$(EXE) :
+bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
-	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)")
+	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE)")
 else
-    bin/stanc$(EXE) :
-	@mkdir -p $(dir $@)
-	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
-	chmod +x bin/stanc$(EXE)
+bin/stanc$(EXE) :
+	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc
+	chmod +x bin/stanc
 endif
 
 
-# bin/stanc2 build rules
-bin/stanc2$(EXE) : $(TBB_TARGETS)
-bin/stanc2$(EXE) : O = $(O_STANC)
-bin/stanc2$(EXE) : CPPFLAGS_MPI =
-bin/stanc2$(EXE) : LDFLAGS_MPI =
-bin/stanc2$(EXE) : LDLIBS_MPI =
-bin/stanc2$(EXE) : bin/cmdstan/libstanc.a
-bin/stanc2$(EXE) : bin/cmdstan/stanc.o
-	@mkdir -p $(dir $@)
-	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
 
 
 
@@ -97,3 +95,4 @@ endif
 
 endif
 # end bin/stanc build rules
+

--- a/make/stanc
+++ b/make/stanc
@@ -56,19 +56,19 @@ else ifneq ($(STANC_XATTR),)
 	xattr -d com.apple.quarantine bin/stanc
 
 else ifneq (,$(wildcard bin/$(OS_TAG)-stanc))
-# use release stanc3 binary (linux, MacOS before Catalina)
+# use release stanc3 binary (Linux & MacOS releases before Catalina)
     bin/stanc$(EXE) :
 	cp bin/$(OS_TAG)-stanc bin/stanc$(EXE)
 	chmod +x bin/stanc$(EXE)
 
 else ifeq ($(OS_TAG),windows)
-# Windows binary not included with 2.22 release - remove for 2.23?
+# get latest stanc3 - Windows
     bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
 	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)")
 
 else
-# get latest stanc3
+# get latest stanc3 - Linux & MacOS
     bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
 	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Adds logic to makefiles for new MacOS security measures introduced with Catalina.

#### Intended Effect:

Allow compilation of Stan programs without forcing users to explicitly allow execution of bin/stanc

#### How to Verify:

No unit tests for makefiles; instead tested new makefile by hand:

- all targets in `make/stanc` work 
- targets "build" and "clean" work as expected
- tested on both Catalina and High Sierra (pre Catalina) by downloading release 2.22.1 and copying included binary file `mac-stanc` into `bin` directory - on High Sierra file doesn't have any added `xattr` permissions, on Catalina file has xattr `com.apple.quarantine` - then running the following sequence of commands:

```
make clean-all
make bin/stanc
```

On Catalina, makefile uses rule at line 53 of `make/stanc` and strips xattr.  On High Sierra, makefile uses rule at line 60.

#### Side Effects:
n/a

#### Documentation:
n/a

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
