### PR TITLE
update pedantic_mode branch Jenkins build 60->62

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -12,7 +12,7 @@ OS ?= missing-submodules
 CMDSTAN_SUBMODULES = 1
 STANC_DL_RETRY = 5
 STANC_DL_DELAY = 10
-STANC3_TEST_BIN_URL ?= https://jenkins.mc-stan.org/job/stanc3-test-binaries/60/artifact
+STANC3_TEST_BIN_URL ?= https://jenkins.mc-stan.org/job/stanc3-test-binaries/62/artifact
 
 ifeq ($(OS),Windows_NT)
  OS_TAG := windows


### PR DESCRIPTION
I made a small fix to the pedantic mode branch (bizarre Fmt bug!) and ran a new Jenkins build, 62. Now trying to update the CmdStan branch.

Are PRs like this the best way to push changes to the CmdStan test branch?

@rok-cesnovar 