### PR TITLE
Fix stdout with transformed data and metadata

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -159,6 +159,7 @@ int command(int argc, const char *argv[]) {
   parser.print(info);
   write_parallel_info(info);
   write_opencl_device(info);
+  info();
 
   // Cross-check arguments
   if (parser.arg("method")->arg("generate_quantities")) {
@@ -216,8 +217,6 @@ int command(int argc, const char *argv[]) {
       = new_model(*var_context, random_seed, &std::cout);
 
   std::vector<std::string> model_compile_info = model.model_compile_info();
-  write_compile_info(info, model_compile_info);
-  info();
 
   write_stan(sample_writer);
   write_model(sample_writer, model.model_name());


### PR DESCRIPTION
#### Summary:

Adding this to a model 
```stan
transformed data {
  print("test");
}
```

produced this output
```
output
  file = output.csv (Default)
  diagnostic_file =  (Default)
  refresh = 100 (Default)
  sig_figs = -1 (Default)
  profile_file = profile.csv (Default)
test
stanc_version = stanc3 f22db2d8
stancflags = --use-opencl
```

This is because stancflags and stanc_version are only available once we instantiate the model by calling its constructor. 
And the print in transformed data happens in that constructor which means its before the print of stancflags and stanc_version.

The fix is to not output stancflags and stanc_version in stdout only to the CSV.

This was discovered because we run cmdstanr tests with the release.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
