### PR TITLE
Fix handling large seed values

### DIFF
--- a/src/cmdstan/arguments/arg_seed.hpp
+++ b/src/cmdstan/arguments/arg_seed.hpp
@@ -12,7 +12,9 @@ class arg_seed : public long_long_int_argument {
   arg_seed() : long_long_int_argument() {
     _name = "seed";
     _description = "Random number generator seed";
-    _validity = "non-negative integer < 4294967296  or -1 to generate seed from system time";
+    _validity
+        = "non-negative integer < 4294967296  or -1 to generate seed from "
+          "system time";
     _default = "-1";
     _default_value = -1;
     _constrained = true;
@@ -25,7 +27,9 @@ class arg_seed : public long_long_int_argument {
               .total_milliseconds();
   }
 
-  bool is_valid(long long int value) { return (value <= UINT_MAX && value >= 0) || value == _default_value; }
+  bool is_valid(long long int value) {
+    return (value <= UINT_MAX && value >= 0) || value == _default_value;
+  }
 
   unsigned int random_value() {
     if (_value == _default_value) {

--- a/src/cmdstan/arguments/arg_seed.hpp
+++ b/src/cmdstan/arguments/arg_seed.hpp
@@ -12,7 +12,7 @@ class arg_seed : public long_long_int_argument {
   arg_seed() : long_long_int_argument() {
     _name = "seed";
     _description = "Random number generator seed";
-    _validity = "non-negative integer < 214748368  or -1 to generate seed from system time";
+    _validity = "non-negative integer < 4294967296  or -1 to generate seed from system time";
     _default = "-1";
     _default_value = -1;
     _constrained = true;
@@ -25,7 +25,7 @@ class arg_seed : public long_long_int_argument {
               .total_milliseconds();
   }
 
-  bool is_valid(long long int value) { return (value <= INT_MAX && value >= 0) || value == _default_value; }
+  bool is_valid(long long int value) { return (value <= UINT_MAX && value >= 0) || value == _default_value; }
 
   unsigned int random_value() {
     if (_value == _default_value) {

--- a/src/cmdstan/arguments/arg_seed.hpp
+++ b/src/cmdstan/arguments/arg_seed.hpp
@@ -12,7 +12,7 @@ class arg_seed : public long_long_int_argument {
   arg_seed() : long_long_int_argument() {
     _name = "seed";
     _description = "Random number generator seed";
-    _validity = "integer >= 0 or -1 to generate seed from system time";
+    _validity = "non-negative integer < 214748368  or -1 to generate seed from system time";
     _default = "-1";
     _default_value = -1;
     _constrained = true;

--- a/src/cmdstan/arguments/arg_seed.hpp
+++ b/src/cmdstan/arguments/arg_seed.hpp
@@ -6,10 +6,10 @@
 
 namespace cmdstan {
 
-class arg_seed : public int_argument {
+class arg_seed : public long_long_int_argument {
  public:
   unsigned int _random_value;
-  arg_seed() : int_argument() {
+  arg_seed() : long_long_int_argument() {
     _name = "seed";
     _description = "Random number generator seed";
     _validity = "integer >= 0 or -1 to generate seed from system time";
@@ -25,7 +25,7 @@ class arg_seed : public int_argument {
               .total_milliseconds();
   }
 
-  bool is_valid(int value) { return value >= 0 || value == _default_value; }
+  bool is_valid(long long int value) { return (value <= INT_MAX && value >= 0) || value == _default_value; }
 
   unsigned int random_value() {
     if (_value == _default_value) {

--- a/src/cmdstan/arguments/singleton_argument.hpp
+++ b/src/cmdstan/arguments/singleton_argument.hpp
@@ -146,6 +146,7 @@ class singleton_argument : public valued_argument {
 
 typedef singleton_argument<double> real_argument;
 typedef singleton_argument<int> int_argument;
+typedef singleton_argument<long long int> long_long_int_argument;
 typedef singleton_argument<unsigned int> u_int_argument;
 typedef singleton_argument<bool> bool_argument;
 typedef singleton_argument<std::string> string_argument;

--- a/src/test/interface/command_test.cpp
+++ b/src/test/interface/command_test.cpp
@@ -485,15 +485,6 @@ TEST(StanUiCommand, random_seed_fail_1) {
   std::string cmd_output = run_command(command).output;
   run_command_output out = run_command(command);
   EXPECT_EQ(1, count_matches(expected_message, out.body));
-
-  std::string command_2
-      = convert_model_path(model_path)
-        + " sample num_samples=10 num_warmup=10 init=0 " + " random seed=2147483648 "
-        + " data file=src/test/test-models/transformed_data_rng_test.init.R"
-        + " output refresh=0 file=test/output.csv";
-  std::string cmd_output_2 = run_command(command).output;
-  run_command_output out_2 = run_command(command);
-  EXPECT_EQ(1, count_matches(expected_message, out_2.body));
 }
 
 TEST(StanUiCommand, random_seed_fail_2) {
@@ -505,8 +496,9 @@ TEST(StanUiCommand, random_seed_fail_2) {
   model_path.push_back("test-models");
   model_path.push_back("transformed_data_rng_test");
 
-  int max = std::numeric_limits<int>::max();
-  unsigned int maxplus = max + 100;
+  long long int max = std::numeric_limits<unsigned int>::max();
+  long long int maxplus = max + 100;
+
   std::string command
       = convert_model_path(model_path)
         + " sample num_samples=10 num_warmup=10 init=0 "

--- a/src/test/interface/command_test.cpp
+++ b/src/test/interface/command_test.cpp
@@ -485,6 +485,15 @@ TEST(StanUiCommand, random_seed_fail_1) {
   std::string cmd_output = run_command(command).output;
   run_command_output out = run_command(command);
   EXPECT_EQ(1, count_matches(expected_message, out.body));
+
+  std::string command_2
+      = convert_model_path(model_path)
+        + " sample num_samples=10 num_warmup=10 init=0 " + " random seed=2147483648 "
+        + " data file=src/test/test-models/transformed_data_rng_test.init.R"
+        + " output refresh=0 file=test/output.csv";
+  std::string cmd_output_2 = run_command(command).output;
+  run_command_output out_2 = run_command(command);
+  EXPECT_EQ(1, count_matches(expected_message, out_2.body));
 }
 
 TEST(StanUiCommand, random_seed_fail_2) {

--- a/src/test/interface/command_test.cpp
+++ b/src/test/interface/command_test.cpp
@@ -499,15 +499,29 @@ TEST(StanUiCommand, random_seed_fail_2) {
   long long int max = std::numeric_limits<unsigned int>::max();
   long long int maxplus = max + 100;
 
-  std::string command
-      = convert_model_path(model_path)
-        + " sample num_samples=10 num_warmup=10 init=0 "
-        + " random seed=" + std::to_string(maxplus) + " "
-        + " data file=src/test/test-models/transformed_data_rng_test.init.R"
-        + " output refresh=0 file=test/output.csv";
-  std::string cmd_output = run_command(command).output;
-  run_command_output out = run_command(command);
-  EXPECT_EQ(1, count_matches(expected_message, out.body));
+  {
+    std::string command
+          = convert_model_path(model_path)
+            + " sample num_samples=10 num_warmup=10 init=0 "
+            + " random seed=" + std::to_string(max) + " "
+            + " data file=src/test/test-models/transformed_data_rng_test.init.R"
+            + " output refresh=0 file=test/output.csv";
+      std::string cmd_output = run_command(command).output;
+      run_command_output out = run_command(command);
+      EXPECT_EQ(0, count_matches(expected_message, out.body));
+  }
+
+  {
+    std::string command
+          = convert_model_path(model_path)
+            + " sample num_samples=10 num_warmup=10 init=0 "
+            + " random seed=" + std::to_string(maxplus) + " "
+            + " data file=src/test/test-models/transformed_data_rng_test.init.R"
+            + " output refresh=0 file=test/output.csv";
+      std::string cmd_output = run_command(command).output;
+      run_command_output out = run_command(command);
+      EXPECT_EQ(1, count_matches(expected_message, out.body));
+  }
 }
 
 TEST(StanUiCommand, json_input) {

--- a/src/test/interface/command_test.cpp
+++ b/src/test/interface/command_test.cpp
@@ -501,26 +501,26 @@ TEST(StanUiCommand, random_seed_fail_2) {
 
   {
     std::string command
-          = convert_model_path(model_path)
-            + " sample num_samples=10 num_warmup=10 init=0 "
-            + " random seed=" + std::to_string(max) + " "
-            + " data file=src/test/test-models/transformed_data_rng_test.init.R"
-            + " output refresh=0 file=test/output.csv";
-      std::string cmd_output = run_command(command).output;
-      run_command_output out = run_command(command);
-      EXPECT_EQ(0, count_matches(expected_message, out.body));
+        = convert_model_path(model_path)
+          + " sample num_samples=10 num_warmup=10 init=0 "
+          + " random seed=" + std::to_string(max) + " "
+          + " data file=src/test/test-models/transformed_data_rng_test.init.R"
+          + " output refresh=0 file=test/output.csv";
+    std::string cmd_output = run_command(command).output;
+    run_command_output out = run_command(command);
+    EXPECT_EQ(0, count_matches(expected_message, out.body));
   }
 
   {
     std::string command
-          = convert_model_path(model_path)
-            + " sample num_samples=10 num_warmup=10 init=0 "
-            + " random seed=" + std::to_string(maxplus) + " "
-            + " data file=src/test/test-models/transformed_data_rng_test.init.R"
-            + " output refresh=0 file=test/output.csv";
-      std::string cmd_output = run_command(command).output;
-      run_command_output out = run_command(command);
-      EXPECT_EQ(1, count_matches(expected_message, out.body));
+        = convert_model_path(model_path)
+          + " sample num_samples=10 num_warmup=10 init=0 "
+          + " random seed=" + std::to_string(maxplus) + " "
+          + " data file=src/test/test-models/transformed_data_rng_test.init.R"
+          + " output refresh=0 file=test/output.csv";
+    std::string cmd_output = run_command(command).output;
+    run_command_output out = run_command(command);
+    EXPECT_EQ(1, count_matches(expected_message, out.body));
   }
 }
 


### PR DESCRIPTION
#### Summary:

Fixes #1003 by allowing values up to max `unsigned int`.

To test run the following with the bernoulli example:

This fails on develop but works on this PR
```
./examples/bernoulli/bernoulli sample data file=examples/bernoulli/bernoulli.data.json random seed=2147483647
```


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
