### PR TITLE
diagnostics writer now has a nullptr if we are not using it

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -500,8 +500,7 @@ int command(int argc, const char *argv[]) {
                                          std::fstream::out),
           "# ");
     } else {
-      diagnostic_writers.emplace_back(
-          std::make_unique<std::fstream>("", std::fstream::out), "# ");
+      diagnostic_writers.emplace_back(nullptr, "# ");
     }
   }
   for (int i = 0; i < num_chains; i++) {


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This needs to wait for https://github.com/stan-dev/stan/pull/3087 but fixes the performance regression in https://github.com/stan-dev/cmdstan/issues/1055

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
