### PR TITLE
Runtime OpenCL device selection, allow seed=0 and fix allow-undefined user_header bug

### DIFF
--- a/make/program
+++ b/make/program
@@ -29,7 +29,7 @@ CXXFLAGS_PROGRAM += -include-pch $(STAN)src/stan/model/model_header$(STAN_FLAGS)
 $(STAN_TARGETS) examples/bernoulli/bernoulli$(EXE) $(patsubst %.stan,%$(EXE),$(wildcard src/test/test-models/*.stan)) : %$(EXE) : $(STAN)src/stan/model/model_header$(STAN_FLAGS).hpp.gch
 endif
 
-ifneq ($(findstring allow_undefined,$(STANCFLAGS)),)
+ifneq ($(findstring allow_undefined,$(STANCFLAGS))$(findstring allow-undefined,$(STANCFLAGS)),)
 $(STAN_TARGETS) examples/bernoulli/bernoulli$(EXE) $(patsubst %.stan,%$(EXE),$(wildcard src/test/test-models/*.stan)) : CXXFLAGS_PROGRAM += -include $(USER_HEADER)
 endif
 

--- a/src/cmdstan/arguments/arg_opencl.hpp
+++ b/src/cmdstan/arguments/arg_opencl.hpp
@@ -1,0 +1,22 @@
+#ifndef CMDSTAN_ARGUMENTS_ARG_OPENCL_HPP
+#define CMDSTAN_ARGUMENTS_ARG_OPENCL_HPP
+
+#include <cmdstan/arguments/arg_opencl_device.hpp>
+#include <cmdstan/arguments/arg_opencl_platform.hpp>
+#include <cmdstan/arguments/categorical_argument.hpp>
+
+namespace cmdstan {
+
+class arg_opencl : public categorical_argument {
+ public:
+  arg_opencl() {
+    _name = "opencl";
+    _description = "OpenCL options";
+
+    _subarguments.push_back(new arg_opencl_device());
+    _subarguments.push_back(new arg_opencl_platform());
+  }
+};
+
+}  // namespace cmdstan
+#endif

--- a/src/cmdstan/arguments/arg_opencl_device.hpp
+++ b/src/cmdstan/arguments/arg_opencl_device.hpp
@@ -1,0 +1,26 @@
+#ifndef CMDSTAN_ARGUMENTS_ARG_OPENCL_DEVICE_HPP
+#define CMDSTAN_ARGUMENTS_ARG_OPENCL_DEVICE_HPP
+
+#include <cmdstan/arguments/singleton_argument.hpp>
+
+namespace cmdstan {
+
+class arg_opencl_device : public int_argument {
+ public:
+  arg_opencl_device() : int_argument() {
+    _name = "device";
+    _description = "ID of the OpenCL device to use";
+    _validity = "device >= 0 or -1 to use the compile-time device ID";
+    _default = "-1";
+    _default_value = -1;
+    _constrained = true;
+    _good_value = 1;
+    _bad_value = -1.0;
+    _value = _default_value;
+  }
+
+  bool is_valid(int value) { return value >= 0 || value == _default_value; }
+};
+
+}  // namespace cmdstan
+#endif

--- a/src/cmdstan/arguments/arg_opencl_platform.hpp
+++ b/src/cmdstan/arguments/arg_opencl_platform.hpp
@@ -1,0 +1,26 @@
+#ifndef CMDSTAN_ARGUMENTS_ARG_OPENCL_PLATFORM_HPP
+#define CMDSTAN_ARGUMENTS_ARG_OPENCL_PLATFORM_HPP
+
+#include <cmdstan/arguments/singleton_argument.hpp>
+
+namespace cmdstan {
+
+class arg_opencl_platform : public int_argument {
+ public:
+  arg_opencl_platform() : int_argument() {
+    _name = "platform";
+    _description = "ID of the OpenCL platform to use";
+    _validity = "platform >= 0 or -1 to use the compile-time platform ID";
+    _default = "-1";
+    _default_value = -1;
+    _constrained = true;
+    _good_value = 1;
+    _bad_value = -1.0;
+    _value = _default_value;
+  }
+
+  bool is_valid(int value) { return value >= 0 || value == _default_value; }
+};
+
+}  // namespace cmdstan
+#endif

--- a/src/cmdstan/arguments/arg_seed.hpp
+++ b/src/cmdstan/arguments/arg_seed.hpp
@@ -12,7 +12,7 @@ class arg_seed : public int_argument {
   arg_seed() : int_argument() {
     _name = "seed";
     _description = "Random number generator seed";
-    _validity = "integer > 0 or -1 to generate seed from system time";
+    _validity = "integer >= 0 or -1 to generate seed from system time";
     _default = "-1";
     _default_value = -1;
     _constrained = true;
@@ -25,7 +25,7 @@ class arg_seed : public int_argument {
               .total_milliseconds();
   }
 
-  bool is_valid(int value) { return value > 0 || value == _default_value; }
+  bool is_valid(int value) { return value >= 0 || value == _default_value; }
 
   unsigned int random_value() {
     if (_value == _default_value) {

--- a/src/cmdstan/arguments/argument_parser.hpp
+++ b/src/cmdstan/arguments/argument_parser.hpp
@@ -95,7 +95,11 @@ class argument_parser {
 
       if (!good_arg) {
         err(cat_name + " is either mistyped or misplaced.");
-
+#ifndef STAN_OPENCL
+        if (cat_name == "opencl") {
+          err("Re-compile the model with STAN_OPENCL to use OpenCL CmdStan arguments.");
+        }
+#endif
         std::vector<std::string> valid_paths;
 
         for (size_t i = 0; i < _arguments.size(); ++i) {

--- a/src/cmdstan/arguments/argument_parser.hpp
+++ b/src/cmdstan/arguments/argument_parser.hpp
@@ -97,7 +97,8 @@ class argument_parser {
         err(cat_name + " is either mistyped or misplaced.");
 #ifndef STAN_OPENCL
         if (cat_name == "opencl") {
-          err("Re-compile the model with STAN_OPENCL to use OpenCL CmdStan arguments.");
+          err("Re-compile the model with STAN_OPENCL to use OpenCL CmdStan "
+              "arguments.");
         }
 #endif
         std::vector<std::string> valid_paths;

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -6,6 +6,7 @@
 #include <cmdstan/arguments/arg_init.hpp>
 #include <cmdstan/arguments/arg_output.hpp>
 #include <cmdstan/arguments/arg_random.hpp>
+#include <cmdstan/arguments/arg_opencl.hpp>
 #include <cmdstan/arguments/argument_parser.hpp>
 #include <cmdstan/io/json/json_data.hpp>
 #include <cmdstan/write_model.hpp>
@@ -115,6 +116,7 @@ int command(int argc, const char *argv[]) {
   valid_arguments.push_back(new arg_init());
   valid_arguments.push_back(new arg_random());
   valid_arguments.push_back(new arg_output());
+  valid_arguments.push_back(new arg_opencl());
   argument_parser parser(valid_arguments);
   int err_code = parser.parse_args(argc, argv, info, err);
   if (err_code != 0) {
@@ -127,6 +129,23 @@ int command(int argc, const char *argv[]) {
   arg_seed *random_arg
       = dynamic_cast<arg_seed *>(parser.arg("random")->arg("seed"));
   unsigned int random_seed = random_arg->random_value();
+
+  int_argument* opencl_device_id = dynamic_cast<int_argument *>(parser.arg("opencl").arg("device"));
+  int_argument* opencl_platform_id = dynamic_cast<int_argument *>(parser.arg("opencl").arg("platform"));
+
+  // Either both device and platform are set or neither in which case we default to compile-time constants
+  if (opencl_device_id->is_default() ^ opencl_platform_id->is_default()) {
+    std::cerr << "Please set both device and platform IDs." << std::endl;
+    return err_code;
+  } else if (!opencl_device_id->is_default() && !opencl_platform_id->is_default()) {
+#ifdef STAN_OPENCL
+    stan::math::opencl_context.select_device(opencl_platform_id->value(), opencl_device_id->value());
+#else
+    std::cerr << "OpenCL device/platorm IDs are set but the model was not compiled with STAN_OPENCL enabled." << std::endl;
+    std::cerr << "Write STAN_OPENCL=true to the make/local file and recompile." << std::endl;
+    return err_code;
+#endif
+  }
 
   parser.print(info);
   write_parallel_info(info);

--- a/src/cmdstan/write_opencl_device.hpp
+++ b/src/cmdstan/write_opencl_device.hpp
@@ -15,12 +15,12 @@ void write_opencl_device(stan::callbacks::writer &writer) {
       && (stan::math::opencl_context.device().size() > 0)) {
     std::stringstream msg_opencl_platform;
     msg_opencl_platform
-        << "opencl_platform = "
+        << "opencl_platform_name = "
         << stan::math::opencl_context.platform()[0].getInfo<CL_PLATFORM_NAME>();
     writer(msg_opencl_platform.str());
     std::stringstream msg_opencl_device;
     msg_opencl_device
-        << "opencl_device = "
+        << "opencl_device_name = "
         << stan::math::opencl_context.device()[0].getInfo<CL_DEVICE_NAME>();
     writer(msg_opencl_device.str());
   }

--- a/src/test/interface/command_test.cpp
+++ b/src/test/interface/command_test.cpp
@@ -479,25 +479,6 @@ TEST(StanUiCommand, random_seed_fail_1) {
 
   std::string command
       = convert_model_path(model_path)
-        + " sample num_samples=10 num_warmup=10 init=0 " + " random seed=0 "
-        + " data file=src/test/test-models/transformed_data_rng_test.init.R"
-        + " output refresh=0 file=test/output.csv";
-  std::string cmd_output = run_command(command).output;
-  run_command_output out = run_command(command);
-  EXPECT_EQ(1, count_matches(expected_message, out.body));
-}
-
-TEST(StanUiCommand, random_seed_fail_2) {
-  std::string expected_message = "is not a valid value for \"seed\"";
-
-  std::vector<std::string> model_path;
-  model_path.push_back("src");
-  model_path.push_back("test");
-  model_path.push_back("test-models");
-  model_path.push_back("transformed_data_rng_test");
-
-  std::string command
-      = convert_model_path(model_path)
         + " sample num_samples=10 num_warmup=10 init=0 " + " random seed=-2 "
         + " data file=src/test/test-models/transformed_data_rng_test.init.R"
         + " output refresh=0 file=test/output.csv";
@@ -506,7 +487,7 @@ TEST(StanUiCommand, random_seed_fail_2) {
   EXPECT_EQ(1, count_matches(expected_message, out.body));
 }
 
-TEST(StanUiCommand, random_seed_fail_3) {
+TEST(StanUiCommand, random_seed_fail_2) {
   std::string expected_message = "is not a valid value for \"seed\"";
 
   std::vector<std::string> model_path;


### PR DESCRIPTION
#### Summary:

Fixes one part of #825 
Fixes #941 
Fixes #953 

The main part of this PR is allowing runtime selection of OpenCL devices.

```
./examples/bernoulli/bernoulli sample data file=examples/bernoulli/bernoulli.data.json opencl platform=0 device=0
```
Specifying only platform or only device IDs will print
```
Please set both device and platform OpenCL IDs.
```
Using opencl args when the model was not compiled with STAN_OPENCL will print

```
opencl is either mistyped or misplaced.
Re-compile the model with STAN_OPENCL to use OpenCL CmdStan arguments.
Failed to parse arguments, terminating Stan
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
