### PR TITLE
Feature/936 sig figs upper limit

### DIFF
--- a/src/cmdstan/stansummary.cpp
+++ b/src/cmdstan/stansummary.cpp
@@ -34,7 +34,7 @@ Options:
                               comma-separated integers from (1,99), inclusive.
                               Default is 5,50,95.
   -s, --sig_figs [n]          Significant figures reported. Default is 2.
-                              Must be an integer from (1, 10), inclusive.
+                              Must be an integer from (1, 18), inclusive.
 )";
   if (argc < 2) {  // pre-empt boost::program_options
     std::cout << usage << std::endl;
@@ -126,7 +126,7 @@ Options:
     std::cout << "Ouput csv_file: " << csv_filename << std::endl;
   }
   if (vm.count("sig_figs") && !vm["sig_figs"].defaulted()) {
-    if (sig_figs < 1 || sig_figs > 10) {
+    if (sig_figs < 1 || sig_figs > 18) {
       std::cout << "Bad value for option --sig_figs: "
                 << vm["sig_figs"].as<int>() << ", exiting." << std::endl;
       std::cout << std::endl << usage << std::endl;


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Increase the limit for precision in summary calculations to match max precision in output.csv file, per PR https://github.com/stan-dev/cmdstan/pull/931

#### Intended Effect:
carry precision through to summary statistics

#### How to Verify:
unit tests

#### Side Effects:
N/A

#### Documentation:
update as part of https://github.com/stan-dev/docs/issues/273

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
