### PR TITLE
Bugfix/remove the use of chmod for windows

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -56,17 +56,17 @@ else ifneq ($(STANC_XATTR),)
 	xattr -d com.apple.quarantine bin/stanc
 
 else ifneq (,$(wildcard bin/$(OS_TAG)-stanc))
-# use release stanc3 binary (Linux & MacOS releases before Catalina)
+# use release stanc3 binary (Windows, Linux & MacOS releases before Catalina)
     bin/stanc$(EXE) :
 	cp bin/$(OS_TAG)-stanc bin/stanc$(EXE)
+ifneq ($(OS_TAG),windows)
 	chmod +x bin/stanc$(EXE)
-
+endif
 else ifeq ($(OS_TAG),windows)
 # get latest stanc3 - Windows
     bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
 	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)")
-
 else
 # get latest stanc3 - Linux & MacOS
     bin/stanc$(EXE) :


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fix for the bug that caused https://github.com/stan-dev/cmdstan/issues/873

Windows does not have chmod and in releases (which come with bin/windows-stanc) we try to use it after copying bin/windows-stanc to bin/stanc.exe
But its not needed. And this fails if users dont have Git for Windows.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
