### PR TITLE
fixes math#1852. Fixes deprecation warning in Google Test

### DIFF
--- a/src/test/interface/arguments/singleton_argument_test.cpp
+++ b/src/test/interface/arguments/singleton_argument_test.cpp
@@ -45,7 +45,7 @@ class CmdStanArgumentsSingleton : public ::testing::Test {
   std::stringstream ss;
 };
 
-TYPED_TEST_CASE_P(CmdStanArgumentsSingleton);
+TYPED_TEST_SUITE_P(CmdStanArgumentsSingleton);
 
 TYPED_TEST_P(CmdStanArgumentsSingleton, constructor) {
   // test fixture would have created the argument
@@ -140,11 +140,11 @@ TYPED_TEST_P(CmdStanArgumentsSingleton, argument_lookup) {
   // EXPECT_EQ(0, this->arg->arg("foo"));
 }
 
-REGISTER_TYPED_TEST_CASE_P(CmdStanArgumentsSingleton, constructor, name,
-                           description, print, print_help, parse_args,
-                           parse_args_unexpected, argument_lookup);
+REGISTER_TYPED_TEST_SUITE_P(CmdStanArgumentsSingleton, constructor, name,
+                            description, print, print_help, parse_args,
+                            parse_args_unexpected, argument_lookup);
 
-INSTANTIATE_TYPED_TEST_CASE_P(real, CmdStanArgumentsSingleton, double);
-INSTANTIATE_TYPED_TEST_CASE_P(int, CmdStanArgumentsSingleton, int);
-INSTANTIATE_TYPED_TEST_CASE_P(bool, CmdStanArgumentsSingleton, bool);
-INSTANTIATE_TYPED_TEST_CASE_P(string, CmdStanArgumentsSingleton, std::string);
+INSTANTIATE_TYPED_TEST_SUITE_P(real, CmdStanArgumentsSingleton, double);
+INSTANTIATE_TYPED_TEST_SUITE_P(int, CmdStanArgumentsSingleton, int);
+INSTANTIATE_TYPED_TEST_SUITE_P(bool, CmdStanArgumentsSingleton, bool);
+INSTANTIATE_TYPED_TEST_SUITE_P(string, CmdStanArgumentsSingleton, std::string);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

When upgrading Google Test (in Stan Math) to the latest version, we use deprecated macros which trigger compiler warnings. Since we fail builds with warnings, we need to fix this at the same time the Stan Math PR goes in.

#### Intended Effect:

Squashes a warning.

#### How to Verify:

1. Update the CmdStan branch to `develop` and the Math branch to `feature/issue-1852-google-benchmarh`
2. Run:
    ```
./runCmdStanTests.py src/test/interface/arguments/singleton_argument_test.cpp
    ```
3. This will have warnings:
    ```
...
clang++ -std=c++1y -Wno-unknown-warning-option -Wno-tautological-compare -Wno-sign-compare -D_REENTRANT -Wno-ignored-attributes     -DSTAN_THREADS -I stan/lib/stan_math/lib/tbb_2019_U8/include -O3 -I src -I stan/src -I lib/rapidjson_1.1.0/ -I stan/lib/stan_math/ -I stan/lib/stan_math/lib/eigen_3.3.7 -I stan/lib/stan_math/lib/boost_1.72.0 -I stan/lib/stan_math/lib/sundials_5.2.0/include -I stan/lib/stan_math/lib/benchmark_1.5.1/googletest/googletest/include -I stan/lib/stan_math/lib/benchmark_1.5.1/googletest/googletest -I lib/rapidjson_1.1.0/ -I stan/lib/stan_math/lib/benchmark_1.5.1/googletest/googletest/include -I stan/lib/stan_math/lib/benchmark_1.5.1/googletest/googletest -I lib/rapidjson_1.1.0/      -DBOOST_DISABLE_ASSERTS        -c src/test/interface/arguments/singleton_argument_test.cpp -o test/interface/arguments/singleton_argument_test.o
src/test/interface/arguments/singleton_argument_test.cpp:48:1: warning: 'TypedTestCase_P_IsDeprecated' is deprecated:
      TYPED_TEST_CASE_P is deprecated, please use TYPED_TEST_SUITE_P [-Wdeprecated-declarations]
TYPED_TEST_CASE_P(CmdStanArgumentsSingleton);
^
stan/lib/stan_math/lib/benchmark_1.5.1/googletest/googletest/include/gtest/gtest-typed-test.h:270:38: note: expanded
      from macro 'TYPED_TEST_CASE_P'
  static_assert(::testing::internal::TypedTestCase_P_IsDeprecated(), ""); \
                                     ^
stan/lib/stan_math/lib/benchmark_1.5.1/googletest/googletest/include/gtest/internal/gtest-internal.h:1241:1: note: 
      'TypedTestCase_P_IsDeprecated' has been explicitly marked deprecated here
GTEST_INTERNAL_DEPRECATED(
^
stan/lib/stan_math/lib/benchmark_1.5.1/googletest/googletest/include/gtest/internal/gtest-port.h:2249:59: note: 
      expanded from macro 'GTEST_INTERNAL_DEPRECATED'
#define GTEST_INTERNAL_DEPRECATED(message) __attribute__((deprecated(message)))
                                                          ^
src/test/interface/arguments/singleton_argument_test.cpp:143:1: warning: 'RegisterTypedTestCase_P_IsDeprecated' is
      deprecated: REGISTER_TYPED_TEST_CASE_P is deprecated, please use REGISTER_TYPED_TEST_SUITE_P
      [-Wdeprecated-declarations]
REGISTER_TYPED_TEST_CASE_P(CmdStanArgumentsSingleton, constructor, name,
^
stan/lib/stan_math/lib/benchmark_1.5.1/googletest/googletest/include/gtest/gtest-typed-test.h:305:38: note: expanded
      from macro 'REGISTER_TYPED_TEST_CASE_P'
  static_assert(::testing::internal::RegisterTypedTestCase_P_IsDeprecated(), \
                                     ^
stan/lib/stan_math/lib/benchmark_1.5.1/googletest/googletest/include/gtest/internal/gtest-internal.h:1251:1: note: 
      'RegisterTypedTestCase_P_IsDeprecated' has been explicitly marked deprecated here
GTEST_INTERNAL_DEPRECATED(
^
stan/lib/stan_math/lib/benchmark_1.5.1/googletest/googletest/include/gtest/internal/gtest-port.h:2249:59: note: 
      expanded from macro 'GTEST_INTERNAL_DEPRECATED'
#define GTEST_INTERNAL_DEPRECATED(message) __attribute__((deprecated(message)))
                                                          ^
...
    ```
4. Update the CmdStan to branch `feature/math-issue-1852-google-benchmark` and Math to `feature/issue-1852-google-benchmark` (same as before)
5. Run    
    ```
./runCmdStanTests.py src/test/interface/arguments/singleton_argument_test.cpp
    ```
6. There will be no warnings.

#### Side Effects:

None. 

#### Documentation:

None. (Just 8 lines of replacing deprecated macros with the equivalent that's not deprecated.)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Generable

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
