### PR TITLE
Feature/872 Precompiled headers for g++

### DIFF
--- a/make/program
+++ b/make/program
@@ -52,12 +52,11 @@ endif
 
 ifeq ($(PRECOMPILED_HEADERS),true)
 PRECOMPILED_MODEL_HEADER=$(STAN)src/stan/model/model_header.hpp.gch
-CXX
-else
-PRECOMPILED_MODEL_HEADER=
 ifeq ($(CXX_TYPE),gcc)
 CXXFLAGS_PROGRAM+= -Wno-ignored-attributes
 endif
+else
+PRECOMPILED_MODEL_HEADER=
 endif
 
 %.d: %.hpp

--- a/make/program
+++ b/make/program
@@ -17,11 +17,6 @@ $(STAN)src/stan/model/model_header.hpp.gch : $(STAN)src/stan/model/model_header.
 	@echo '--- Compiling pre-compiled header ---	'
 	$(COMPILE.cpp) $< $(OUTPUT_OPTION)
 
-ifeq ($(CXX_TYPE),clang)
-CXXFLAGS_PROGRAM += -include-pch $(STAN)src/stan/model/model_header.hpp.gch
-$(STAN_TARGETS) examples/bernoulli/bernoulli$(EXE) $(patsubst %.stan,%$(EXE),$(wildcard src/test/test-models/*.stan)) : %$(EXE) : $(STAN)src/stan/model/model_header.hpp.gch
-endif
-
 ifneq ($(findstring allow_undefined,$(STANCFLAGS)),)
 $(STAN_TARGETS) examples/bernoulli/bernoulli$(EXE) $(patsubst %.stan,%$(EXE),$(wildcard src/test/test-models/*.stan)) : CXXFLAGS_PROGRAM += -include $(USER_HEADER)
 endif
@@ -48,7 +43,7 @@ endif
 %.d: %.hpp
 
 .PRECIOUS: %.hpp
-%$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
+%$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(STAN)src/stan/model/model_header.hpp.gch
 	@echo ''
 	@echo '--- Compiling, linking C++ code ---'
 	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)

--- a/make/program
+++ b/make/program
@@ -52,8 +52,12 @@ endif
 
 ifeq ($(PRECOMPILED_HEADERS),true)
 PRECOMPILED_MODEL_HEADER=$(STAN)src/stan/model/model_header.hpp.gch
+CXX
 else
 PRECOMPILED_MODEL_HEADER=
+ifeq ($(CXX_TYPE),gcc)
+CXXFLAGS_PROGRAM+= -Wno-ignored-attributes
+endif
 endif
 
 %.d: %.hpp

--- a/make/program
+++ b/make/program
@@ -44,10 +44,22 @@ endif
 	@echo '--- Translating Stan model to C++ code ---'
 	$(WINE) $(BINSTANC) $(STANCFLAGS) --o=$(subst  \,/,$@) $(subst  \,/,$<)
 
+ifeq ($(OS),Windows_NT)
+PRECOMPILED_HEADERS ?= false
+else
+PRECOMPILED_HEADERS ?= true
+endif
+
+ifeq ($(PRECOMPILED_HEADERS),true)
+PRECOMPILED_MODEL_HEADER=$(STAN)src/stan/model/model_header.hpp.gch
+else
+PRECOMPILED_MODEL_HEADER=
+endif
+
 %.d: %.hpp
 
 .PRECIOUS: %.hpp
-%$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(STAN)src/stan/model/model_header.hpp.gch
+%$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(PRECOMPILED_MODEL_HEADER)
 	@echo ''
 	@echo '--- Compiling, linking C++ code ---'
 	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)

--- a/make/program
+++ b/make/program
@@ -17,6 +17,10 @@ $(STAN)src/stan/model/model_header.hpp.gch : $(STAN)src/stan/model/model_header.
 	@echo '--- Compiling pre-compiled header ---	'
 	$(COMPILE.cpp) $< $(OUTPUT_OPTION)
 
+ifeq ($(CXX_TYPE),clang)
+CXXFLAGS_PROGRAM += -include-pch $(STAN)src/stan/model/model_header.hpp.gch
+endif
+
 ifneq ($(findstring allow_undefined,$(STANCFLAGS)),)
 $(STAN_TARGETS) examples/bernoulli/bernoulli$(EXE) $(patsubst %.stan,%$(EXE),$(wildcard src/test/test-models/*.stan)) : CXXFLAGS_PROGRAM += -include $(USER_HEADER)
 endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes #872 by adding precompiled headers for g++.

The implemented logic is as follows:

1. Has the user set the makefile variable `PRECOMPILED_HEADERS`? If yes, use the supplied value and proceed to step 3. If not go to step 2.
2. Is the user on Windows? If yes, set `PRECOMPILED_HEADERS=false`. If not, set `PRECOMPILED_HEADERS=true`
3. If `PRECOMPILED_HEADERS=true` add the precompiled model header as a dependency to the model executable. If `PRECOMPILED_HEADERS` is set to anything else, do not add the dependency.

Additionally if you are using g++ this adds a the "-Wno-ignore-attributes" which silences the g++ warnings seen [here](https://github.com/stan-dev/cmdstan/issues/872#issuecomment-626764948),

The reasoning behind this three step logic is that given that g++ precompiled headers are rather large (500-700MB) we give the users the option to turn them off if they wish to. But the default is to build it if you are not using Windows.

**How to test:**

If you are using clang, just test that your normal workflow still works. Nothing changed there.
If you are using g++ on Linux or Mac then run the following commands on develop and on this branch

```
touch examples/bernoulli/bernoulli.stan
time make examples/bernoulli/bernoulli
```
You should see a 50% decrease in compile time, apart from the first compile where the precompiled header gets built.

If you are using windows you first need to put `PRECOMPILED_HEADERS=true` in the make/local file. If you will not add that, things should work as before.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
