### PR TITLE
changed the ebfmi satisfactory message

### DIFF
--- a/src/cmdstan/diagnose.cpp
+++ b/src/cmdstan/diagnose.cpp
@@ -162,7 +162,7 @@ int main(int argc, const char *argv[]) {
                   << std::endl
                   << std::endl;
       } else {
-        std::cout << "E-BFMI satisfactory for all transitions." << std::endl
+        std::cout << "E-BFMI satisfactory." << std::endl
                   << std::endl;
       }
     } else if (chains.param_name(i).find("__") == std::string::npos) {

--- a/src/cmdstan/diagnose.cpp
+++ b/src/cmdstan/diagnose.cpp
@@ -162,8 +162,7 @@ int main(int argc, const char *argv[]) {
                   << std::endl
                   << std::endl;
       } else {
-        std::cout << "E-BFMI satisfactory." << std::endl
-                  << std::endl;
+        std::cout << "E-BFMI satisfactory." << std::endl << std::endl;
       }
     } else if (chains.param_name(i).find("__") == std::string::npos) {
       double n_eff = chains.effective_sample_size(i);

--- a/src/test/interface/example_output/corr_gauss.nom
+++ b/src/test/interface/example_output/corr_gauss.nom
@@ -7,7 +7,7 @@ Checking sampler transitions for divergences.
 No divergent transitions found.
 
 Checking E-BFMI - sampler transitions HMC potential energy.
-E-BFMI satisfactory for all transitions.
+E-BFMI satisfactory.
 
 Effective sample size satisfactory.
 

--- a/src/test/interface/example_output/corr_gauss_depth15.nom
+++ b/src/test/interface/example_output/corr_gauss_depth15.nom
@@ -5,7 +5,7 @@ Checking sampler transitions for divergences.
 No divergent transitions found.
 
 Checking E-BFMI - sampler transitions HMC potential energy.
-E-BFMI satisfactory for all transitions.
+E-BFMI satisfactory.
 
 Effective sample size satisfactory.
 

--- a/src/test/interface/example_output/corr_gauss_depth8.nom
+++ b/src/test/interface/example_output/corr_gauss_depth8.nom
@@ -7,7 +7,7 @@ Checking sampler transitions for divergences.
 No divergent transitions found.
 
 Checking E-BFMI - sampler transitions HMC potential energy.
-E-BFMI satisfactory for all transitions.
+E-BFMI satisfactory.
 
 Effective sample size satisfactory.
 

--- a/src/test/interface/example_output/mix.nom
+++ b/src/test/interface/example_output/mix.nom
@@ -5,7 +5,7 @@ Checking sampler transitions for divergences.
 No divergent transitions found.
 
 Checking E-BFMI - sampler transitions HMC potential energy.
-E-BFMI satisfactory for all transitions.
+E-BFMI satisfactory.
 
 The following parameters had fewer than 0.001 effective draws per transition:
   mu[1], mu[2], theta


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Currently, running diagnose.cpp on a chain with satisfactory e-bfmi writes to stdout:
> "E-BFMI satisfactory for all transitions."

This is misleading, because BFMI isn't a per-transition metric but rather a per-chain metric.

#### Intended Effect:
Replace "E-BFMI satisfactory for all transitions." with "E-BFMI satisfactory."

#### How to Verify:
Run sampler diagnostics on a chain with satisfactory E-BFMI.

#### Side Effects:
None

#### Documentation:
None needed

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Jacob B. Socolar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
