### PR TITLE
Minor cleanup of the num_threads arg

### DIFF
--- a/src/cmdstan/arguments/arg_num_threads.hpp
+++ b/src/cmdstan/arguments/arg_num_threads.hpp
@@ -9,8 +9,12 @@ class arg_num_threads : public int_argument {
  public:
   arg_num_threads() : int_argument() {
     _name = "num_threads";
-    _description = std::string("Number of threads available to the program.");
+    _description = std::string("Number of threads available to the program. For full effect, the model must be compiled with STAN_THREADS=true.");
+#ifdef STAN_THREADS
     _validity = "num_threads > 0 || num_threads == -1";
+#else
+    _validity = "num_threads == 1";
+#endif
     _default = "1";
     _default_value = 1;
     _good_value = 1.0;

--- a/src/cmdstan/arguments/arg_num_threads.hpp
+++ b/src/cmdstan/arguments/arg_num_threads.hpp
@@ -9,7 +9,9 @@ class arg_num_threads : public int_argument {
  public:
   arg_num_threads() : int_argument() {
     _name = "num_threads";
-    _description = std::string("Number of threads available to the program. For full effect, the model must be compiled with STAN_THREADS=true.");
+    _description = std::string(
+        "Number of threads available to the program. For full effect, the "
+        "model must be compiled with STAN_THREADS=true.");
 #ifdef STAN_THREADS
     _validity = "num_threads > 0 || num_threads == -1";
 #else


### PR DESCRIPTION
#### Summary:

If STAN_THREADS is not on, the text when the argument is valid is off. This fixes that and adds a bit of additional description.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
