### PR TITLE
Add `./model info` to obtain compile-time information

### DIFF
--- a/src/cmdstan/arguments/argument_parser.hpp
+++ b/src/cmdstan/arguments/argument_parser.hpp
@@ -3,6 +3,8 @@
 
 #include <cmdstan/arguments/arg_method.hpp>
 #include <cmdstan/arguments/argument.hpp>
+#include <cmdstan/write_stan.hpp>
+#include <cmdstan/write_stan_flags.hpp>
 #include <stan/services/error_codes.hpp>
 #include <cstring>
 #include <string>
@@ -86,6 +88,11 @@ class argument_parser {
         print_help(info, true);
         _help_flag |= true;
         args.clear();
+      } else if (cat_name == "info") {
+        _help_flag |= true;
+        write_stan(info);
+        write_stan_flags(info);
+        return stan::services::error_codes::OK;
       }
 
       if (_help_flag) {

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -16,6 +16,7 @@
 #include <cmdstan/write_parallel_info.hpp>
 #include <cmdstan/write_profiling.hpp>
 #include <cmdstan/write_stan.hpp>
+#include <cmdstan/write_stan_flags.hpp>
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/stream_logger.hpp>

--- a/src/cmdstan/write_stan_flags.hpp
+++ b/src/cmdstan/write_stan_flags.hpp
@@ -8,29 +8,29 @@ namespace cmdstan {
 
 void write_stan_flags(stan::callbacks::writer &writer) {
 #ifdef STAN_OPENCL
-        writer("STAN_OPENCL=true");
+  writer("STAN_OPENCL=true");
 #else
-        writer("STAN_OPENCL=false");
+  writer("STAN_OPENCL=false");
 #endif
 #ifdef STAN_THREADS
-        writer("STAN_THREADS=true");
+  writer("STAN_THREADS=true");
 #else
-        writer("STAN_THREADS=false");
+  writer("STAN_THREADS=false");
 #endif
 #ifdef STAN_MPI
-        writer("STAN_MPI=true");
+  writer("STAN_MPI=true");
 #else
-        writer("STAN_MPI=false");
+  writer("STAN_MPI=false");
 #endif
 #ifdef STAN_NO_RANGE_CHECKS
-        writer("STAN_NO_RANGE_CHECKS=true");
+  writer("STAN_NO_RANGE_CHECKS=true");
 #else
-        writer("STAN_NO_RANGE_CHECKS=false");
+  writer("STAN_NO_RANGE_CHECKS=false");
 #endif
 #ifdef STAN_CPP_OPTIMS
-        writer("STAN_CPP_OPTIMS=true");
+  writer("STAN_CPP_OPTIMS=true");
 #else
-        writer("STAN_CPP_OPTIMS=false");
+  writer("STAN_CPP_OPTIMS=false");
 #endif
 }
 

--- a/src/cmdstan/write_stan_flags.hpp
+++ b/src/cmdstan/write_stan_flags.hpp
@@ -18,9 +18,9 @@ void write_stan_flags(stan::callbacks::writer &writer) {
   writer("STAN_MPI=false");
 #endif
 #ifdef STAN_OPENCL
-        writer("STAN_OPENCL=true");
+  writer("STAN_OPENCL=true");
 #else
-        writer("STAN_OPENCL=false");
+  writer("STAN_OPENCL=false");
 #endif
 #ifdef STAN_NO_RANGE_CHECKS
   writer("STAN_NO_RANGE_CHECKS=true");

--- a/src/cmdstan/write_stan_flags.hpp
+++ b/src/cmdstan/write_stan_flags.hpp
@@ -1,0 +1,38 @@
+#ifndef CMDSTAN_WRITE_STAN_FLAGS_HPP
+#define CMDSTAN_WRITE_STAN_FLAGS_HPP
+
+#include <stan/callbacks/writer.hpp>
+#include <string>
+
+namespace cmdstan {
+
+void write_stan_flags(stan::callbacks::writer &writer) {
+#ifdef STAN_OPENCL
+        writer("STAN_OPENCL=true");
+#else
+        writer("STAN_OPENCL=false");
+#endif
+#ifdef STAN_THREADS
+        writer("STAN_THREADS=true");
+#else
+        writer("STAN_THREADS=false");
+#endif
+#ifdef STAN_MPI
+        writer("STAN_MPI=true");
+#else
+        writer("STAN_MPI=false");
+#endif
+#ifdef STAN_NO_RANGE_CHECKS
+        writer("STAN_NO_RANGE_CHECKS=true");
+#else
+        writer("STAN_NO_RANGE_CHECKS=false");
+#endif
+#ifdef STAN_CPP_OPTIMS
+        writer("STAN_CPP_OPTIMS=true");
+#else
+        writer("STAN_CPP_OPTIMS=false");
+#endif
+}
+
+}  // namespace cmdstan
+#endif

--- a/src/cmdstan/write_stan_flags.hpp
+++ b/src/cmdstan/write_stan_flags.hpp
@@ -7,11 +7,6 @@
 namespace cmdstan {
 
 void write_stan_flags(stan::callbacks::writer &writer) {
-#ifdef STAN_OPENCL
-  writer("STAN_OPENCL=true");
-#else
-  writer("STAN_OPENCL=false");
-#endif
 #ifdef STAN_THREADS
   writer("STAN_THREADS=true");
 #else
@@ -21,6 +16,11 @@ void write_stan_flags(stan::callbacks::writer &writer) {
   writer("STAN_MPI=true");
 #else
   writer("STAN_MPI=false");
+#endif
+#ifdef STAN_OPENCL
+        writer("STAN_OPENCL=true");
+#else
+        writer("STAN_OPENCL=false");
 #endif
 #ifdef STAN_NO_RANGE_CHECKS
   writer("STAN_NO_RANGE_CHECKS=true");


### PR DESCRIPTION
#### Summary:

Closes #887 

The idea explained in the issue is that

`./examples/bernoulli/bernoulli info`

would return:
```
stan_version_major = 2
stan_version_minor = 26
stan_version_patch = 1
STAN_OPENCL=false
STAN_THREADS=false
STAN_MPI=false
STAN_NO_RANGE_CHECKS=false
STAN_CPP_OPTIMS=false
```
There are all compile-time information about the built executable. Some of them could be obtained by running the model, others like STAN_CPP_OPTIMS, STAN_NO_RANGE_CHECKS would be harder to figure out.

Maybe we could also include other information, this is what came to mind for now. In order to get stanc flags we would need to instantiate the model and for that we need the data, so I opted not including that for now, but we could still do that at a later point.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
