### PR TITLE
Don't enforce `fixed_param` sampler when model has no parameters

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -689,10 +689,6 @@ int command(int argc, const char *argv[]) {
         = dynamic_cast<categorical_argument *>(sample_arg->arg("adapt"));
     bool adapt_engaged
         = dynamic_cast<bool_argument *>(adapt->arg("engaged"))->value();
-    if (model.num_params_r() == 0) {
-      // nothing to adapt (and the adaptive sampler wouldn't work correctly)
-      adapt_engaged = false;
-    }
 
     if (algo->value() == "fixed_param") {
       return_code = stan::services::sample::fixed_param(

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -689,12 +689,12 @@ int command(int argc, const char *argv[]) {
         = dynamic_cast<categorical_argument *>(sample_arg->arg("adapt"));
     bool adapt_engaged
         = dynamic_cast<bool_argument *>(adapt->arg("engaged"))->value();
+    if (model.num_params_r() == 0) {
+      // nothing to adapt (and the adaptive sampler wouldn't work correctly)
+      adapt_engaged = false;
+    }
 
-    if (model.num_params_r() == 0 || algo->value() == "fixed_param") {
-      if (algo->value() != "fixed_param")
-        info(
-            "Model contains no parameters, running fixed_param sampler, "
-            "no updates to Markov chain");
+    if (algo->value() == "fixed_param") {
       return_code = stan::services::sample::fixed_param(
           model, *(init_contexts[0]), random_seed, id, init_radius, num_samples,
           num_thin, refresh, interrupt, logger, init_writers[0],

--- a/src/test/interface/fixed_param_sampler_test.cpp
+++ b/src/test/interface/fixed_param_sampler_test.cpp
@@ -88,8 +88,4 @@ TEST(McmcFixedParamSampler, check_empty_but_algorithm_not_fixed_param) {
   }
 
   EXPECT_EQ(success, true);
-  std::string expected_message
-      = "Model contains no parameters, running fixed_param sampler";
-  EXPECT_TRUE(
-      boost::algorithm::contains(command_output.output, expected_message));
 }


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run tests: `./runCmdStanTests.py src/test`
- [X] Declare copyright holder and open-source license: see below

#### Summary:

Before CmdStan 2.27 you could not sample from a parameterless model with the default settings. CmdStan 2.27 fixes this annoyance by automatically switching to `fixed_param` sampler when model has zero parameters. (It changes not only defaults but also forces `fixed_param` even if HMC is explicitly specified.)
This fix however causes problems for interfaces like CmdStanPy because the interface thinks the sampler is HMC and the output CSV from `fixed_param` is missing expected adaptation info. PR #1030 intends to fix _that_ issue by adjusting the sampler config recorded in the CSV file.

This PR is an alternative to #1030. Instead of modifying the config info this simply reverses the `fixed_param` hack; HMC is always the default. Parameterless models will be able to run HMC just fine after stan-dev/stan#3071 is merged.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Niko Huurre

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
