### PR TITLE
Bugfix/876 fix make clean-all and building of stanc.d

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,6 @@ pipeline {
                     agent { label 'windows' }
                     steps {
                         setupCXX()
-                        bat "mingw32-make -f stan/lib/stan_math/make/standalone math-libs"
                         runWinTests()
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,6 +144,7 @@ pipeline {
                     agent { label 'windows' }
                     steps {
                         setupCXX()
+                        bat "mingw32-make -f stan/lib/stan_math/make/standalone math-libs"
                         runWinTests()
                     }
                     post {

--- a/make/program
+++ b/make/program
@@ -44,21 +44,6 @@ endif
 	@echo '--- Translating Stan model to C++ code ---'
 	$(WINE) $(BINSTANC) $(STANCFLAGS) --o=$(subst  \,/,$@) $(subst  \,/,$<)
 
-ifeq ($(OS),Windows_NT)
-PRECOMPILED_HEADERS ?= false
-else
-PRECOMPILED_HEADERS ?= true
-endif
-
-ifeq ($(PRECOMPILED_HEADERS),true)
-PRECOMPILED_MODEL_HEADER=$(STAN)src/stan/model/model_header.hpp.gch
-ifeq ($(CXX_TYPE),gcc)
-CXXFLAGS_PROGRAM+= -Wno-ignored-attributes
-endif
-else
-PRECOMPILED_MODEL_HEADER=
-endif
-
 %.d: %.hpp
 
 .PRECIOUS: %.hpp
@@ -79,19 +64,5 @@ ifneq ($(notdir $(shell where tbb.dll)),tbb.dll)
 	else \
 		echo 'Using existing $(@D)/tbb.dll'; \
 	fi
-endif
-endif
-
-##
-# Dependencies file
-##
-ifneq (,$(STAN_TARGETS))
-$(patsubst %$(EXE),%.d,$(STAN_TARGETS)) : DEPTARGETS += -MT $(patsubst %.d,%$(EXE),$@) -include $< -include $(CMDSTAN_MAIN)
--include $(patsubst %$(EXE),%.d,$(STAN_TARGETS))
--include src/cmdstan/stanc.d
--include $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP))
--include $(patsubst %.cpp,%.d,$(CMDSTAN_MAIN))
-ifeq ($(CXX_TYPE),clang)
--include $(STAN)src/stan/model/model_header.d
 endif
 endif

--- a/make/program
+++ b/make/program
@@ -66,3 +66,19 @@ ifneq ($(notdir $(shell where tbb.dll)),tbb.dll)
 	fi
 endif
 endif
+
+##
+# Dependencies file
+##
+ifneq (,$(STAN_TARGETS))
+$(patsubst %$(EXE),%.d,$(STAN_TARGETS)) : DEPTARGETS += -MT $(patsubst %.d,%$(EXE),$@) -include $< -include $(CMDSTAN_MAIN)
+-include $(patsubst %$(EXE),%.d,$(STAN_TARGETS))
+-include $(patsubst %.cpp,%.d,$(CMDSTAN_MAIN))
+ifeq ($(PRECOMPILED_HEADERS),true)
+-include $(STAN)src/stan/model/model_header.d
+endif
+ifneq ($(STANC2),)
+-include src/cmdstan/stanc.d
+-include $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP))
+endif
+endif

--- a/make/program
+++ b/make/program
@@ -58,7 +58,7 @@ ifeq ($(OS),Windows_NT)
 ifneq ($(notdir $(shell where tbb.dll)),tbb.dll)
 	@echo 'Intel TBB is not in PATH.'
 	@echo 'Consider calling '
-	@echo 'make install-tbb'
+	@echo '$(HELP_MAKE) install-tbb'
 	@echo 'to avoid copying Intel TBB library files.'
 	@if ! [[ -f "$(@D)/tbb.dll" ]]; then \
 		cp -v $(TBB_TARGETS) $(@D); \

--- a/make/program
+++ b/make/program
@@ -19,6 +19,7 @@ $(STAN)src/stan/model/model_header.hpp.gch : $(STAN)src/stan/model/model_header.
 
 ifeq ($(CXX_TYPE),clang)
 CXXFLAGS_PROGRAM += -include-pch $(STAN)src/stan/model/model_header.hpp.gch
+$(STAN_TARGETS) examples/bernoulli/bernoulli$(EXE) $(patsubst %.stan,%$(EXE),$(wildcard src/test/test-models/*.stan)) : %$(EXE) : $(STAN)src/stan/model/model_header.hpp.gch
 endif
 
 ifneq ($(findstring allow_undefined,$(STANCFLAGS)),)
@@ -47,7 +48,7 @@ endif
 %.d: %.hpp
 
 .PRECIOUS: %.hpp
-%$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(PRECOMPILED_MODEL_HEADER)
+%$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
 	@echo ''
 	@echo '--- Compiling, linking C++ code ---'
 	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)

--- a/make/stanc
+++ b/make/stanc
@@ -75,7 +75,6 @@ else
 	chmod +x bin/stanc$(EXE)
 endif
 
-
 # bin/stanc2 build rules
 bin/stanc2$(EXE) : $(TBB_TARGETS)
 bin/stanc2$(EXE) : O = $(O_STANC)
@@ -86,8 +85,6 @@ bin/stanc2$(EXE) : bin/cmdstan/libstanc.a
 bin/stanc2$(EXE) : bin/cmdstan/stanc.o
 	@mkdir -p $(dir $@)
 	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
-
-
 
 # libstanc build rules
 STANC_TEMPLATE_INSTANTIATION_CPP := $(call findfiles,$(STAN)src/stan/lang,*_inst.cpp) $(call findfiles,$(STAN)src/stan/lang,*_def.cpp)
@@ -104,7 +101,7 @@ $(STANC_TEMPLATE_INSTANTIATION) : bin/cmdstan/%.o : $(STAN)src/stan/%.cpp
 
 $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP)) : DEPTARGETS = -MT $(patsubst stan/src/stan/lang/%.d,bin/cmdstan/lang/%.o,$@) -MT $@
 
-ifneq ($(filter bin/stanc$(EXE) bin/stan/libstanc.a $(STANC_TEMPLATE_INSTANTIATION),$(MAKECMDGOALS)),)
+ifneq ($(filter bin/stanc2$(EXE) bin/stan/libstanc.a $(STANC_TEMPLATE_INSTANTIATION),$(MAKECMDGOALS)),)
 -include $(patsubst %.cpp,%.d,$(STANC_TEMPLATE_INSTANTIATION_CPP))
 endif
 # end libstanc build rules

--- a/make/tests
+++ b/make/tests
@@ -9,10 +9,6 @@ else
 LIB_DIRS_TBB=
 endif
 
-test/%/tbb.dll : $(TBB_TARGETS)
-	@mkdir -p test/$*
-	cp -v $(TBB_TARGETS) test/$*
-
 .PRECIOUS: $(LIB_DIRS_TBB)
 
 test/%$(EXE) : CXXFLAGS += $(CXXFLAGS_GTEST)

--- a/make/tests
+++ b/make/tests
@@ -2,20 +2,11 @@
 # Build test executables
 ##
 
-ifeq ($(OS),Windows_NT)
-LIB_DIRS_FULL=$(filter %/, $(wildcard src/test/interface/*/) src/test/interface/)
-LIB_DIRS_TBB=$(LIB_DIRS_FULL:src/%/=%/tbb.dll)
-else
-LIB_DIRS_TBB=
-endif
-
-.PRECIOUS: $(LIB_DIRS_TBB)
-
 test/%$(EXE) : CXXFLAGS += $(CXXFLAGS_GTEST)
 test/%$(EXE) : CPPFLAGS += $(CPPFLAGS_GTEST)
 test/%$(EXE) : INC += $(INC_GTEST) -I $(RAPIDJSON)
-test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)  $(LIB_DIRS_TBB)
-	$(LINK.cpp) $(filter-out src/test/test-models/% src/%.csv bin/% test/%.hpp %.hpp-test test/%/tbb.dll,$^) $(LDLIBS) $(OUTPUT_OPTION)
+test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
+	$(LINK.cpp) $(filter-out src/test/test-models/% src/%.csv bin/% test/%.hpp %.hpp-test,$^) $(LDLIBS) $(OUTPUT_OPTION)
 
 test/%.o : src/test/%.cpp
 	@mkdir -p $(dir $@)

--- a/makefile
+++ b/makefile
@@ -22,10 +22,6 @@ help:
 STAN ?= stan/
 MATH ?= $(STAN)lib/stan_math/
 RAPIDJSON ?= lib/rapidjson_1.1.0/
-ifeq ($(OS),Windows_NT)
-  O_STANC ?= 3
-endif
-O_STANC ?= 0
 INC_FIRST ?= -I src -I $(STAN)src -I $(RAPIDJSON)
 USER_HEADER ?= $(dir $<)user_header.hpp
 
@@ -55,17 +51,20 @@ include make/command
 CMDSTAN_VERSION := 2.23.0
 CMDSTAN_VERSION_DOC := 2.23
 
+ifeq ($(OS),Windows_NT)
+HELP_MAKE=mingw32-make
+else
+HELP_MAKE=make
+endif
+
+
 .PHONY: help
 help:
 	@echo '--------------------------------------------------------------------------------'
 	@echo 'CmdStan v$(CMDSTAN_VERSION) help'
 	@echo ''
 	@echo '  Build CmdStan utilities:'
-ifeq ($(OS),Windows_NT)
-	@echo '    > mingw32-make build'
-else
-	@echo '    > make build'
-endif
+	@echo '    > $(HELP_MAKE) build'
 	@echo ''
 	@echo '    This target will:'
 	@echo '    1. Install the Stan compiler bin/stanc$(EXE) from stanc3 binaries.'
@@ -76,11 +75,7 @@ endif
 	@echo ''
 	@echo '    Note: to build using multiple cores, use the -j option to make, e.g., '
 	@echo '    for 4 cores:'
-ifeq ($(OS),Windows_NT)
-	@echo '    > mingw32-make build -j4'
-else
-	@echo '    > make build -j4'
-endif
+	@echo '    > $(HELP_MAKE) build -j4'
 	@echo ''
 ifeq ($(OS),Windows_NT)
 	@echo '    On Windows it is recommended to include with the PATH environment'
@@ -113,19 +108,11 @@ endif
 	@echo '  Example - bernoulli model: examples/bernoulli/bernoulli.stan'
 	@echo ''
 	@echo '    1. Build the model:'
-	@echo '       > make examples/bernoulli/bernoulli$(EXE)'
+	@echo '       > $(HELP_MAKE) examples/bernoulli/bernoulli$(EXE)'
 	@echo '    2. Run the model:'
-ifeq ($(OS),Windows_NT)
-	@echo '       > examples\bernoulli\bernoulli$(EXE) sample data file=examples/bernoulli/bernoulli.data.R'
-else
 	@echo '       > examples/bernoulli/bernoulli$(EXE) sample data file=examples/bernoulli/bernoulli.data.R'
-endif
 	@echo '    3. Look at the samples:'
-ifeq ($(OS),Windows_NT)
-	@echo '       > bin\stansummary$(EXE) output.csv'
-else
 	@echo '       > bin/stansummary$(EXE) output.csv'
-endif
 	@echo ''
 	@echo ''
 	@echo '  Clean CmdStan:'
@@ -140,7 +127,6 @@ help-dev:
 	@echo '--------------------------------------------------------------------------------'
 	@echo 'CmdStan help for developers:'
 	@$(MAKE) print-compiler-flags
-	@echo '  - O_STANC (Opt for stanc):    ' $(O_STANC)
 	@echo ''
 	@echo '  If this copy of CmdStan has been cloned using git,'
 	@echo '  before building CmdStan utilities the first time you need'
@@ -183,7 +169,7 @@ ifeq ($(OS),Windows_NT)
 		@echo 'NOTE: Please add $(TBB_BIN_ABSOLUTE_PATH) to your PATH variable.'
 		@echo 'You may call'
 		@echo ''
-		@echo 'mingw32-make install-tbb'
+		@echo '$(HELP_MAKE) install-tbb'
 		@echo ''
 		@echo 'to automatically update your user configuration.'
 endif

--- a/makefile
+++ b/makefile
@@ -10,8 +10,6 @@
 # - CXX: The compiler to use. Expecting g++ or clang++.
 # - O: Optimization level. Valid values are {s, 0, 1, 2, 3}.
 #      Default is 3.
-# - O_STANC: Optimization level for compiling stanc.
-#      Valid values are {s, 0, 1, 2, 3}. Default is 0
 # - STANCFLAGS: Extra options for calling stanc
 ##
 
@@ -31,15 +29,6 @@ O_STANC ?= 0
 INC_FIRST ?= -I src -I $(STAN)src -I $(RAPIDJSON)
 USER_HEADER ?= $(dir $<)user_header.hpp
 
-
--include $(MATH)make/compiler_flags
--include $(MATH)make/dependencies
--include $(MATH)make/libraries
-include make/stanc
-include make/program
-include make/tests
-include make/command
-
 ifeq ($(OS),Windows_NT)
 PRECOMPILED_HEADERS ?= false
 else
@@ -54,6 +43,14 @@ endif
 else
 PRECOMPILED_MODEL_HEADER=
 endif
+
+-include $(MATH)make/compiler_flags
+-include $(MATH)make/dependencies
+-include $(MATH)make/libraries
+include make/stanc
+include make/program
+include make/tests
+include make/command
 
 CMDSTAN_VERSION := 2.23.0
 CMDSTAN_VERSION_DOC := 2.23

--- a/makefile
+++ b/makefile
@@ -218,7 +218,7 @@ clean: clean-manual
 
 clean-deps:
 	@echo '  removing dependency files'
-	$(RM) $(call findfiles,src,*.d) $(call findfiles,src/stan,*.d) $(call findfiles,$(MATH)/stan,*.d)
+	$(RM) $(call findfiles,src,*.d) $(call findfiles,src/stan,*.d) $(call findfiles,$(MATH)/stan,*.d) $(call findfiles,$(STAN)/src/stan/,*.d)
 	$(RM) $(call findfiles,src,*.d.*) $(call findfiles,src/stan,*.d.*) $(call findfiles,$(MATH)/stan,*.d.*)
 	$(RM) $(call findfiles,src,*.dSYM) $(call findfiles,src/stan,*.dSYM) $(call findfiles,$(MATH)/stan,*.dSYM)
 

--- a/runCmdStanTests.py
+++ b/runCmdStanTests.py
@@ -85,6 +85,13 @@ def makeTestModels(j):
         command = 'make -j%d test-models-hpp' % j
     doCommand(command)
 
+def makeMathLibs(j):
+    if j == None:
+        command = 'make -f stan/lib/stan_math/make/standalone math-libs'
+    else:
+        command = 'make -j%d -f stan/lib/stan_math/make/standalone math-libs' % j
+    doCommand(command)
+
 def makeTests(dirname, filenames, j):
     targets = list()
     for name in filenames:
@@ -162,6 +169,8 @@ def main():
 
     # pass 0:  make build, compile all test models
     makeBuild(j)
+    if (isWin()):
+        makeMathLibs(j)
     makeTestModels(j)
 
     # pass 1:  call make to compile test targets


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes #876 by adding a rule to delete stan/src/stan/*.d files and remove the need to build stanc.d file if not using stanc2.

This also moves the precompiled headers logic to the main makefile file which enables adding the precompiled header to `make build` if it is used.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar, Faculty of Computer and Information Sciences, University of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
