### PR TITLE
Bugfix/issues on develop

### DIFF
--- a/make/program
+++ b/make/program
@@ -19,6 +19,7 @@ $(STAN)src/stan/model/model_header.hpp.gch : $(STAN)src/stan/model/model_header.
 
 ifeq ($(CXX_TYPE),clang)
 CXXFLAGS_PROGRAM += -include-pch $(STAN)src/stan/model/model_header.hpp.gch
+$(STAN_TARGETS) examples/bernoulli/bernoulli$(EXE) $(patsubst %.stan,%$(EXE),$(wildcard src/test/test-models/*.stan)) : %$(EXE) : $(STAN)src/stan/model/model_header.hpp.gch
 endif
 
 ifneq ($(findstring allow_undefined,$(STANCFLAGS)),)
@@ -44,25 +45,10 @@ endif
 	@echo '--- Translating Stan model to C++ code ---'
 	$(WINE) $(BINSTANC) $(STANCFLAGS) --o=$(subst  \,/,$@) $(subst  \,/,$<)
 
-ifeq ($(OS),Windows_NT)
-PRECOMPILED_HEADERS ?= false
-else
-PRECOMPILED_HEADERS ?= true
-endif
-
-ifeq ($(PRECOMPILED_HEADERS),true)
-PRECOMPILED_MODEL_HEADER=$(STAN)src/stan/model/model_header.hpp.gch
-ifeq ($(CXX_TYPE),gcc)
-CXXFLAGS_PROGRAM+= -Wno-ignored-attributes
-endif
-else
-PRECOMPILED_MODEL_HEADER=
-endif
-
 %.d: %.hpp
 
 .PRECIOUS: %.hpp
-%$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(PRECOMPILED_MODEL_HEADER)
+%$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
 	@echo ''
 	@echo '--- Compiling, linking C++ code ---'
 	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

Jenkins cmdstan develop tests are failing with warnings. See https://jenkins.mc-stan.org/blue/organizations/jenkins/CmdStan/activity

This is an attempt to fix this.

Examples of error:

```
[Linux interface tests with MPI@GCC4] Sleeping for 5 seconds due to JENKINS-32191...
[Linux interface tests with MPI@GCC4] Parsing console log (workspace: '/home/jenkins-slave/jenkins-slave-files/workspace/CmdStan_develop')
[Linux interface tests with MPI@GCC4] [-ERROR-] Can't resolve absolute paths for some files:
[Linux interface tests with MPI@GCC4] [-ERROR-] - /home/jenkins-slave/jenkins-slave-files/workspace/CmdStan_develop/stan/lib/stan_math/lib/tbb/src/test/interface/metric_test.cpp
[Linux interface tests with MPI@GCC4] [-ERROR-] Can't create fingerprints for some files:
[Linux interface tests with MPI@GCC4] [-ERROR-] - '/home/jenkins-slave/jenkins-slave-files/workspace/CmdStan_develop/stan/lib/stan_math/lib/tbb/src/test/interface/metric_test.cpp', IO exception has been thrown: java.nio.file.NoSuchFileException: /home/jenkins-slave/jenkins-slave-files/workspace/CmdStan_develop/stan/lib/stan_math/lib/tbb/src/test/interface/metric_test.cpp
[Linux interface tests with MPI@GCC4] [-ERROR-] Can't determine head commit using 'git rev-parse'. Skipping blame.
[Linux interface tests with MPI@GCC4] [-ERROR-] hudson.plugins.git.GitException: Command "/usr/bin/git rev-parse HEAD^{commit}" returned status code 128:
stdout: 
stderr: fatal: not a git repository (or any of the parent directories): .git

[Linux interface tests with MPI@GCC4] [-ERROR-] 	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2372)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2302)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2298)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommand(CliGitAPIImpl.java:1857)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommand(CliGitAPIImpl.java:1869)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.revParse(CliGitAPIImpl.java:994)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at hudson.plugins.git.GitAPI.revParse(GitAPI.java:316)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at io.jenkins.plugins.analysis.core.scm.GitBlamer.blame(GitBlamer.java:65)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at io.jenkins.plugins.analysis.core.steps.IssuesScanner$ReportPostProcessor.invoke(IssuesScanner.java:180)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at io.jenkins.plugins.analysis.core.steps.IssuesScanner$ReportPostProcessor.invoke(IssuesScanner.java:148)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3052)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at hudson.remoting.UserRequest.perform(UserRequest.java:212)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at hudson.remoting.Request$2.run(Request.java:369)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[Linux interface tests with MPI@GCC4] [-ERROR-] 	at java.lang.Thread.run(Thread.java:748)
```
Similar one happens on Windows.

First trying to debug by reverting all recent makefile changes.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
