### PR TITLE
Feature/1029 record fixed param

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -426,7 +426,7 @@ int command(int argc, const char *argv[]) {
         info(
             "Model contains no parameters, running fixed_param sampler, "
             "no updates to Markov chain");
-      write_fixed_param(sample_writer)
+      write_fixed_param(sample_writer);
       return_code = stan::services::sample::fixed_param(
           model, *init_context, random_seed, id, init_radius, num_samples,
           num_thin, refresh, interrupt, logger, init_writer, sample_writer,

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -10,6 +10,7 @@
 #include <cmdstan/arguments/arg_profile_file.hpp>
 #include <cmdstan/arguments/argument_parser.hpp>
 #include <cmdstan/io/json/json_data.hpp>
+#include <cmdstan/write_fixed_param.hpp>
 #include <cmdstan/write_datetime.hpp>
 #include <cmdstan/write_model_compile_info.hpp>
 #include <cmdstan/write_model.hpp>
@@ -425,6 +426,7 @@ int command(int argc, const char *argv[]) {
         info(
             "Model contains no parameters, running fixed_param sampler, "
             "no updates to Markov chain");
+      write_fixed_param(sample_writer)
       return_code = stan::services::sample::fixed_param(
           model, *init_context, random_seed, id, init_radius, num_samples,
           num_thin, refresh, interrupt, logger, init_writer, sample_writer,

--- a/src/cmdstan/write_fixed_param.hpp
+++ b/src/cmdstan/write_fixed_param.hpp
@@ -6,8 +6,7 @@
 #include <string>
 
 namespace cmdstan {
-void write_fixed_param(stan::callbacks::writer& writer,
-                        std::vector<std::string>& fixed_param) {
+void write_fixed_param(stan::callbacks::writer& writer) {
   std::stringstream fixed_param_msg;
   fixed_param_msg << "fixed_param = 1";
   writer(fixed_param_msg.str());

--- a/src/cmdstan/write_fixed_param.hpp
+++ b/src/cmdstan/write_fixed_param.hpp
@@ -1,0 +1,16 @@
+#ifndef CMDSTAN_WRITE_FIXED_PARAM_HPP
+#define CMDSTAN_WRITE_FIXED_PARAM_HPP
+
+#include <stan/callbacks/writer.hpp>
+#include <stan/version.hpp>
+#include <string>
+
+namespace cmdstan {
+void write_fixed_param(stan::callbacks::writer& writer,
+                        std::vector<std::string>& fixed_param) {
+  std::stringstream fixed_param_msg;
+  fixed_param_msg << "fixed_param = 1";
+  writer(fixed_param_msg.str());
+}
+}  // namespace cmdstan
+#endif

--- a/src/test/interface/fixed_param_sampler_test.cpp
+++ b/src/test/interface/fixed_param_sampler_test.cpp
@@ -92,4 +92,7 @@ TEST(McmcFixedParamSampler, check_empty_but_algorithm_not_fixed_param) {
       = "Model contains no parameters, running fixed_param sampler";
   EXPECT_TRUE(
       boost::algorithm::contains(command_output.output, expected_message));
+
+  // stopped here - see datetime_test - check that header has "fixed_param = 1"
+
 }

--- a/src/test/interface/fixed_param_sampler_test.cpp
+++ b/src/test/interface/fixed_param_sampler_test.cpp
@@ -6,8 +6,8 @@
 #include <fstream>
 #include <boost/algorithm/string.hpp>
 
-using cmdstan::test::count_matches;
 using cmdstan::test::convert_model_path;
+using cmdstan::test::count_matches;
 using cmdstan::test::run_command;
 using cmdstan::test::run_command_output;
 
@@ -109,7 +109,8 @@ TEST(McmcFixedParamSampler, check_csv_header_has_fixed_param) {
   model_path.push_back("empty");
 
   std::string command = convert_model_path(model_path);
-  command += " sample algorithm=fixed_param output file=" + convert_model_path(model_path) + ".csv";
+  command += " sample algorithm=fixed_param output file="
+             + convert_model_path(model_path) + ".csv";
   run_command_output command_output;
   bool success = true;
   try {
@@ -155,5 +156,4 @@ TEST(McmcFixedParamSampler, check_csv_header_doesnt_have_fixed_param) {
   EXPECT_EQ(0, count_matches("# fixed_param = 1", output_file))
       << "# fixed_param = 1" << std::endl
       << output_file;
-
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
In `command.hpp`, before invoking service method `fixed_param`, add line "# fixed_param=1" to Stan CSV header.

#### Intended Effect:
This will make it easier for wrapper interfaces to check Stan CSV files.  see https://github.com/stan-dev/cmdstan/issues/1029

#### How to Verify:
Added more unit tests 

#### Side Effects:
CSV header files will change only when method `fixed_param` is invoked.  Should be harmless.

#### Documentation:
n/a

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
