### PR TITLE
fix build under macOS Catalina where boost build failed to set correc…

### DIFF
--- a/make/command
+++ b/make/command
@@ -18,7 +18,11 @@ BOOST_PROGRAM_OPTIONS_LIB=$(BOOST)/stage/lib/libboost_program_options*.a
 BOOST_BUILD_OPTS= address-model=$(WINBITNESS)
 else
 BOOST_PROGRAM_OPTIONS_LIB=$(BOOST)/stage/lib/libboost_program_options.a
+ifeq ($(OS),Darwin)
+BOOST_BUILD_OPTS ?= toolset=$(CXX_TYPE)
+else
 BOOST_BUILD_OPTS=
+endif
 endif
 
 .PRECIOUS: bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE)


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run tests: `./runCmdStanTests.py src/test`
- [X] Declare copyright holder and open-source license: see below

#### Summary:

this fix makes cmdstan build again under macOS where boost build started to use g++ as toolset instead of clang. This caused compilation of program_options to fail.

#### Intended Effect:

make build should work under macOS

#### How to Verify:

run make build on a macOS machine

#### Side Effects:

none

#### Documentation:

NA

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
