### PR TITLE
All error messages written to stderr, including model instantiation failures; simplify return codes

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -226,7 +226,7 @@ int command(int argc, const char *argv[]) {
 
   // Instantiate model
   stan::model::model_base &model
-      = new_model(*var_context, random_seed, &std::cerr);
+      = new_model(*var_context, random_seed, &std::cout);
 
   std::vector<std::string> model_compile_info = model.model_compile_info();
 

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -68,6 +68,13 @@ stan::math::profile_map &get_stan_profile_data();
 
 namespace cmdstan {
 
+struct return_codes {
+  enum {
+    OK = 0,
+    NOT_OK = 1
+  };
+};
+
 #ifdef STAN_MPI
 stan::math::mpi_cluster &get_mpi_cluster() {
   static stan::math::mpi_cluster cluster;
@@ -129,13 +136,13 @@ int command(int argc, const char *argv[]) {
     if (argc > 1)
       std::cerr << "Failed to parse command arguments, cannot run model."
                 << std::endl;
-    return err_code;
+    return return_codes::NOT_OK;
   } else if (err_code != 0) {
     std::cerr << "Unexpected failure, quitting." << std::endl;
-    return err_code;
+    return return_codes::NOT_OK;
   }
   if (parser.help_printed())
-    return stan::services::error_codes::OK;
+    return return_codes::OK;
 
   arg_seed *random_arg
       = dynamic_cast<arg_seed *>(parser.arg("random")->arg("seed"));
@@ -153,7 +160,7 @@ int command(int argc, const char *argv[]) {
       || (!opencl_device_id->is_default()
           && opencl_platform_id->is_default())) {
     std::cerr << "Please set both device and platform OpenCL IDs." << std::endl;
-    return stan::services::error_codes::CONFIG;
+    return return_codes::NOT_OK;
   } else if (!opencl_device_id->is_default()
              && !opencl_platform_id->is_default()) {
     stan::math::opencl_context.select_device(opencl_platform_id->value(),
@@ -219,7 +226,7 @@ int command(int argc, const char *argv[]) {
 
   // Instantiate model
   stan::model::model_base &model
-      = new_model(*var_context, random_seed, &std::cout);
+      = new_model(*var_context, random_seed, &std::cerr);
 
   std::vector<std::string> model_compile_info = model.model_compile_info();
 
@@ -252,7 +259,7 @@ int command(int argc, const char *argv[]) {
   std::shared_ptr<stan::io::var_context> init_context = get_var_context(init);
 
   // Invoke specified method
-  int return_code = stan::services::error_codes::OK;
+  int return_code = return_codes::OK;
 
   if (parser.arg("method")->arg("generate_quantities")) {
     string_argument *fitted_params_file = dynamic_cast<string_argument *>(

--- a/src/cmdstan/main.cpp
+++ b/src/cmdstan/main.cpp
@@ -1,11 +1,16 @@
 #include <cmdstan/command.hpp>
 #include <stan/services/error_codes.hpp>
 
+
 int main(int argc, const char *argv[]) {
   try {
-    return cmdstan::command(argc, argv);
+    int err_code = cmdstan::command(argc, argv);
+    if (err_code == 0)
+      return cmdstan::return_codes::OK;
+    else
+      return cmdstan::return_codes::NOT_OK;
   } catch (const std::exception &e) {
     std::cerr << e.what() << std::endl;
-    return stan::services::error_codes::SOFTWARE;
+    return cmdstan::return_codes::NOT_OK;
   }
 }

--- a/src/test/interface/command_test.cpp
+++ b/src/test/interface/command_test.cpp
@@ -129,7 +129,7 @@ TEST(StanUiCommand, refresh_zero_ok) {
                         " sample num_samples=10 num_warmup=10 init=0 output "
                         "refresh=0 file=test/output.csv";
   run_command_output out = run_command(command);
-  EXPECT_EQ(int(stan::services::error_codes::OK), out.err_code);
+  EXPECT_EQ(int(cmdstan::return_codes::OK), out.err_code);
   EXPECT_EQ(0, count_matches("Iteration:", out.output));
 }
 
@@ -144,7 +144,7 @@ TEST(StanUiCommand, refresh_nonzero_ok) {
                         " sample num_samples=10 num_warmup=10 init=0 output "
                         "refresh=1 file=test/output.csv";
   run_command_output out = run_command(command);
-  EXPECT_EQ(int(stan::services::error_codes::OK), out.err_code);
+  EXPECT_EQ(int(cmdstan::return_codes::OK), out.err_code);
   EXPECT_EQ(20, count_matches("Iteration:", out.output));
 }
 
@@ -160,7 +160,7 @@ TEST(StanUiCommand, zero_init_value_fail) {
   std::string command = convert_model_path(model_path)
                         + " sample init=0 output file=test/output.csv";
   run_command_output out = run_command(command);
-  EXPECT_EQ(int(stan::services::error_codes::SOFTWARE), out.err_code);
+  EXPECT_EQ(int(cmdstan::return_codes::NOT_OK), out.err_code);
 
   EXPECT_TRUE(out.header.length() > 0U);
   EXPECT_TRUE(out.body.length() > 0U);
@@ -182,7 +182,7 @@ TEST(StanUiCommand, zero_init_domain_fail) {
                         + " sample init=0 output file=test/output.csv";
 
   run_command_output out = run_command(command);
-  EXPECT_EQ(int(stan::services::error_codes::SOFTWARE), out.err_code);
+  EXPECT_EQ(int(cmdstan::return_codes::NOT_OK), out.err_code);
 
   EXPECT_TRUE(out.header.length() > 0U);
   EXPECT_TRUE(out.body.length() > 0U);
@@ -211,7 +211,7 @@ TEST(StanUiCommand, user_init_value_fail) {
                         + " output file=test/output.csv";
 
   run_command_output out = run_command(command);
-  EXPECT_EQ(int(stan::services::error_codes::SOFTWARE), out.err_code);
+  EXPECT_EQ(int(cmdstan::return_codes::NOT_OK), out.err_code);
 
   EXPECT_TRUE(out.header.length() > 0U);
   EXPECT_TRUE(out.body.length() > 0U);
@@ -240,7 +240,7 @@ TEST(StanUiCommand, user_init_domain_fail) {
                         + " output file=test/output.csv";
 
   run_command_output out = run_command(command);
-  EXPECT_EQ(int(stan::services::error_codes::SOFTWARE), out.err_code);
+  EXPECT_EQ(int(cmdstan::return_codes::NOT_OK), out.err_code);
 
   EXPECT_TRUE(out.header.length() > 0U);
   EXPECT_TRUE(out.body.length() > 0U);
@@ -258,7 +258,7 @@ TEST(StanUiCommand, CheckCommand_no_args) {
 
   std::string command = convert_model_path(model_path);
   run_command_output out = run_command(command);
-  EXPECT_EQ(int(stan::services::error_codes::USAGE), out.err_code);
+  EXPECT_EQ(int(cmdstan::return_codes::NOT_OK), out.err_code);
 }
 
 TEST(StanUiCommand, CheckCommand_help) {
@@ -271,7 +271,7 @@ TEST(StanUiCommand, CheckCommand_help) {
   std::string command = convert_model_path(model_path) + " help";
 
   run_command_output out = run_command(command);
-  EXPECT_EQ(int(stan::services::error_codes::OK), out.err_code);
+  EXPECT_EQ(int(cmdstan::return_codes::OK), out.err_code);
 }
 
 TEST(StanUiCommand, CheckCommand_unrecognized_argument) {
@@ -284,7 +284,7 @@ TEST(StanUiCommand, CheckCommand_unrecognized_argument) {
   std::string command = convert_model_path(model_path) + " foo";
 
   run_command_output out = run_command(command);
-  EXPECT_EQ(int(stan::services::error_codes::USAGE), out.err_code);
+  EXPECT_EQ(int(cmdstan::return_codes::NOT_OK), out.err_code);
 }
 
 TEST(StanUiCommand, timing_info) {
@@ -298,7 +298,7 @@ TEST(StanUiCommand, timing_info) {
                         " sample num_samples=10 num_warmup=10 init=0 output "
                         "refresh=0 file=test/output.csv";
   run_command_output out = run_command(command);
-  EXPECT_EQ(int(stan::services::error_codes::OK), out.err_code);
+  EXPECT_EQ(int(cmdstan::return_codes::OK), out.err_code);
 
   std::fstream output_csv_stream("test/output.csv");
   std::stringstream output_sstream;
@@ -323,7 +323,7 @@ TEST(StanUiCommand, run_info) {
                         " sample num_samples=10 num_warmup=10 init=0 output "
                         "refresh=0 file=test/output.csv";
   run_command_output out = run_command(command);
-  EXPECT_EQ(int(stan::services::error_codes::OK), out.err_code);
+  EXPECT_EQ(int(cmdstan::return_codes::OK), out.err_code);
 
   std::fstream output_csv_stream("test/output.csv");
   std::stringstream output_sstream;

--- a/src/test/interface/metric_test.cpp
+++ b/src/test/interface/metric_test.cpp
@@ -66,10 +66,10 @@ TEST(StanUiCommand, metric_file_test) {
 
               run_command_output out = run_command(command);
               if (adapt == "1" && num_warmup == "0") {
-                EXPECT_EQ(int(stan::services::error_codes::CONFIG),
+                EXPECT_EQ(int(cmdstan::return_codes::NOT_OK),
                           out.err_code);
               } else {
-                EXPECT_EQ(int(stan::services::error_codes::OK), out.err_code);
+                EXPECT_EQ(int(cmdstan::return_codes::OK), out.err_code);
 
                 std::fstream output_csv_stream("test/output.csv");
                 std::stringstream output_sstream;


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Ensures that all error messages are written to stderr, including bad input data.
PR #992 overlooked the output stream passed in to the `new_model` function; changed it from standard output to standard error, as the only messages written to this output stream are error messages.

#### Intended Effect:

- Consistent handling of error messages - all error messages should go to standard error.

- Simplify return codes - the set of POSIX return codes in stan::services::error_codes aren't actionable for CmdStan users and the interfaces which wrap them.  

#### How to Verify:

Unit tests.

#### Side Effects:

As for #992, document that errors are not going to standard error, not standard out.

#### Documentation:

CmdStan User's guide now has section on return codes and common errors.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
