### PR TITLE
Fix PATH setting in RTools 3.5 test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,7 @@ jobs:
       run: |
         Invoke-WebRequest -Uri https://cran.rstudio.com/bin/windows/Rtools/Rtools35.exe -OutFile ./R35.exe
         Start-Process -FilePath ./R35.exe -ArgumentList /VERYSILENT -NoNewWindow -Wait
-        echo "::add-path::C:/Rtools/bin"
-        echo "::add-path::C:/Rtools/mingw_64/bin"
+        echo "C:/Rtools/bin;C:/Rtools/mingw_64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
       shell: powershell
     - name: Print toolchain versions and paths
       run: |
@@ -34,7 +33,7 @@ jobs:
     - name: Build Math libs & add to PATH
       run: |
         mingw32-make -f stan/lib/stan_math/make/standalone math-libs
-        echo "::add-path::D:/a/cmdstan/cmdstan/stan/lib/stan_math/lib/tbb"
+        echo "D:/a/cmdstan/cmdstan/stan/lib/stan_math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
       shell: powershell
     - name: Compile & run the example model
       run: |


### PR DESCRIPTION
#### Summary:

Replaces the use of ::add-path:: that was disabled on Github Actions (see https://github.com/stan-dev/cmdstan/runs/1446801081)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar, Uni. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
