### PR TITLE
Pull correct linux arch for stanc3

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -31,7 +31,7 @@ else ifeq ($(OS),Linux)
  else ifeq ($(shell uname -m),aarch64)
   ARCH_TAG := -arm64
  else ifeq ($(shell uname -m),armv7l)
-  ifeq ($(readelf -A /proc/self/exe | grep Tag_ABI_VFP_args),)
+  ifeq ($(shell readelf -A /usr/bin/file | grep Tag_ABI_VFP_args),)
     ARCH_TAG := -armel
   else
     ARCH_TAG := -armhf

--- a/make/stanc
+++ b/make/stanc
@@ -22,6 +22,22 @@ else ifeq ($(OS),Darwin)
  STANC_XATTR := $(shell xattr bin/mac-stanc 2>/dev/null)
 else ifeq ($(OS),Linux)
  OS_TAG := linux
+ ifeq ($(shell uname -m),mips64)
+  ARCH_TAG := -mips64el
+ else ifeq ($(shell uname -m),ppc64le)
+  ARCH_TAG := -ppc64el
+ else ifeq ($(shell uname -m),s390x)
+  ARCH_TAG := -s390x
+ else ifeq ($(shell uname -m),aarch64)
+  ARCH_TAG := -arm64
+ else ifeq ($(shell uname -m),armv7l)
+  ifeq ($(readelf -A /proc/self/exe | grep Tag_ABI_VFP_args),)
+    ARCH_TAG := -armel
+  else
+    ARCH_TAG := -armhf
+  endif
+ endif
+
 else ifeq ($(OS),missing-submodules)
  CMDSTAN_SUBMODULES = 0
 else
@@ -45,7 +61,7 @@ ifeq ($(OS_TAG),windows)
 else
     bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
-	curl -L $(STANC3_TEST_BIN_URL)/bin/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
+	curl -L $(STANC3_TEST_BIN_URL)/bin/$(OS_TAG)$(ARCH_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
 	chmod +x bin/stanc$(EXE)
 endif
 
@@ -72,7 +88,7 @@ else
 # get latest stanc3 - Linux & MacOS
     bin/stanc$(EXE) :
 	@mkdir -p $(dir $@)
-	curl -L https://github.com/stan-dev/stanc3/releases/download/$(STANC3_VERSION)/$(OS_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
+	curl -L https://github.com/stan-dev/stanc3/releases/download/$(STANC3_VERSION)/$(OS_TAG)$(ARCH_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
 	chmod +x bin/stanc$(EXE)
 endif
 endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
This PR adds the functionality for downloading the stanc3 for additional architectures on linux. The following architectures are now supported:

 - `arm64`
 - `armel`
 - `armhf`
 - `mips64el`
 - `ppc64el`
 - `s390x`

I've tested this under QEMU, and the correct stanc3 binary is downloaded and the bernoulli model compiles and runs under all architectures

#### Intended Effect:
Automatic support for `cmdstan` across more linux architectures

#### How to Verify:
Call `make build` on a non-x86 linux system

#### Side Effects:
N/A

#### Documentation:
N/A
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
