### PR TITLE
Fix #1043

### DIFF
--- a/src/cmdstan/arguments/arg_num_threads.hpp
+++ b/src/cmdstan/arguments/arg_num_threads.hpp
@@ -18,7 +18,7 @@ class arg_num_threads : public int_argument {
 #else
     _validity = "num_threads == 1";
 #endif
-    _default = boost::lexical_cast<std::string>(stan::math::internal::get_num_threads());
+    _default = "1 or the value of the STAN_NUM_THREADS environment variable if set.";
     _default_value = stan::math::internal::get_num_threads();
     _good_value = 1.0;
     _bad_value = -2.0;

--- a/src/cmdstan/arguments/arg_num_threads.hpp
+++ b/src/cmdstan/arguments/arg_num_threads.hpp
@@ -18,7 +18,8 @@ class arg_num_threads : public int_argument {
 #else
     _validity = "num_threads == 1";
 #endif
-    _default = "1 or the value of the STAN_NUM_THREADS environment variable if set.";
+    _default
+        = "1 or the value of the STAN_NUM_THREADS environment variable if set.";
     _default_value = stan::math::internal::get_num_threads();
     _good_value = 1.0;
     _bad_value = -2.0;

--- a/src/cmdstan/arguments/arg_num_threads.hpp
+++ b/src/cmdstan/arguments/arg_num_threads.hpp
@@ -2,6 +2,7 @@
 #define CMDSTAN_ARGUMENTS_ARG_NUM_THREADS_HPP
 
 #include <cmdstan/arguments/singleton_argument.hpp>
+#include <stan/math/prim/core/init_threadpool_tbb.hpp>
 
 namespace cmdstan {
 
@@ -17,8 +18,8 @@ class arg_num_threads : public int_argument {
 #else
     _validity = "num_threads == 1";
 #endif
-    _default = "1";
-    _default_value = 1;
+    _default = boost::lexical_cast<std::string>(stan::math::internal::get_num_threads());
+    _default_value = stan::math::internal::get_num_threads();
     _good_value = 1.0;
     _bad_value = -2.0;
     _constrained = true;


### PR DESCRIPTION
#### Summary:

Found a bit of a cleaner solution. We default num_threads to whatever is set to STAN_NUM_THREADS. Or if its not set, then it defaults to 1.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
