### PR TITLE
Add make/local.example and minor fixes

### DIFF
--- a/examples/bernoulli/bernoulli.stan
+++ b/examples/bernoulli/bernoulli.stan
@@ -1,6 +1,6 @@
 data {
   int<lower=0> N;
-  int<lower=0,upper=1> y[N];
+  array[N] int<lower=0,upper=1> y; // or int<lower=0,upper=1> y[N];
 }
 parameters {
   real<lower=0,upper=1> theta;

--- a/make/local.example
+++ b/make/local.example
@@ -1,4 +1,5 @@
-# This file contains examples for makefile flags that can be used in Cmdstan's make/local file
+# To use this template, make a copy from make/local.example to make/local and uncomment options as needed.
+# Be sure to run `make clean-all` before compiling a model to make sure everything gets rebuilt.
 
 # Change the C++ compiler
 # CXX=clang++
@@ -18,12 +19,14 @@
 # This example enables pedantic mode
 # STANCFLAGS+= --warn-pedantic
 
-# Enable C++ compiler and linker optimization recommended by Stan developers
+# Enable C++ compiler and linker optimization recommended by Stan developers.
+# Can significantly slow down compilation.
 # STAN_CPP_OPTIMS=true
 
-# Remove range checks from the model for faster runtime
+# Remove range checks from the model for faster runtime. Use this flag with caution
+# and only once the indexing has been validated. In case of any unexpected behavior
+# remove the flag for easier debugging.
 # STAN_NO_RANGE_CHECKS=true
 
 # Adding other arbitrary C++ compiler flags
-# CXXFLAGS+= -march=native -mtune=native
-
+# CXXFLAGS+= -funroll-loops

--- a/make/local.example
+++ b/make/local.example
@@ -1,0 +1,29 @@
+# This file contains examples for makefile flags that can be used in Cmdstan's make/local file
+
+# Change the C++ compiler
+# CXX=clang++
+
+# Enable threading
+# STAN_THREADS=true
+
+# Enable the MPI backend (requires also setting (replace gcc with clang on Mac)
+# STAN_MPI=true
+# CXX=mpicxx
+# TBB_CXX_TYPE=gcc
+
+# Enable the OpenCL backend
+# STAN_OPENCL=true
+
+# Add flags that are forwarded to the Stan-to-C++ compiler (stanc3).
+# This example enables pedantic mode
+# STANCFLAGS+= --warn-pedantic
+
+# Enable C++ compiler and linker optimization recommended by Stan developers
+# STAN_CPP_OPTIMS=true
+
+# Remove range checks from the model for faster runtime
+# STAN_NO_RANGE_CHECKS=true
+
+# Adding other arbitrary C++ compiler flags
+# CXXFLAGS+= -march=native -mtune=native
+

--- a/makefile
+++ b/makefile
@@ -185,7 +185,8 @@ endif
 	@echo '      directory of the Stan program.'
 	@echo '    STANC3_VERSION: When set, uses that tagged version specified; otherwise, downloads'
 	@echo '      the nightly version.'
-	@echo '    STAN_CPP_OPTIMS: Turns on additonal compiler flags for performance           '
+	@echo '    STAN_CPP_OPTIMS: Turns on additonal compiler flags for performance.'
+	@echo '    STAN_NO_RANGE_CHECKS: Removes the range checks from the model for performance.'
 	@echo ''
 	@echo ''
 	@echo '  Example - bernoulli model: examples/bernoulli/bernoulli.stan'
@@ -233,7 +234,7 @@ help-dev:
 	@echo ''
 	@echo '- *$(EXE)        : If a Stan model exists at *.stan, this target will build'
 	@echo '                   the Stan model as an executable.'
-	@echo '- compile_info   : prints compiler flags for compiling a CmdStan executable.'
+	@echo '- info   : prints compiler flags for compiling a CmdStan executable.'
 	@echo '--------------------------------------------------------------------------------'
 
 .PHONY: build-mpi

--- a/makefile
+++ b/makefile
@@ -234,7 +234,7 @@ help-dev:
 	@echo ''
 	@echo '- *$(EXE)        : If a Stan model exists at *.stan, this target will build'
 	@echo '                   the Stan model as an executable.'
-	@echo '- info   : prints compiler flags for compiling a CmdStan executable.'
+	@echo '- compile_info   : prints compiler flags for compiling a CmdStan executable.'
 	@echo '--------------------------------------------------------------------------------'
 
 .PHONY: build-mpi


### PR DESCRIPTION
#### Summary:

A bit of last minute cleaning pre 2.27:
- adds docs for STAN_NO_RANGE_CHECKS to `make help`
- uses new array syntax in the example model
- add the make/local.example file to showcase examples on how to use the make/local file (fixes #942)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
