### PR TITLE
Add model compile information to stdout and csv

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -8,6 +8,7 @@
 #include <cmdstan/arguments/arg_random.hpp>
 #include <cmdstan/arguments/argument_parser.hpp>
 #include <cmdstan/io/json/json_data.hpp>
+#include <cmdstan/write_model_compile_info.hpp>
 #include <cmdstan/write_model.hpp>
 #include <cmdstan/write_opencl_device.hpp>
 #include <cmdstan/write_parallel_info.hpp>
@@ -131,7 +132,6 @@ int command(int argc, const char *argv[]) {
   parser.print(info);
   write_parallel_info(info);
   write_opencl_device(info);
-  info();
 
   stan::callbacks::writer init_writer;
   stan::callbacks::interrupt interrupt;
@@ -164,11 +164,16 @@ int command(int argc, const char *argv[]) {
   stan::model::model_base &model
       = new_model(*var_context, random_seed, &std::cout);
 
+  std::vector<std::string> model_compile_info = model.model_compile_info();
+  write_compile_info(info, model_compile_info);
+  info();
+
   write_stan(sample_writer);
   write_model(sample_writer, model.model_name());
   parser.print(sample_writer);
   write_parallel_info(sample_writer);
   write_opencl_device(sample_writer);
+  write_compile_info(sample_writer, model_compile_info);
 
   write_stan(diagnostic_writer);
   write_model(diagnostic_writer, model.model_name());

--- a/src/cmdstan/write_model_compile_info.hpp
+++ b/src/cmdstan/write_model_compile_info.hpp
@@ -7,11 +7,11 @@
 #include <vector>
 
 namespace cmdstan {
-void write_compile_info(stan::callbacks::writer &writer,
-                 std::vector<std::string>& compile_info) {
-    for (int i = 0; i < compile_info.size(); i++) {
-       writer(compile_info[i]);
-    }
+void write_compile_info(stan::callbacks::writer& writer,
+                        std::vector<std::string>& compile_info) {
+  for (int i = 0; i < compile_info.size(); i++) {
+    writer(compile_info[i]);
+  }
 }
 }  // namespace cmdstan
 #endif

--- a/src/cmdstan/write_model_compile_info.hpp
+++ b/src/cmdstan/write_model_compile_info.hpp
@@ -1,0 +1,17 @@
+#ifndef CMDSTAN_WRITE_COMPILE_INFO_HPP
+#define CMDSTAN_WRITE_COMPILE_INFO_HPP
+
+#include <stan/callbacks/writer.hpp>
+#include <stan/version.hpp>
+#include <string>
+#include <vector>
+
+namespace cmdstan {
+void write_compile_info(stan::callbacks::writer &writer,
+                 std::vector<std::string>& compile_info) {
+    for (int i = 0; i < compile_info.size(); i++) {
+       writer(compile_info[i]);
+    }
+}
+}  // namespace cmdstan
+#endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Addresses a part of #887 

Add models compile information (stanc version and flags used) to the stdout and CSV.

Example: 
```
data
  file = examples/bernoulli/bernoulli.data.json
init = 2 (Default)
random
  seed = 21139381 (Default)
output
  file = output.csv (Default)
  diagnostic_file =  (Default)
  refresh = 100 (Default)
stanc_version = stanc3 66c38187 (Unix)
stancflags = --warn-pedantic
```
```
# init = 2 (Default)
# random
#   seed = 21139381 (Default)
# output
#   file = output.csv (Default)
#   diagnostic_file =  (Default)
#   refresh = 100 (Default)
# stanc_version = stanc3 66c38187 (Unix)
# stancflags = --warn-pedantic
```

This should be included to make reproducing easier, especially with stanc optimization flag now available.

The tests will fail until https://github.com/stan-dev/stanc3/pull/598 and https://github.com/stan-dev/stan/pull/2932 are merged

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar, Univ. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
