### PR TITLE
Fix Windows Rtools 3.5 Boost program options bug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,23 +1,16 @@
 name: Manual build test
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
-    branches: [ master, develop, test ]
+    branches: [ develop ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ develop ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
       with:  
         submodules: 'recursive'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Manual build test
+name: Windows Rtools 3.5 
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+name: Manual build test
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master, develop, test ]
+  pull_request:
+    branches: [ master, develop ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+      with:  
+        submodules: 'recursive'
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '2.x'
+    - name: Download & install RTools
+      run: |
+        Invoke-WebRequest -Uri https://cran.rstudio.com/bin/windows/Rtools/Rtools35.exe -OutFile ./R35.exe
+        Start-Process -FilePath ./R35.exe -ArgumentList /VERYSILENT -NoNewWindow -Wait
+        echo "::add-path::C:/Rtools/bin"
+        echo "::add-path::C:/Rtools/mingw_64/bin"
+      shell: powershell
+    - name: Print toolchain versions and paths
+      run: |
+        g++ --version
+        mingw32-make --version
+        Get-Command g++ | Select-Object -ExpandProperty Definition
+        Get-Command mingw32-make | Select-Object -ExpandProperty Definition
+      shell: powershell
+    - name: Build Math libs & add to PATH
+      run: |
+        mingw32-make -f stan/lib/stan_math/make/standalone math-libs
+        echo "::add-path::D:/a/cmdstan/cmdstan/stan/lib/stan_math/lib/tbb"
+      shell: powershell
+    - name: Compile & run the example model
+      run: |
+        mingw32-make examples/bernoulli/bernoulli.exe
+        ./examples/bernoulli/bernoulli.exe sample data file=examples/bernoulli/bernoulli.data.json
+      shell: powershell

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,8 +18,7 @@ def runTests(String prefix = "") {
 def runWinTests(String prefix = "") {
     withEnv(["PATH+TBB=${WORKSPACE}\\stan\\lib\\stan_math\\lib\\tbb"]) {
        bat "echo %PATH%"
-       try { bat "mingw32-make -j${env.PARALLEL} build" }
-       finally { bat 'cat stan/lib/stan_math/lib/boost_1.72.0/bootstrap.log' }
+       bat "mingw32-make -j${env.PARALLEL} build"
        
        bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"
     }
@@ -69,72 +68,72 @@ pipeline {
             }
             post { always { deleteDir() }}
         }
-        // stage('Verify changes') {
-        //     agent { label 'linux' }
-        //     steps {
-        //         script {
+        stage('Verify changes') {
+            agent { label 'linux' }
+            steps {
+                script {
 
-        //             retry(3) { checkout scm }
-        //             sh 'git clean -xffd'
+                    retry(3) { checkout scm }
+                    sh 'git clean -xffd'
 
-        //             def paths = ['src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile'].join(" ")
-        //             skipRemainingStages = utils.verifyChanges(paths)
-        //         }
-        //     }
-        //     post {
-        //         always {
-        //             deleteDir()
-        //         }
-        //     }
-        // }
-        // stage("Clang-format") {
-        //     agent any
-        //     steps {
-        //         sh "printenv"
-        //         deleteDir()
-        //         retry(3) { checkout scm }
-        //         withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-        //             usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-        //             sh """#!/bin/bash
-        //                 set -x
-        //                 git checkout -b ${branchName()}
-        //                 clang-format --version
-        //                 find src -name '*.hpp' -o -name '*.cpp' | xargs -n20 -P${env.PARALLEL} clang-format -i
-        //                 if [[ `git diff` != "" ]]; then
-        //                     git config --global user.email "mc.stanislaw@gmail.com"
-        //                     git config --global user.name "Stan Jenkins"
-        //                     git add src
-        //                     git commit -m "[Jenkins] auto-formatting by `clang-format --version`"
-        //                     git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/cmdstan.git ${branchName()}
-        //                     echo "Exiting build because clang-format found changes."
-        //                     echo "Those changes are now found on stan-dev/cmdstan under branch ${branchName()}"
-        //                     echo "Please 'git pull' before continuing to develop."
-        //                     exit 1
-        //                 fi
-        //             """
-        //         }
-        //     }
-        //     post {
-        //         always { deleteDir() }
-        //         failure {
-        //             script {
-        //                 emailext (
-        //                     subject: "[StanJenkins] Autoformattted: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
-        //                     body: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' " +
-        //                         "has been autoformatted and the changes committed " +
-        //                         "to your branch, if permissions allowed." +
-        //                         "Please pull these changes before continuing." +
-        //                         "\n\n" +
-        //                         "See https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms" +
-        //                         " for setting up the autoformatter locally.\n"+
-        //                     "(Check console output at ${env.BUILD_URL})",
-        //                     recipientProviders: [[$class: 'RequesterRecipientProvider']],
-        //                     to: "${env.CHANGE_AUTHOR_EMAIL}"
-        //                 )
-        //             }
-        //         }
-        //     }
-        // }
+                    def paths = ['src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile'].join(" ")
+                    skipRemainingStages = utils.verifyChanges(paths)
+                }
+            }
+            post {
+                always {
+                    deleteDir()
+                }
+            }
+        }
+        stage("Clang-format") {
+            agent any
+            steps {
+                sh "printenv"
+                deleteDir()
+                retry(3) { checkout scm }
+                withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                    usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                    sh """#!/bin/bash
+                        set -x
+                        git checkout -b ${branchName()}
+                        clang-format --version
+                        find src -name '*.hpp' -o -name '*.cpp' | xargs -n20 -P${env.PARALLEL} clang-format -i
+                        if [[ `git diff` != "" ]]; then
+                            git config --global user.email "mc.stanislaw@gmail.com"
+                            git config --global user.name "Stan Jenkins"
+                            git add src
+                            git commit -m "[Jenkins] auto-formatting by `clang-format --version`"
+                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/cmdstan.git ${branchName()}
+                            echo "Exiting build because clang-format found changes."
+                            echo "Those changes are now found on stan-dev/cmdstan under branch ${branchName()}"
+                            echo "Please 'git pull' before continuing to develop."
+                            exit 1
+                        fi
+                    """
+                }
+            }
+            post {
+                always { deleteDir() }
+                failure {
+                    script {
+                        emailext (
+                            subject: "[StanJenkins] Autoformattted: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
+                            body: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' " +
+                                "has been autoformatted and the changes committed " +
+                                "to your branch, if permissions allowed." +
+                                "Please pull these changes before continuing." +
+                                "\n\n" +
+                                "See https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms" +
+                                " for setting up the autoformatter locally.\n"+
+                            "(Check console output at ${env.BUILD_URL})",
+                            recipientProviders: [[$class: 'RequesterRecipientProvider']],
+                            to: "${env.CHANGE_AUTHOR_EMAIL}"
+                        )
+                    }
+                }
+            }
+        }
         stage('Parallel tests') {
             when {
                 expression {
@@ -171,85 +170,85 @@ pipeline {
                     }
                 }
 
-                // stage('Linux interface tests with MPI') {
-                //     agent { label 'linux && mpi'}
-                //     steps {
-                //         setupCXX("${MPICXX}")
-                //         sh "echo STAN_MPI=true >> make/local"
-                //         sh "echo CXX_TYPE=gcc >> make/local"
-                //         sh "make build-mpi > build-mpi.log 2>&1"
-                //         sh runTests("./")
-                //     }
-                //     post {
-                //         always {
+                stage('Linux interface tests with MPI') {
+                    agent { label 'linux && mpi'}
+                    steps {
+                        setupCXX("${MPICXX}")
+                        sh "echo STAN_MPI=true >> make/local"
+                        sh "echo CXX_TYPE=gcc >> make/local"
+                        sh "make build-mpi > build-mpi.log 2>&1"
+                        sh runTests("./")
+                    }
+                    post {
+                        always {
 
-                //             recordIssues id: "Linux_mpi",
-                //             name: "Linux interface tests with MPI",
-                //             enabledForFailure: true,
-                //             aggregatingResults : true,
-                //             tools: [
-                //                 gcc4(id: "Linux_mpi_gcc4", name: "Linux interface tests with MPI@GCC4"),
-                //                 clang(id: "Linux_mpi_clang", name: "Linux interface tests with MPI@CLANG")
-                //             ],
-                //             blameDisabled: false,
-                //             qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-                //             healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
-                //             referenceJobName: env.BRANCH_NAME
+                            recordIssues id: "Linux_mpi",
+                            name: "Linux interface tests with MPI",
+                            enabledForFailure: true,
+                            aggregatingResults : true,
+                            tools: [
+                                gcc4(id: "Linux_mpi_gcc4", name: "Linux interface tests with MPI@GCC4"),
+                                clang(id: "Linux_mpi_clang", name: "Linux interface tests with MPI@CLANG")
+                            ],
+                            blameDisabled: false,
+                            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                            healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+                            referenceJobName: env.BRANCH_NAME
 
-                //             deleteDir()
-                //         }
-                //     }
-                // }
+                            deleteDir()
+                        }
+                    }
+                }
 
-                // stage('Mac interface tests') {
-                //     agent { label 'osx'}
-                //     steps {
-                //         setupCXX()
-                //         sh runTests("./")
-                //     }
-                //     post {
-                //         always {
+                stage('Mac interface tests') {
+                    agent { label 'osx'}
+                    steps {
+                        setupCXX()
+                        sh runTests("./")
+                    }
+                    post {
+                        always {
 
-                //             recordIssues id: "Mac",
-                //             name: "Mac interface tests",
-                //             enabledForFailure: true,
-                //             aggregatingResults : true,
-                //             tools: [
-                //                 gcc4(id: "Mac_gcc4", name: "Mac interface tests@GCC4"),
-                //                 clang(id: "Mac_clang", name: "Mac interface tests@CLANG")
-                //             ],
-                //             blameDisabled: false,
-                //             qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-                //             healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
-                //             referenceJobName: env.BRANCH_NAME
+                            recordIssues id: "Mac",
+                            name: "Mac interface tests",
+                            enabledForFailure: true,
+                            aggregatingResults : true,
+                            tools: [
+                                gcc4(id: "Mac_gcc4", name: "Mac interface tests@GCC4"),
+                                clang(id: "Mac_clang", name: "Mac interface tests@CLANG")
+                            ],
+                            blameDisabled: false,
+                            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                            healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+                            referenceJobName: env.BRANCH_NAME
 
-                //             deleteDir()
-                //         }
-                //     }
-                // }
+                            deleteDir()
+                        }
+                    }
+                }
 
-                // stage('Upstream CmdStan Performance tests') {
-                //     when {
-                //             expression {
-                //                 env.BRANCH_NAME ==~ /PR-\d+/ ||
-                //                 env.BRANCH_NAME == "downstream_tests" ||
-                //                 env.BRANCH_NAME == "downstream_hotfix"
-                //             }
-                //         }
-                //     steps {
-                //         script{
-                //             build(
-                //                 job: "CmdStan Performance Tests/downstream_tests",
-                //                 parameters: [
-                //                     string(name: 'cmdstan_pr', value: env.BRANCH_NAME),
-                //                     string(name: 'stan_pr', value: params.stan_pr),
-                //                     string(name: 'math_pr', value: params.math_pr)
-                //                 ],
-                //                 wait:true
-                //             )
-                //         }
-                //     }
-                // }
+                stage('Upstream CmdStan Performance tests') {
+                    when {
+                            expression {
+                                env.BRANCH_NAME ==~ /PR-\d+/ ||
+                                env.BRANCH_NAME == "downstream_tests" ||
+                                env.BRANCH_NAME == "downstream_hotfix"
+                            }
+                        }
+                    steps {
+                        script{
+                            build(
+                                job: "CmdStan Performance Tests/downstream_tests",
+                                parameters: [
+                                    string(name: 'cmdstan_pr', value: env.BRANCH_NAME),
+                                    string(name: 'stan_pr', value: params.stan_pr),
+                                    string(name: 'math_pr', value: params.math_pr)
+                                ],
+                                wait:true
+                            )
+                        }
+                    }
+                }
 
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,9 @@ pipeline {
                     agent { label 'windows' }
                     steps {
                         setupCXX()
-                        runWinTests()
+                        bat "g++ --version"
+                        bat "mingw32-make --version"
+                        runWinTests()                        
                     }
                     post {
                         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,9 @@ def runTests(String prefix = "") {
 def runWinTests(String prefix = "") {
     withEnv(["PATH+TBB=${WORKSPACE}\\stan\\lib\\stan_math\\lib\\tbb"]) {
        bat "echo %PATH%"
-       bat "mingw32-make -j${env.PARALLEL} build"
+       try { bat "mingw32-make -j${env.PARALLEL} build" }
+       finally { junit 'stan/lib/stan_math/lib/boost_1.72.0/bootstrap.log' }
+       
        bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"
     }
 }
@@ -150,7 +152,7 @@ pipeline {
                     }
                     post {
                         always {
-
+                            
                             recordIssues id: "Windows",
                             name: "Windows interface tests",
                             enabledForFailure: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,10 +144,11 @@ pipeline {
                     agent { label 'windows' }
                     steps {
                         setupCXX()
-                        runWinTests()                        
+                        runWinTests()
                     }
                     post {
                         always {
+
                             recordIssues id: "Windows",
                             name: "Windows interface tests",
                             enabledForFailure: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,72 +69,72 @@ pipeline {
             }
             post { always { deleteDir() }}
         }
-        stage('Verify changes') {
-            agent { label 'linux' }
-            steps {
-                script {
+        // stage('Verify changes') {
+        //     agent { label 'linux' }
+        //     steps {
+        //         script {
 
-                    retry(3) { checkout scm }
-                    sh 'git clean -xffd'
+        //             retry(3) { checkout scm }
+        //             sh 'git clean -xffd'
 
-                    def paths = ['src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile'].join(" ")
-                    skipRemainingStages = utils.verifyChanges(paths)
-                }
-            }
-            post {
-                always {
-                    deleteDir()
-                }
-            }
-        }
-        stage("Clang-format") {
-            agent any
-            steps {
-                sh "printenv"
-                deleteDir()
-                retry(3) { checkout scm }
-                withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                    usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                    sh """#!/bin/bash
-                        set -x
-                        git checkout -b ${branchName()}
-                        clang-format --version
-                        find src -name '*.hpp' -o -name '*.cpp' | xargs -n20 -P${env.PARALLEL} clang-format -i
-                        if [[ `git diff` != "" ]]; then
-                            git config --global user.email "mc.stanislaw@gmail.com"
-                            git config --global user.name "Stan Jenkins"
-                            git add src
-                            git commit -m "[Jenkins] auto-formatting by `clang-format --version`"
-                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/cmdstan.git ${branchName()}
-                            echo "Exiting build because clang-format found changes."
-                            echo "Those changes are now found on stan-dev/cmdstan under branch ${branchName()}"
-                            echo "Please 'git pull' before continuing to develop."
-                            exit 1
-                        fi
-                    """
-                }
-            }
-            post {
-                always { deleteDir() }
-                failure {
-                    script {
-                        emailext (
-                            subject: "[StanJenkins] Autoformattted: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
-                            body: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' " +
-                                "has been autoformatted and the changes committed " +
-                                "to your branch, if permissions allowed." +
-                                "Please pull these changes before continuing." +
-                                "\n\n" +
-                                "See https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms" +
-                                " for setting up the autoformatter locally.\n"+
-                            "(Check console output at ${env.BUILD_URL})",
-                            recipientProviders: [[$class: 'RequesterRecipientProvider']],
-                            to: "${env.CHANGE_AUTHOR_EMAIL}"
-                        )
-                    }
-                }
-            }
-        }
+        //             def paths = ['src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile'].join(" ")
+        //             skipRemainingStages = utils.verifyChanges(paths)
+        //         }
+        //     }
+        //     post {
+        //         always {
+        //             deleteDir()
+        //         }
+        //     }
+        // }
+        // stage("Clang-format") {
+        //     agent any
+        //     steps {
+        //         sh "printenv"
+        //         deleteDir()
+        //         retry(3) { checkout scm }
+        //         withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+        //             usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+        //             sh """#!/bin/bash
+        //                 set -x
+        //                 git checkout -b ${branchName()}
+        //                 clang-format --version
+        //                 find src -name '*.hpp' -o -name '*.cpp' | xargs -n20 -P${env.PARALLEL} clang-format -i
+        //                 if [[ `git diff` != "" ]]; then
+        //                     git config --global user.email "mc.stanislaw@gmail.com"
+        //                     git config --global user.name "Stan Jenkins"
+        //                     git add src
+        //                     git commit -m "[Jenkins] auto-formatting by `clang-format --version`"
+        //                     git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/cmdstan.git ${branchName()}
+        //                     echo "Exiting build because clang-format found changes."
+        //                     echo "Those changes are now found on stan-dev/cmdstan under branch ${branchName()}"
+        //                     echo "Please 'git pull' before continuing to develop."
+        //                     exit 1
+        //                 fi
+        //             """
+        //         }
+        //     }
+        //     post {
+        //         always { deleteDir() }
+        //         failure {
+        //             script {
+        //                 emailext (
+        //                     subject: "[StanJenkins] Autoformattted: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
+        //                     body: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' " +
+        //                         "has been autoformatted and the changes committed " +
+        //                         "to your branch, if permissions allowed." +
+        //                         "Please pull these changes before continuing." +
+        //                         "\n\n" +
+        //                         "See https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms" +
+        //                         " for setting up the autoformatter locally.\n"+
+        //                     "(Check console output at ${env.BUILD_URL})",
+        //                     recipientProviders: [[$class: 'RequesterRecipientProvider']],
+        //                     to: "${env.CHANGE_AUTHOR_EMAIL}"
+        //                 )
+        //             }
+        //         }
+        //     }
+        // }
         stage('Parallel tests') {
             when {
                 expression {
@@ -171,85 +171,85 @@ pipeline {
                     }
                 }
 
-                stage('Linux interface tests with MPI') {
-                    agent { label 'linux && mpi'}
-                    steps {
-                        setupCXX("${MPICXX}")
-                        sh "echo STAN_MPI=true >> make/local"
-                        sh "echo CXX_TYPE=gcc >> make/local"
-                        sh "make build-mpi > build-mpi.log 2>&1"
-                        sh runTests("./")
-                    }
-                    post {
-                        always {
+                // stage('Linux interface tests with MPI') {
+                //     agent { label 'linux && mpi'}
+                //     steps {
+                //         setupCXX("${MPICXX}")
+                //         sh "echo STAN_MPI=true >> make/local"
+                //         sh "echo CXX_TYPE=gcc >> make/local"
+                //         sh "make build-mpi > build-mpi.log 2>&1"
+                //         sh runTests("./")
+                //     }
+                //     post {
+                //         always {
 
-                            recordIssues id: "Linux_mpi",
-                            name: "Linux interface tests with MPI",
-                            enabledForFailure: true,
-                            aggregatingResults : true,
-                            tools: [
-                                gcc4(id: "Linux_mpi_gcc4", name: "Linux interface tests with MPI@GCC4"),
-                                clang(id: "Linux_mpi_clang", name: "Linux interface tests with MPI@CLANG")
-                            ],
-                            blameDisabled: false,
-                            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-                            healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
-                            referenceJobName: env.BRANCH_NAME
+                //             recordIssues id: "Linux_mpi",
+                //             name: "Linux interface tests with MPI",
+                //             enabledForFailure: true,
+                //             aggregatingResults : true,
+                //             tools: [
+                //                 gcc4(id: "Linux_mpi_gcc4", name: "Linux interface tests with MPI@GCC4"),
+                //                 clang(id: "Linux_mpi_clang", name: "Linux interface tests with MPI@CLANG")
+                //             ],
+                //             blameDisabled: false,
+                //             qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                //             healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+                //             referenceJobName: env.BRANCH_NAME
 
-                            deleteDir()
-                        }
-                    }
-                }
+                //             deleteDir()
+                //         }
+                //     }
+                // }
 
-                stage('Mac interface tests') {
-                    agent { label 'osx'}
-                    steps {
-                        setupCXX()
-                        sh runTests("./")
-                    }
-                    post {
-                        always {
+                // stage('Mac interface tests') {
+                //     agent { label 'osx'}
+                //     steps {
+                //         setupCXX()
+                //         sh runTests("./")
+                //     }
+                //     post {
+                //         always {
 
-                            recordIssues id: "Mac",
-                            name: "Mac interface tests",
-                            enabledForFailure: true,
-                            aggregatingResults : true,
-                            tools: [
-                                gcc4(id: "Mac_gcc4", name: "Mac interface tests@GCC4"),
-                                clang(id: "Mac_clang", name: "Mac interface tests@CLANG")
-                            ],
-                            blameDisabled: false,
-                            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-                            healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
-                            referenceJobName: env.BRANCH_NAME
+                //             recordIssues id: "Mac",
+                //             name: "Mac interface tests",
+                //             enabledForFailure: true,
+                //             aggregatingResults : true,
+                //             tools: [
+                //                 gcc4(id: "Mac_gcc4", name: "Mac interface tests@GCC4"),
+                //                 clang(id: "Mac_clang", name: "Mac interface tests@CLANG")
+                //             ],
+                //             blameDisabled: false,
+                //             qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                //             healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+                //             referenceJobName: env.BRANCH_NAME
 
-                            deleteDir()
-                        }
-                    }
-                }
+                //             deleteDir()
+                //         }
+                //     }
+                // }
 
-                stage('Upstream CmdStan Performance tests') {
-                    when {
-                            expression {
-                                env.BRANCH_NAME ==~ /PR-\d+/ ||
-                                env.BRANCH_NAME == "downstream_tests" ||
-                                env.BRANCH_NAME == "downstream_hotfix"
-                            }
-                        }
-                    steps {
-                        script{
-                            build(
-                                job: "CmdStan Performance Tests/downstream_tests",
-                                parameters: [
-                                    string(name: 'cmdstan_pr', value: env.BRANCH_NAME),
-                                    string(name: 'stan_pr', value: params.stan_pr),
-                                    string(name: 'math_pr', value: params.math_pr)
-                                ],
-                                wait:true
-                            )
-                        }
-                    }
-                }
+                // stage('Upstream CmdStan Performance tests') {
+                //     when {
+                //             expression {
+                //                 env.BRANCH_NAME ==~ /PR-\d+/ ||
+                //                 env.BRANCH_NAME == "downstream_tests" ||
+                //                 env.BRANCH_NAME == "downstream_hotfix"
+                //             }
+                //         }
+                //     steps {
+                //         script{
+                //             build(
+                //                 job: "CmdStan Performance Tests/downstream_tests",
+                //                 parameters: [
+                //                     string(name: 'cmdstan_pr', value: env.BRANCH_NAME),
+                //                     string(name: 'stan_pr', value: params.stan_pr),
+                //                     string(name: 'math_pr', value: params.math_pr)
+                //                 ],
+                //                 wait:true
+                //             )
+                //         }
+                //     }
+                // }
 
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,6 @@ def runWinTests(String prefix = "") {
     withEnv(["PATH+TBB=${WORKSPACE}\\stan\\lib\\stan_math\\lib\\tbb"]) {
        bat "echo %PATH%"
        bat "mingw32-make -j${env.PARALLEL} build"
-       
        bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"
     }
 }
@@ -145,13 +144,10 @@ pipeline {
                     agent { label 'windows' }
                     steps {
                         setupCXX()
-                        bat "g++ --version"
-                        bat "mingw32-make --version"
                         runWinTests()                        
                     }
                     post {
                         always {
-                            
                             recordIssues id: "Windows",
                             name: "Windows interface tests",
                             enabledForFailure: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ def runWinTests(String prefix = "") {
     withEnv(["PATH+TBB=${WORKSPACE}\\stan\\lib\\stan_math\\lib\\tbb"]) {
        bat "echo %PATH%"
        try { bat "mingw32-make -j${env.PARALLEL} build" }
-       finally { junit 'stan/lib/stan_math/lib/boost_1.72.0/bootstrap.log' }
+       finally { bat 'cat stan/lib/stan_math/lib/boost_1.72.0/bootstrap.log' }
        
        bat "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"
     }

--- a/make/command
+++ b/make/command
@@ -33,7 +33,7 @@ bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : bin/%$(EXE) : bin/cmd
 $(BOOST_PROGRAM_OPTIONS_LIB):
 	@mkdir -p $(dir $@)
 ifeq ($(OS),Windows_NT)
-	cd $(BOOST); ./bootstrap.bat
+	cd $(BOOST); ./bootstrap.bat --with-toolset=$(CXX_TYPE)
 else
 	cd $(BOOST); ./bootstrap.sh
 endif

--- a/make/command
+++ b/make/command
@@ -33,7 +33,7 @@ bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : bin/%$(EXE) : bin/cmd
 $(BOOST_PROGRAM_OPTIONS_LIB):
 	@mkdir -p $(dir $@)
 ifeq ($(OS),Windows_NT)
-	cd $(BOOST); sh bootstrap.sh
+	cd $(BOOST); ./bootstrap.bat
 else
 	cd $(BOOST); ./bootstrap.sh
 endif

--- a/make/command
+++ b/make/command
@@ -15,7 +15,7 @@ WINBITNESS=32
 endif
 endif
 BOOST_PROGRAM_OPTIONS_LIB=$(BOOST)/stage/lib/libboost_program_options*.a
-BOOST_BUILD_OPTS=--toolset=$(CXX_TYPE) address-model=$(WINBITNESS)
+BOOST_BUILD_OPTS= address-model=$(WINBITNESS)
 else
 BOOST_PROGRAM_OPTIONS_LIB=$(BOOST)/stage/lib/libboost_program_options.a
 BOOST_BUILD_OPTS=

--- a/make/command
+++ b/make/command
@@ -33,7 +33,7 @@ bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : bin/%$(EXE) : bin/cmd
 $(BOOST_PROGRAM_OPTIONS_LIB):
 	@mkdir -p $(dir $@)
 ifeq ($(OS),Windows_NT)
-	cd $(BOOST); ./bootstrap.bat --with-toolset=$(CXX_TYPE)
+	cd $(BOOST); ./bootstrap.bat gcc
 else
 	cd $(BOOST); ./bootstrap.sh
 endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This fixes #913 and adds Github Actions tests for Windows Rtools 3.5 (for now it tests that it builds and is able to build the example model).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar, Univ. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
