### PR TITLE
Feature/861 stan threads always on

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,6 +18,7 @@
 # The default target of this Makefile is...
 help:
 
+
 -include $(HOME)/.config/stan/make.local  # user-defined variables
 -include make/local                       # user-defined variables
 
@@ -30,6 +31,10 @@ endif
 O_STANC ?= 0
 INC_FIRST ?= -I src -I $(STAN)src -I $(RAPIDJSON)
 USER_HEADER ?= $(dir $<)user_header.hpp
+
+ifeq ($(origin STAN_THREADS), undefined)
+STAN_THREADS=TRUE
+endif
 
 
 -include $(MATH)make/compiler_flags


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Add logic to CmdStan makefile so that makefile variable `STAN_THREADS` is set to `TRUE`.

#### Intended Effect:

Avoid linker errors.  see issue #861 

#### How to Verify:

Unit tests

#### Side Effects:

Some models may run slower, see discussion here:  https://discourse.mc-stan.org/t/makefiles-and-compiler-flag-dstan-threads-always-on/14482/5?u=mitzimorris

#### Documentation:

NA - compiler flag `STAN_THREADS` no mentioned in user's guide.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University
 
By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
