### PR TITLE
Allows download of specific stanc3 version

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -13,6 +13,7 @@ CMDSTAN_SUBMODULES = 1
 STANC_DL_RETRY = 5
 STANC_DL_DELAY = 10
 STANC3_TEST_BIN_URL ?=
+STANC3_VERSION ?= nightly
 
 ifeq ($(OS),Windows_NT)
  OS_TAG := windows
@@ -66,12 +67,12 @@ else ifeq ($(OS_TAG),windows)
 # get latest stanc3 - Windows
     bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
-	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)")
+	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/$(STANC3_VERSION)/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)")
 else
 # get latest stanc3 - Linux & MacOS
     bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
-	curl -L https://github.com/stan-dev/stanc3/releases/download/nightly/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
+	curl -L https://github.com/stan-dev/stanc3/releases/download/$(STANC3_VERSION)/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
 	chmod +x bin/stanc$(EXE)
 endif
 

--- a/makefile
+++ b/makefile
@@ -114,6 +114,8 @@ endif
 	@echo '      header file that is included. This defaults to "user_header.hpp" in the'
 	@echo '      directory of the Stan program.'
 	@echo '    STANC2: When set, use bin/stanc2 to generate C++ code.'
+	@echo '    STANC3_VERSION: When set, uses that tagged version specified; otherwise, downloads'
+	@echo '      the nightly version.'
 	@echo ''
 	@echo ''
 	@echo '  Example - bernoulli model: examples/bernoulli/bernoulli.stan'


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Adds a way to download a specific stanc3 version.

This PR adds a `STANC3_VERSION` make variable. The default is `nightly`.

There's documentation for it too in the makefile.


#### Intended Effect:

Allows user to download a specific STANC3_VERSION.

#### How to Verify:

```
rm bin/stanc
make bin/stanc STANC3_VERSION=v2.24.1
./bin/stanc --version
```

Should print

```
stanc3 v2.24.1 (Unix)
```

#### Side Effects:

One thing that a user may expect is for the `bin/stanc` to be updated if a new version is provided. This won't do that. You have to remove `bin/stanc` for this to download a different version.

#### Documentation:

In the `makefile`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Generable

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
