### PR TITLE
Bugfix/868 Fix make test-models-hpp rule

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -70,7 +70,8 @@ test-headers: $(HEADER_TESTS)
 TEST_MODELS := $(wildcard src/test/test-models/*.stan)
 
 .PHONY: test-models-hpp
-test-models-hpp:  $(TEST_MODELS)
+test-models-hpp: 
+	$(MAKE) $(patsubst %.stan,%$(EXE),$(TEST_MODELS)) 
 
 ##
 # Tests that depend on compiled models


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes #868 by fixing the test-models-hpp rule to:

```
TEST_MODELS := $(wildcard src/test/test-models/*.stan)

.PHONY: test-models-hpp
test-models-hpp: 
	$(MAKE) $(patsubst %.stan,%$(EXE),$(TEST_MODELS)) 
```

Will restart tests a few times to make sure.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
