### PR TITLE
use auto for threadpool init so we can update tbb

### DIFF
--- a/src/test/interface/tbb_threadpool_test.cpp
+++ b/src/test/interface/tbb_threadpool_test.cpp
@@ -5,7 +5,7 @@
 #include <gtest/gtest.h>
 
 TEST(StanUiCommand, threadpool_init) {
-  tbb::task_scheduler_init &scheduler_init = stan::math::init_threadpool_tbb();
+  auto& scheduler_init = stan::math::init_threadpool_tbb();
   EXPECT_TRUE(scheduler_init.is_active());
   scheduler_init.terminate();
   EXPECT_FALSE(scheduler_init.is_active());


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This just updates the `tbb_threadpool_test` so that it uses `auto` for the return type of `stan::math::init_threadpool_tbb();`. This let's us update to the new `task_arena` in the updated tbb in [`math#2447`](https://github.com/stan-dev/math/pull/2447)

#### Intended Effect:

#### How to Verify:

```
./runCmdStanTests.py -j20 src/test/interface/tbb_threadpool_test.cpp
```

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
