### PR TITLE
Rename STAN_COMPILER_OPTIMS to STAN_CPP_OPTIMS

### DIFF
--- a/makefile
+++ b/makefile
@@ -63,7 +63,7 @@ CXX_TYPE ?= other
 CXX_MAJOR := $(shell $(CXX) -dumpversion 2>&1 | cut -d'.' -f1)
 CXX_MINOR := $(shell $(CXX) -dumpversion 2>&1 | cut -d'.' -f2)
 
-ifdef STAN_COMPILER_OPTIMS
+ifdef STAN_CPP_OPTIMS
 	ifeq (clang,$(CXX_TYPE))
 		CXXFLAGS_OPTIM ?= -fvectorize -ftree-vectorize -fslp-vectorize -ftree-slp-vectorize -fno-standalone-debug -fstrict-return -funroll-loops
 		ifeq ($(shell expr $(CXX_MAJOR) \>= 5), 1)
@@ -185,7 +185,7 @@ endif
 	@echo '    STANC2: When set, use bin/stanc2 to generate C++ code.'
 	@echo '    STANC3_VERSION: When set, uses that tagged version specified; otherwise, downloads'
 	@echo '      the nightly version.'
-	@echo '    STAN_COMPILER_OPTIMS: Turns on additonal compiler flags for performance           '
+	@echo '    STAN_CPP_OPTIMS: Turns on additonal compiler flags for performance           '
 	@echo ''
 	@echo ''
 	@echo '  Example - bernoulli model: examples/bernoulli/bernoulli.stan'


### PR DESCRIPTION
### Summary:

PR title says it all: renames STAN_COMPILER_OPTIMS to STAN_CPP_OPTIMS

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar, Uni. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
