### PR TITLE
Add GHA tarball builder

### DIFF
--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -41,7 +41,7 @@ name: CmdStan tarball builder
           default: 'master'
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: ocaml/opam2:alpine-3.9-ocaml-4.07
       options: --user root
@@ -75,16 +75,16 @@ jobs:
           eval $(opam env)
           dune subst
           dune build @install --profile static
-          mv _build/default/src/stanc/stanc.exe linux-stanc
+          mv _build/default/src/stanc/stanc.exe ${{ github.job }}-stanc
       
       - name: Upload Linux stanc
         uses: actions/upload-artifact@v2
         with:
-          name: linux-stanc
-          path: linux-stanc
+          name: ${{ github.job }}-stanc
+          path: ${{ github.job }}-stanc
 
   windows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: ubuntu:bionic
       options: --user root
@@ -100,7 +100,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.opam"
-          key: windows-stanc-binary-4.07
+          key: ${{ github.job }}-stanc-binary-4.07
 
       - name: Install dependencies
         run: |
@@ -123,13 +123,13 @@ jobs:
           eval $(opam env)
           dune subst
           dune build -x windows
-          mv _build/default.windows/src/stanc/stanc.exe windows-stanc
+          mv _build/default.windows/src/stanc/stanc.exe ${{ github.job }}-stanc
 
       - name: Upload Windows stanc
         uses: actions/upload-artifact@v2
         with:
-          name: windows-stanc
-          path: windows-stanc
+          name: ${{ github.job }}-stanc
+          path: ${{ github.job }}-stanc
   mac:
     runs-on: macOS-latest
     steps:    
@@ -144,7 +144,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.opam"
-          key: macOS-stanc-binary-4.07
+          key: ${{ github.job }}-stanc-binary-4.07
 
       - name: Install dependencies
         run: |
@@ -161,19 +161,22 @@ jobs:
           eval $(opam env)
           dune subst
           dune build @install
-          mv _build/default/src/stanc/stanc.exe mac-stanc
+          mv _build/default/src/stanc/stanc.exe ${{ github.job }}-stanc
       
       - name: Upload MacOS binaries
         uses: actions/upload-artifact@v2
         with:
-          name: mac-stanc
-          path: mac-stanc
+          name: ${{ github.job }}-stanc
+          path: ${{ github.job }}-stanc
   build:
     needs:  [linux, windows, mac]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+        architecture: 'x64'
     - uses: actions/checkout@v2
       with:
         repository: ${{ github.event.inputs.cmdstan_repo }}
@@ -243,5 +246,3 @@ jobs:
       with:
         name:  cmdstan-${{ github.event.inputs.tarball_name }}
         path: 'cmdstan-${{ github.event.inputs.tarball_name }}.tar.gz'
-
-    

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -1,0 +1,247 @@
+name: CmdStan tarball builder
+
+'on':
+  workflow_dispatch:
+    inputs:
+      tarball_name: 
+        description: 'CmdStan build name'
+        required: true
+        default: ''
+      cmdstan_repo:
+        description: 'CmdStan repo'
+        required: true
+        default: 'stan-dev/cmdstan'
+      cmdstan_branch:
+          description: 'CmdStan branch'
+          required: true
+          default: 'develop'
+      stan_repo:
+        description: 'Stan repo'
+        required: true
+        default: 'stan-dev/stan'
+      stan_branch:
+          description: 'Stan branch'
+          required: true
+          default: 'develop'
+      math_repo:
+        description: 'Math repo'
+        required: true
+        default: 'stan-dev/math'
+      math_branch:
+          description: 'Math branch'
+          required: true
+          default: 'develop'
+      stanc3_repo:
+        description: 'Stanc3 repo'
+        required: true
+        default: 'stan-dev/stanc3'
+      stanc3_branch:
+          description: 'Stanc3 branch'
+          required: true
+          default: 'master'
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    container:
+      image: ocaml/opam2:alpine-3.9-ocaml-4.07
+      options: --user root
+    steps:    
+      - name: Checkout stanc3
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.inputs.stanc3_repo }}
+          ref: ${{ github.event.inputs.stanc3_branch }}
+
+      - name: opam caching
+        id: opam-cache
+        uses: actions/cache@v2
+        with:
+          path: "~/.opam"
+          key: linux-stanc-binary-4.07
+
+      - name: Install dependencies
+        run: |
+          sudo apk update
+          sudo apk add build-base bzip2 git tar curl ca-certificates openssl m4 bash
+          opam init --disable-sandboxing -y
+          opam switch 4.07.0 || opam switch create 4.07.0
+          eval $(opam env)
+          opam repo add internet https://opam.ocaml.org
+          opam update
+          bash -x scripts/install_build_deps.sh
+
+      - name: Build static Linux binaries
+        run: |
+          eval $(opam env)
+          dune subst
+          dune build @install --profile static
+          mv _build/default/src/stanc/stanc.exe linux-stanc
+      
+      - name: Upload Linux stanc
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-stanc
+          path: linux-stanc
+
+  windows:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:bionic
+      options: --user root
+    steps:    
+      - name: Checkout stanc3
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.inputs.stanc3_repo }}
+          ref: ${{ github.event.inputs.stanc3_branch }}
+
+      - name: opam caching
+        id: opam-cache
+        uses: actions/cache@v2
+        with:
+          path: "~/.opam"
+          key: windows-stanc-binary-4.07
+
+      - name: Install dependencies
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends ca-certificates rsync git build-essential m4 sudo \
+          unzip pkg-config libpcre3-dev mingw-w64 gcc wget gawk bubblewrap
+          wget https://github.com/ocaml/opam/releases/download/2.0.4/opam-2.0.4-x86_64-linux
+          sudo install opam-2.0.4-x86_64-linux /usr/local/bin/opam
+          opam init --comp 4.02.3 --disable-sandboxing -y
+          eval $(opam env)
+          opam switch 4.07.0 || opam switch create 4.07.0
+          eval $(opam env)
+          opam update
+          bash -x scripts/install_build_deps_windows.sh
+          eval $(opam env)
+          opam install -y js_of_ocaml-compiler.3.4.0 js_of_ocaml-ppx.3.4.0 js_of_ocaml.3.4.0
+
+      - name: Build Windows binaries
+        run: |
+          eval $(opam env)
+          dune subst
+          dune build -x windows
+          mv _build/default.windows/src/stanc/stanc.exe windows-stanc
+
+      - name: Upload Windows stanc
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-stanc
+          path: windows-stanc
+  mac:
+    runs-on: macOS-latest
+    steps:    
+      - name: Checkout stanc3
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.inputs.stanc3_repo }}
+          ref: ${{ github.event.inputs.stanc3_branch }}
+
+      - name: opam caching
+        id: opam-cache
+        uses: actions/cache@v2
+        with:
+          path: "~/.opam"
+          key: macOS-stanc-binary-4.07
+
+      - name: Install dependencies
+        run: |
+          brew install gpatch
+          brew install opam
+          opam init --disable-sandboxing -y
+          eval $(opam env)
+          opam switch 4.07.0 || opam switch create 4.07.0          
+          eval $(opam env)
+          bash -x scripts/install_build_deps.sh
+
+      - name: Build MacOS binaries
+        run: |
+          eval $(opam env)
+          dune subst
+          dune build @install
+          mv _build/default/src/stanc/stanc.exe mac-stanc
+      
+      - name: Upload MacOS binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: mac-stanc
+          path: mac-stanc
+  build:
+    needs:  [linux, windows, mac]
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+      with:
+        repository: ${{ github.event.inputs.cmdstan_repo }}
+        ref: ${{ github.event.inputs.cmdstan_branch }}
+        path: cmdstan
+
+    - uses: actions/checkout@v2
+      with:
+        repository: ${{ github.event.inputs.stan_repo }}
+        ref: ${{ github.event.inputs.stan_branch }}
+        path: cmdstan/stan
+
+    - uses: actions/checkout@v2
+      with:
+        repository: ${{ github.event.inputs.math_repo }}
+        ref: ${{ github.event.inputs.math_branch }}
+        path: cmdstan/stan/lib/stan_math
+    
+    - name: Building
+      run: |
+        cd cmdstan
+        make build
+        make clean-all
+    
+    - name: install git-archive-all
+      run: |
+        pip install git-archive-all
+
+    - name: Package tarball part 1
+      run: |
+        cd cmdstan
+        git-archive-all cmdstan-${{ github.event.inputs.tarball_name }}.tar.gz
+        mv cmdstan-${{ github.event.inputs.tarball_name }}.tar.gz ../cmdstan-${{ github.event.inputs.tarball_name }}.tar.gz
+        cd ..
+        mkdir cmdstan-${{ github.event.inputs.tarball_name }}
+        tar -xvzf cmdstan-${{ github.event.inputs.tarball_name }}.tar.gz
+    
+    - name: Download MacOS binaries
+      uses: actions/download-artifact@v2
+      with:
+          name: mac-stanc
+          path: bins/mac-stanc
+
+    - name: Download Linux binaries
+      uses: actions/download-artifact@v2
+      with:
+          name: linux-stanc
+          path: bins/linux-stanc
+
+    - name: Download Windows binaries
+      uses: actions/download-artifact@v2
+      with:
+          name: windows-stanc
+          path: bins/windows-stanc
+
+    - name: Package tarball part 2
+      run: |
+        mkdir cmdstan-${{ github.event.inputs.tarball_name }}/bin
+        mv bins/linux-stanc/linux-stanc cmdstan-${{ github.event.inputs.tarball_name }}/bin/linux-stanc
+        mv bins/windows-stanc/windows-stanc cmdstan-${{ github.event.inputs.tarball_name }}/bin/windows-stanc
+        mv bins/mac-stanc/mac-stanc cmdstan-${{ github.event.inputs.tarball_name }}/bin/mac-stanc
+        tar -cvzf cmdstan-${{ github.event.inputs.tarball_name }}.tar.gz cmdstan-${{ github.event.inputs.tarball_name }}
+        ls -l
+
+    - name: Upload tarball
+      uses: actions/upload-artifact@v2
+      with:
+        name:  cmdstan-${{ github.event.inputs.tarball_name }}
+        path: 'cmdstan-${{ github.event.inputs.tarball_name }}.tar.gz'
+
+    


### PR DESCRIPTION
#### Summary:

Adds a GHA to build CmdStan tarball  by specifiyng
- math branch
- stan branch
- cmdstan branch
- stanc3 branch

Fixes https://github.com/stan-dev/stanc3/issues/765

Can be used to share works in progress or experimental branches.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
