### PR TITLE
Revert "Revert "Add additional compiler optimization flags""

### DIFF
--- a/examples/bernoulli/bernoulli.stan
+++ b/examples/bernoulli/bernoulli.stan
@@ -1,10 +1,10 @@
-data { 
-  int<lower=0> N; 
+data {
+  int<lower=0> N;
   int<lower=0,upper=1> y[N];
-} 
+}
 parameters {
   real<lower=0,upper=1> theta;
-} 
+}
 model {
   theta ~ beta(1,1);  // uniform prior on interval 0,1
   y ~ bernoulli(theta);

--- a/make/command
+++ b/make/command
@@ -27,7 +27,7 @@ endif
 
 .PRECIOUS: bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE)
 bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : CPPFLAGS_MPI =
-bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : LDFLAGS_MPI =
+bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : LDFLAGS_MPI = 
 bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : LDLIBS_MPI =
 bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : bin/%$(EXE) : bin/cmdstan/%.o $(BOOST_PROGRAM_OPTIONS_LIB)
 	@mkdir -p $(dir $@)

--- a/makefile
+++ b/makefile
@@ -25,6 +25,70 @@ RAPIDJSON ?= lib/rapidjson_1.1.0/
 INC_FIRST ?= -I src -I $(STAN)src -I $(RAPIDJSON)
 USER_HEADER ?= $(dir $<)user_header.hpp
 
+## Set default compiler
+ifeq (default,$(origin CXX))
+  ifeq ($(OS),Darwin)  ## Darwin is Mac OS X
+    CXX := clang++
+  endif
+  ifeq ($(OS),Linux)
+    CXX := g++
+  endif
+  ifeq ($(OS),Windows_NT)
+    CXX := g++
+  endif
+endif
+
+# Detect compiler type
+# - CXX_TYPE: {gcc, clang, mingw32-gcc, other}
+# - CXX_MAJOR: major version of CXX
+# - CXX_MINOR: minor version of CXX
+ifneq (,$(findstring clang,$(CXX)))
+  CXX_TYPE ?= clang
+endif
+ifneq (,$(findstring mingw32-g,$(CXX)))
+  CXX_TYPE ?= mingw32-gcc
+endif
+ifneq (,$(findstring gcc,$(CXX)))
+  CXX_TYPE ?= gcc
+endif
+ifneq (,$(findstring g++,$(CXX)))
+  CXX_TYPE ?= gcc
+endif
+CXX_TYPE ?= other
+CXX_MAJOR := $(shell $(CXX) -dumpversion 2>&1 | cut -d'.' -f1)
+CXX_MINOR := $(shell $(CXX) -dumpversion 2>&1 | cut -d'.' -f2)
+
+ifdef STAN_COMPILER_OPTIMS
+	ifeq (clang,$(CXX_TYPE))
+		CXXFLAGS_OPTIM ?= -fvectorize -ftree-vectorize -fslp-vectorize -ftree-slp-vectorize -fno-standalone-debug -fstrict-return -funroll-loops
+		ifeq ($(shell expr $(CXX_MAJOR) \>= 5), 1)
+			CXXFLAGS_FLTO ?= -flto=full -fwhole-program-vtables -fstrict-vtable-pointers -fforce-emit-vtables
+		endif
+	endif
+	ifeq (mingw32-g,$(CXX_TYPE))
+	else ifeq (gcc,$(CXX_TYPE))
+		CXXFLAGS_OPTIM_SUNDIALS ?= -fweb -fivopts -ftree-loop-linear
+		CPPFLAGS_OPTIM_SUNDIALS ?= $(CXXFLAGS_OPTIM_SUNDIALS)
+		# temp to contro for compiler versions while letting user override
+		# CXXFLAGS_OPTIM
+		CXXFLAGS_VERSION_OPTIM ?= -fweb -fivopts -ftree-loop-linear -floop-strip-mine -floop-block -floop-nest-optimize -ftree-vectorize -ftree-loop-distribution -funroll-loops
+		ifeq ($(shell expr $(CXX_MAJOR) \>= 5), 1)
+		  CXXFLAGS_VERSION_OPTIM += -floop-unroll-and-jam
+	  endif
+		ifeq ($(shell expr $(CXX_MAJOR) \>= 7), 1)
+		  CXXFLAGS_VERSION_OPTIM += -fsplit-loops
+			ifneq ($(OS),Windows_NT)
+				CXXFLAGS_FLTO ?= -flto -fuse-linker-plugin -fdevirtualize-at-ltrans
+      endif
+	  endif
+		ifndef STAN_MPI
+		  CXXFLAGS_VISIBILITY ?= -fvisibility=hidden -fvisibility-inlines-hidden
+		endif
+		CXXFLAGS_OPTIM ?= $(CXXFLAGS_VERSION_OPTIM) $(CXXFLAGS_VISIBILITY)
+		LDFLAGS_FLTO ?=  $(CXXFLAGS_FLTO)
+	endif
+endif
+
 ifdef STAN_THREADS
 STAN_FLAG_THREADS=_threads
 endif
@@ -46,7 +110,7 @@ endif
 ifeq ($(PRECOMPILED_HEADERS),true)
 PRECOMPILED_MODEL_HEADER=$(STAN)src/stan/model/model_header$(STAN_FLAGS).hpp.gch
 ifeq ($(CXX_TYPE),gcc)
-CXXFLAGS_PROGRAM+= -Wno-ignored-attributes
+CXXFLAGS_PROGRAM+= -Wno-ignored-attributes $(CXXFLAGS_OPTIM) $(CXXFLAGS_FLTO)
 endif
 else
 PRECOMPILED_MODEL_HEADER=
@@ -116,6 +180,7 @@ endif
 	@echo '    STANC2: When set, use bin/stanc2 to generate C++ code.'
 	@echo '    STANC3_VERSION: When set, uses that tagged version specified; otherwise, downloads'
 	@echo '      the nightly version.'
+	@echo '    STAN_COMPILER_OPTIMS: Turns on additonal compiler flags for performance           '
 	@echo ''
 	@echo ''
 	@echo '  Example - bernoulli model: examples/bernoulli/bernoulli.stan'

--- a/makefile
+++ b/makefile
@@ -25,6 +25,11 @@ RAPIDJSON ?= lib/rapidjson_1.1.0/
 INC_FIRST ?= -I src -I $(STAN)src -I $(RAPIDJSON)
 USER_HEADER ?= $(dir $<)user_header.hpp
 
+## Detect operating system
+ifneq ($(OS),Windows_NT)
+  OS := $(shell uname -s)
+endif
+
 ## Set default compiler
 ifeq (default,$(origin CXX))
   ifeq ($(OS),Darwin)  ## Darwin is Mac OS X


### PR DESCRIPTION
Revert revert to add the additional compiler flags. @mitzimorris and @bob-carpenter both had trouble getting this to install on mac and it looks like the windows tests failed (but the tests passed before merge so idk whats up with that?) The odd thing is that nothing should happen if the user does not have the `STAN_COMPILER_OPTIMS` flag enabled.