### PR TITLE
Precompile windows gcc 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
       shell: powershell
     - name: Build Math libs & add to PATH
       run: |
+        make print-PRECOMPILED_HEADERS
         mingw32-make -f stan/lib/stan_math/make/standalone math-libs
         echo "D:/a/cmdstan/cmdstan/stan/lib/stan_math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
       shell: powershell

--- a/makefile
+++ b/makefile
@@ -108,10 +108,14 @@ endif
 STAN_FLAGS=$(STAN_FLAG_THREADS)$(STAN_FLAG_MPI)$(STAN_FLAG_OPENCL)
 
 ifeq ($(OS),Windows_NT)
+ifeq (clang,$(CXX_TYPE))
+PRECOMPILED_HEADERS ?= false
+else
 ifeq ($(shell expr $(CXX_MAJOR) \>= 8), 1)
 PRECOMPILED_HEADERS ?= true
 else
 PRECOMPILED_HEADERS ?= false
+endif
 endif
 else
 PRECOMPILED_HEADERS ?= true

--- a/makefile
+++ b/makefile
@@ -108,7 +108,11 @@ endif
 STAN_FLAGS=$(STAN_FLAG_THREADS)$(STAN_FLAG_MPI)$(STAN_FLAG_OPENCL)
 
 ifeq ($(OS),Windows_NT)
+ifeq ($(shell expr $(CXX_MAJOR) \>= 8), 1)
+PRECOMPILED_HEADERS ?= true
+else
 PRECOMPILED_HEADERS ?= false
+endif
 else
 PRECOMPILED_HEADERS ?= true
 endif


### PR DESCRIPTION
#### Summary:

This PR changes the makefile logic so that `PRECOMPILED_HEADERS=true` is automatically set on Windows if its using g++ 8 or newer (RTools 4.0 supplied toolchain).
Currently its not used on Windows by default.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
