### PR TITLE
Update make logic for Windows dll check

### DIFF
--- a/make/program
+++ b/make/program
@@ -57,6 +57,9 @@ endif
 	$(RM) $(subst  \,/,$*).o
 ifeq ($(OS),Windows_NT)
 ifneq (,$(findstring tbb.dll, $(notdir $(shell where tbb.dll))))
+	@echo $(findstring tbb.dll, $(notdir $(shell where tbb.dll)))
+	@echo $(notdir $(shell where tbb.dll))
+	@echo $(shell where tbb.dll)
 	@echo 'Intel TBB is not in PATH.'
 	@echo 'Consider calling '
 	@echo '$(HELP_MAKE) install-tbb'

--- a/make/program
+++ b/make/program
@@ -56,10 +56,7 @@ endif
 	$(LINK.cpp) $(subst \,/,$*.o) $(CMDSTAN_MAIN_O) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(subst \,/,$(OUTPUT_OPTION))
 	$(RM) $(subst  \,/,$*).o
 ifeq ($(OS),Windows_NT)
-ifneq (,$(findstring tbb.dll, $(notdir $(shell where tbb.dll))))
-	@echo $(findstring tbb.dll, $(notdir $(shell where tbb.dll)))
-	@echo $(notdir $(shell where tbb.dll))
-	@echo $(shell where tbb.dll)
+ifeq (,$(findstring tbb.dll, $(notdir $(shell where tbb.dll))))
 	@echo 'Intel TBB is not in PATH.'
 	@echo 'Consider calling '
 	@echo '$(HELP_MAKE) install-tbb'

--- a/make/program
+++ b/make/program
@@ -56,7 +56,7 @@ endif
 	$(LINK.cpp) $(subst \,/,$*.o) $(CMDSTAN_MAIN_O) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS) $(subst \,/,$(OUTPUT_OPTION))
 	$(RM) $(subst  \,/,$*).o
 ifeq ($(OS),Windows_NT)
-ifneq ($(notdir $(shell where tbb.dll)),tbb.dll)
+ifneq (,$(findstring tbb.dll, $(notdir $(shell where tbb.dll))))
 	@echo 'Intel TBB is not in PATH.'
 	@echo 'Consider calling '
 	@echo '$(HELP_MAKE) install-tbb'


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Resolves #1027 by changing the detection logic to be substring-based rather than strict equality

#### Intended Effect: 
Make tbb check more robust on Windows

#### How to Verify:
Run on a windows machine with two copies of `tbb.dll` in the PATH

#### Side Effects: None

#### Documentation: No change

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
