### PR TITLE
Feature/857 makefile stanc2

### DIFF
--- a/makefile
+++ b/makefile
@@ -61,7 +61,7 @@ else
 endif
 	@echo ''
 	@echo '    This target will:'
-	@echo '    1. Install the Stan compiler bin/stanc$(EXE) from stanc3 binaries and build bin/stanc2$(EXE).'
+	@echo '    1. Install the Stan compiler bin/stanc$(EXE) from stanc3 binaries.'
 	@echo '    2. Build the print utility bin/print$(EXE) (deprecated; will be removed in v3.0)'
 	@echo '    3. Build the stansummary utility bin/stansummary$(EXE)'
 	@echo '    4. Build the diagnose utility bin/diagnose$(EXE)'
@@ -170,7 +170,7 @@ build-mpi: $(MPI_TARGETS)
 
 ifeq ($(CMDSTAN_SUBMODULES),1)
 .PHONY: build
-build: bin/stanc$(EXE) bin/stanc2$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(CMDSTAN_MAIN_O)
+build: bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(CMDSTAN_MAIN_O)
 	@echo ''
 ifeq ($(OS),Windows_NT)
 		@echo 'NOTE: Please add $(TBB_BIN_ABSOLUTE_PATH) to your PATH variable.'


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
makefile task `build` no longer builds the old stanc2 compiler

#### Intended Effect:
Speed up CmdStan install time

#### How to Verify:

`> time make build`

On my MacBook, time to build (single core) build task when building `bin/stanc2`:  

```
real	2m9.018s
user	5m32.845s
sys	0m17.848s
```

Time to build for this PR:

```
real	1m6.436s
user	2m31.346s
sys	0m8.281s
```

After `make clean-all`, build example model `bernoulli` with makefile flag `STANC2=TRUE` - this will trigger build of `bin/stanc2`

```
make clean-all
make STANC=TRUE examples/bernoulli/bernoulli
```

#### Side Effects:
NA

#### Documentation:
NA
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
