### PR TITLE
Feature/936 sig figs upper limit

### DIFF
--- a/src/cmdstan/stansummary.cpp
+++ b/src/cmdstan/stansummary.cpp
@@ -239,6 +239,9 @@ Options:
   // Write to csv file (optional)
   if (vm.count("csv_filename")) {
     std::ofstream csv_file(csv_filename.c_str(), std::ios_base::app);
+    if (vm.count("sig_figs") && !vm["sig_figs"].defaulted()) {
+      csv_file << std::setprecision(vm["sig_figs"].as<int>());
+    }
     write_header(header, column_widths, max_name_length, true, &csv_file);
     write_params(chains, lp_param, column_widths, model_formats,
                  max_name_length, sig_figs, 0, true, &csv_file);

--- a/src/test/interface/stansummary_test.cpp
+++ b/src/test/interface/stansummary_test.cpp
@@ -439,3 +439,57 @@ TEST(CommandStansummary, check_csv_output) {
   if (return_code != 0)
     FAIL();
 }
+
+TEST(CommandStansummary, check_csv_output_sig_figs) {
+  std::string csv_header
+      = "name,Mean,MCSE,StdDev,5%,50%,95%,N_Eff,N_Eff/s,R_hat";
+  std::string lp
+      = "\"lp__\",-7.3,0.037,0.77,-9.1,-7,-6.8,4.4e+02,1.9e+04,1";
+  std::string energy
+      = "\"energy__\",7.8,0.051,1,6.8,7.5,9.9,4.1e+02,1.8e+04,1";
+  std::string theta
+      = "\"theta\",0.26,0.0061,0.12,0.079,0.25,0.47,3.8e+02,1.7e+04,1";
+
+  std::string path_separator;
+  path_separator.push_back(get_path_separator());
+  std::string command = "bin" + path_separator + "stansummary";
+  std::string csv_file = "src" + path_separator + "test" + path_separator
+                         + "interface" + path_separator + "example_output"
+                         + path_separator + "bernoulli_chain_1.csv";
+
+  std::string target_csv_file = "src" + path_separator + "test" + path_separator
+                                + "interface" + path_separator
+                                + "example_output" + path_separator
+                                + "tmp_test_target_csv_file.csv";
+  std::string arg_csv_file = "--csv_file " + target_csv_file;
+  std::string arg_sig_figs = "--sig_figs 2";
+
+  run_command_output out
+      = run_command(command + " "
+                    + arg_csv_file + " "
+                    + arg_sig_figs + " "
+                    + csv_file);
+  ASSERT_FALSE(out.hasError) << "\"" << out.command << "\" quit with an error";
+
+  std::ifstream target_stream(target_csv_file.c_str());
+  if (!target_stream.is_open())
+    FAIL();
+  std::string line;
+  std::getline(target_stream, line);
+  EXPECT_EQ(csv_header, line);
+  std::getline(target_stream, line);
+  EXPECT_EQ(lp, line);
+  std::getline(target_stream, line);  // accept_stat
+  std::getline(target_stream, line);  // stepsize
+  std::getline(target_stream, line);  // treedepth
+  std::getline(target_stream, line);  // n_leapfrog
+  std::getline(target_stream, line);  // divergent
+  std::getline(target_stream, line);  // energy
+  EXPECT_EQ(energy, line);
+  std::getline(target_stream, line);
+  EXPECT_EQ(theta, line);
+  target_stream.close();
+  int return_code = std::remove(target_csv_file.c_str());
+  if (return_code != 0)
+    FAIL();
+}

--- a/src/test/interface/stansummary_test.cpp
+++ b/src/test/interface/stansummary_test.cpp
@@ -443,10 +443,8 @@ TEST(CommandStansummary, check_csv_output) {
 TEST(CommandStansummary, check_csv_output_sig_figs) {
   std::string csv_header
       = "name,Mean,MCSE,StdDev,5%,50%,95%,N_Eff,N_Eff/s,R_hat";
-  std::string lp
-      = "\"lp__\",-7.3,0.037,0.77,-9.1,-7,-6.8,4.4e+02,1.9e+04,1";
-  std::string energy
-      = "\"energy__\",7.8,0.051,1,6.8,7.5,9.9,4.1e+02,1.8e+04,1";
+  std::string lp = "\"lp__\",-7.3,0.037,0.77,-9.1,-7,-6.8,4.4e+02,1.9e+04,1";
+  std::string energy = "\"energy__\",7.8,0.051,1,6.8,7.5,9.9,4.1e+02,1.8e+04,1";
   std::string theta
       = "\"theta\",0.26,0.0061,0.12,0.079,0.25,0.47,3.8e+02,1.7e+04,1";
 
@@ -464,11 +462,8 @@ TEST(CommandStansummary, check_csv_output_sig_figs) {
   std::string arg_csv_file = "--csv_file " + target_csv_file;
   std::string arg_sig_figs = "--sig_figs 2";
 
-  run_command_output out
-      = run_command(command + " "
-                    + arg_csv_file + " "
-                    + arg_sig_figs + " "
-                    + csv_file);
+  run_command_output out = run_command(command + " " + arg_csv_file + " "
+                                       + arg_sig_figs + " " + csv_file);
   ASSERT_FALSE(out.hasError) << "\"" << out.command << "\" quit with an error";
 
   std::ifstream target_stream(target_csv_file.c_str());


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Change stanstummary code so that if `sig_figs` arg is specified and output is saved to CSV file,
the precision of the CSV file is set to `sig_figs`.

#### Intended Effect:

Allow CmdStanPy users to get summary with extra precision as needed.

#### How to Verify:

Unit test

#### Side Effects:

N/A

#### Documentation:

see https://github.com/stan-dev/docs/issues/273

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
