### PR TITLE
Remove tbb_scheduler_init.h include from the test

### DIFF
--- a/src/test/interface/tbb_threadpool_test.cpp
+++ b/src/test/interface/tbb_threadpool_test.cpp
@@ -1,7 +1,6 @@
 #include <cmdstan/command.hpp>
 #include <test/test-models/proper.hpp>
 #include <stan/math/prim/core/init_threadpool_tbb.hpp>
-#include <tbb/task_scheduler_init.h>
 #include <gtest/gtest.h>
 
 TEST(StanUiCommand, threadpool_init) {


### PR DESCRIPTION
#### Summary:

This include is throwing warnings in https://github.com/stan-dev/math/pull/2447

The warnings looks like this:

```
stan/lib/stan_math/lib/tbb_2020.3/include/tbb/task_scheduler_init.h:21:154: note: #pragma message: TBB Warning: tbb/task_scheduler_init.h is deprecated. For details, please see Deprecated Features appendix in the TBB reference manual.
 #pragma message("TBB Warning: tbb/task_scheduler_init.h is deprecated. For details, please see Deprecated Features appendix in the TBB reference manual.")
```                                                          


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
