### PR TITLE
Using STAN_THREADS, STAN_MPI and STAN_OPENCL without rebuilding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /test/
 
 # main intermediate
-src/cmdstan/main.o
+src/cmdstan/main*.o
 
 # test models
 /src/test/test-models/*

--- a/make/program
+++ b/make/program
@@ -8,6 +8,9 @@ CMDSTAN_MAIN ?= src/cmdstan/main.cpp
 CMDSTAN_MAIN_O = $(patsubst %.cpp,%$(STAN_FLAGS).o,$(CMDSTAN_MAIN))
 
 $(CMDSTAN_MAIN_O) : $(CMDSTAN_MAIN)
+	@echo ''
+ifeq ($(STAN_FLAGS),)
+	@echo '--- Compiling the main object file. This might take up to a minute. ---	'
 	@mkdir -p $(dir $@)
 	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
 
@@ -19,7 +22,7 @@ $(STAN)src/stan/model/model_header$(STAN_FLAGS).d : $(STAN)src/stan/model/model_
 $(STAN)src/stan/model/model_header$(STAN_FLAGS).d : DEPTARGETS = -MT $(patsubst %.d,%.hpp.gch,$@) -MT $@
 $(STAN)src/stan/model/model_header$(STAN_FLAGS).hpp.gch : $(STAN)src/stan/model/model_header.hpp
 	@echo ''
-	@echo '--- Compiling pre-compiled header ---	'
+	@echo '--- Compiling pre-compiled header. This might take a few seconds. ---'
 	$(COMPILE.cpp) $< $(OUTPUT_OPTION)
 
 ifeq ($(CXX_TYPE),clang)

--- a/make/program
+++ b/make/program
@@ -9,7 +9,6 @@ CMDSTAN_MAIN_O = $(patsubst %.cpp,%$(STAN_FLAGS).o,$(CMDSTAN_MAIN))
 
 $(CMDSTAN_MAIN_O) : $(CMDSTAN_MAIN)
 	@echo ''
-ifeq ($(STAN_FLAGS),)
 	@echo '--- Compiling the main object file. This might take up to a minute. ---'
 	@mkdir -p $(dir $@)
 	$(COMPILE.cpp) $(OUTPUT_OPTION) $<

--- a/make/program
+++ b/make/program
@@ -1,25 +1,30 @@
 ##
 # Models (to be passed through stanc)
 ##
-CMDSTAN_MAIN ?= src/cmdstan/main.cpp
-CMDSTAN_MAIN_O = $(patsubst %.cpp,%.o,$(CMDSTAN_MAIN))
 
 STAN_TARGETS = $(patsubst %.stan,%$(EXE),$(wildcard $(patsubst %$(EXE),%.stan,$(MAKECMDGOALS))))
+
+CMDSTAN_MAIN ?= src/cmdstan/main.cpp
+CMDSTAN_MAIN_O = $(patsubst %.cpp,%$(STAN_FLAGS).o,$(CMDSTAN_MAIN))
+
+$(CMDSTAN_MAIN_O) : $(CMDSTAN_MAIN)
+	@mkdir -p $(dir $@)
+	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
 
 ##
 # Precompiled model header
 ##
-$(STAN)src/stan/model/model_header.d : $(STAN)src/stan/model/model_header.hpp
+$(STAN)src/stan/model/model_header$(STAN_FLAGS).d : $(STAN)src/stan/model/model_header.hpp
 	$(COMPILE.cpp) $(DEPFLAGS) $<
-$(STAN)src/stan/model/model_header.d : DEPTARGETS = -MT $(patsubst %.d,%.hpp.gch,$@) -MT $@
-$(STAN)src/stan/model/model_header.hpp.gch : $(STAN)src/stan/model/model_header.hpp
+$(STAN)src/stan/model/model_header$(STAN_FLAGS).d : DEPTARGETS = -MT $(patsubst %.d,%.hpp.gch,$@) -MT $@
+$(STAN)src/stan/model/model_header$(STAN_FLAGS).hpp.gch : $(STAN)src/stan/model/model_header.hpp
 	@echo ''
 	@echo '--- Compiling pre-compiled header ---	'
 	$(COMPILE.cpp) $< $(OUTPUT_OPTION)
 
 ifeq ($(CXX_TYPE),clang)
-CXXFLAGS_PROGRAM += -include-pch $(STAN)src/stan/model/model_header.hpp.gch
-$(STAN_TARGETS) examples/bernoulli/bernoulli$(EXE) $(patsubst %.stan,%$(EXE),$(wildcard src/test/test-models/*.stan)) : %$(EXE) : $(STAN)src/stan/model/model_header.hpp.gch
+CXXFLAGS_PROGRAM += -include-pch $(STAN)src/stan/model/model_header$(STAN_FLAGS).hpp.gch
+$(STAN_TARGETS) examples/bernoulli/bernoulli$(EXE) $(patsubst %.stan,%$(EXE),$(wildcard src/test/test-models/*.stan)) : %$(EXE) : $(STAN)src/stan/model/model_header$(STAN_FLAGS).hpp.gch
 endif
 
 ifneq ($(findstring allow_undefined,$(STANCFLAGS)),)
@@ -48,7 +53,7 @@ endif
 %.d: %.hpp
 
 .PRECIOUS: %.hpp
-%$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
+%$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(PRECOMPILED_MODEL_HEADER)
 	@echo ''
 	@echo '--- Compiling, linking C++ code ---'
 	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)
@@ -74,9 +79,9 @@ endif
 ifneq (,$(STAN_TARGETS))
 $(patsubst %$(EXE),%.d,$(STAN_TARGETS)) : DEPTARGETS += -MT $(patsubst %.d,%$(EXE),$@) -include $< -include $(CMDSTAN_MAIN)
 -include $(patsubst %$(EXE),%.d,$(STAN_TARGETS))
--include $(patsubst %.cpp,%.d,$(CMDSTAN_MAIN))
+-include $(patsubst %.cpp,%$(STAN_FLAGS).d,$(CMDSTAN_MAIN))
 ifeq ($(PRECOMPILED_HEADERS),true)
--include $(STAN)src/stan/model/model_header.d
+-include $(STAN)src/stan/model/model_header$(STAN_FLAGS).d
 endif
 ifneq ($(STANC2),)
 -include src/cmdstan/stanc.d

--- a/make/program
+++ b/make/program
@@ -10,7 +10,7 @@ CMDSTAN_MAIN_O = $(patsubst %.cpp,%$(STAN_FLAGS).o,$(CMDSTAN_MAIN))
 $(CMDSTAN_MAIN_O) : $(CMDSTAN_MAIN)
 	@echo ''
 ifeq ($(STAN_FLAGS),)
-	@echo '--- Compiling the main object file. This might take up to a minute. ---	'
+	@echo '--- Compiling the main object file. This might take up to a minute. ---'
 	@mkdir -p $(dir $@)
 	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
 

--- a/makefile
+++ b/makefile
@@ -25,6 +25,18 @@ RAPIDJSON ?= lib/rapidjson_1.1.0/
 INC_FIRST ?= -I src -I $(STAN)src -I $(RAPIDJSON)
 USER_HEADER ?= $(dir $<)user_header.hpp
 
+ifdef STAN_THREADS
+STAN_FLAG_THREADS=_threads
+endif
+ifdef STAN_MPI
+STAN_FLAG_MPI=_mpi
+endif
+ifdef STAN_OPENCL
+STAN_FLAG_OPENCL=_opencl
+endif
+
+STAN_FLAGS=$(STAN_FLAG_THREADS)$(STAN_FLAG_MPI)$(STAN_FLAG_OPENCL)
+
 ifeq ($(OS),Windows_NT)
 PRECOMPILED_HEADERS ?= false
 else
@@ -217,8 +229,8 @@ clean-manual:
 
 clean-all: clean clean-deps clean-libraries clean-manual
 	$(RM) bin/stanc$(EXE) bin/stanc2$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE)
-	$(RM) -r $(CMDSTAN_MAIN_O) bin/cmdstan
-	$(RM) $(wildcard $(STAN)src/stan/model/model_header.hpp.gch)
+	$(RM) -r src/cmdstan/main.*.o bin/cmdstan
+	$(RM) $(wildcard $(STAN)src/stan/model/model_header.*.hpp.gch)
 	$(RM) examples/bernoulli/bernoulli$(EXE) examples/bernoulli/bernoulli.o examples/bernoulli/bernoulli.d examples/bernoulli/bernoulli.hpp
 
 clean-program:

--- a/makefile
+++ b/makefile
@@ -229,8 +229,8 @@ clean-manual:
 
 clean-all: clean clean-deps clean-libraries clean-manual
 	$(RM) bin/stanc$(EXE) bin/stanc2$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE)
-	$(RM) -r src/cmdstan/main.*.o bin/cmdstan
-	$(RM) $(wildcard $(STAN)src/stan/model/model_header.*.hpp.gch)
+	$(RM) -r src/cmdstan/main*.o bin/cmdstan
+	$(RM) $(wildcard $(STAN)src/stan/model/model_header*.hpp.gch)
 	$(RM) examples/bernoulli/bernoulli$(EXE) examples/bernoulli/bernoulli.o examples/bernoulli/bernoulli.d examples/bernoulli/bernoulli.hpp
 
 clean-program:

--- a/makefile
+++ b/makefile
@@ -44,7 +44,7 @@ PRECOMPILED_HEADERS ?= true
 endif
 
 ifeq ($(PRECOMPILED_HEADERS),true)
-PRECOMPILED_MODEL_HEADER=$(STAN)src/stan/model/model_header.hpp.gch
+PRECOMPILED_MODEL_HEADER=$(STAN)src/stan/model/model_header$(STAN_FLAGS).hpp.gch
 ifeq ($(CXX_TYPE),gcc)
 CXXFLAGS_PROGRAM+= -Wno-ignored-attributes
 endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:


This PR makes switching on STAN_THREADS, STAN_MPI and STAN_OPENCL much easier.
What it does is changes the dependencies that need to be built for the model exe.

Currently that is:
`main.o` and `model_header.hpp.gch` for everything

Now the the dependency would be:
`main$(STAN_FLAGS).o` and `model_header$(STAN_FLAGS).hpp.gch`

Where `$(STAN_FLAGS)` is built as follows:
```
ifdef STAN_THREADS
STAN_FLAG_THREADS=_threads
endif
ifdef STAN_MPI
STAN_FLAG_MPI=_mpi
endif
ifdef STAN_OPENCL
STAN_FLAG_OPENCL=_opencl
endif

STAN_FLAGS=$(STAN_FLAG_THREADS)$(STAN_FLAG_MPI)$(STAN_FLAG_OPENCL)
```

Without the STAN_THREADS, STAN_MPI or STAN_OPENCL the dependencies are still `main.o` and `model_header.hpp.gch`. 
With STAN_THREADS the dependencies are  `main_threads.o` and `model_header_threads.hpp.gch`.
With MPI its `main_mpi.o` and `model_header_mpi.hpp.gch`. 
With thread and mpi its `main_threads_mpi.o` and `model_header_threads_mpi.hpp.gch`.
With STAN_OPENCL its `main_opencl.o` and `model_header_opencl.hpp.gch`.

The drawback: extra used space, especially the .hpp.gch files. With clang++ each .hpp.gch file is an extra ~200MB, with g++ its more 500-700MB. 

But, for those that dont use flags, nothing changes. And if you dont really use all combinations its not a big deal.

`make clean-all`
`make build -j4`

`time make examples/bernoulli/bernoulli`

Should be fast, the default main.o and precompiled header should have been build by `make build`
```
real    0m7,968s
user    0m7,586s
sys     0m0,349s
```

`touch examples/bernoulli/bernoulli.stan`
`time make STAN_THREADS=true examples/bernoulli/bernoulli`

Will be slower as `main_threads.o` and `model_header_threads.hpp.gch` need to be built.

real    0m43,892s
user    0m42,704s
sys     0m0,923s

`touch examples/bernoulli/bernoulli.stan`
`time make examples/bernoulli/bernoulli`

Should still be fast, nothing changed, main.o and precompiled header should still be there.

real    0m6,211s
user    0m5,988s
sys     0m0,191s

`touch examples/bernoulli/bernoulli.stan`
`time make STAN_THREADS=true examples/bernoulli/bernoulli`

Should be fast, nothing changed, main_threads.o and precompiled header for threads should still be there.

real    0m6,514s
user    0m6,237s
sys     0m0,238s

It also works with STAN_OPENCL and STAN_MPI and any mix of them.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar, Univ. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
