### PR TITLE
Fix #997: proper use of `std::setprecision` in `bin/diagnose`

### DIFF
--- a/src/cmdstan/diagnose.cpp
+++ b/src/cmdstan/diagnose.cpp
@@ -47,7 +47,7 @@ int main(int argc, const char *argv[]) {
     std::cout << "No valid input files, exiting." << std::endl;
     return 0;
   }
-  
+
   std::cout << std::fixed << std::setprecision(2);
 
   // Parse specified files
@@ -97,8 +97,7 @@ int main(int argc, const char *argv[]) {
       if (n_max > 0) {
         has_errors = true;
         double pct = 100 * static_cast<double>(n_max) / num_samples;
-        std::cout << n_max << " of " << num_samples << " ("
-                  << pct << "%)"
+        std::cout << n_max << " of " << num_samples << " (" << pct << "%)"
                   << " transitions hit the maximum treedepth limit of "
                   << max_limit << ", or 2^" << max_limit << " leapfrog steps."
                   << std::endl

--- a/src/cmdstan/diagnose.cpp
+++ b/src/cmdstan/diagnose.cpp
@@ -47,6 +47,8 @@ int main(int argc, const char *argv[]) {
     std::cout << "No valid input files, exiting." << std::endl;
     return 0;
   }
+  
+  std::cout << std::fixed << std::setprecision(2);
 
   // Parse specified files
   std::cout << "Processing csv files: " << filenames[0];
@@ -96,7 +98,7 @@ int main(int argc, const char *argv[]) {
         has_errors = true;
         double pct = 100 * static_cast<double>(n_max) / num_samples;
         std::cout << n_max << " of " << num_samples << " ("
-                  << std::setprecision(2) << pct << "%)"
+                  << pct << "%)"
                   << " transitions hit the maximum treedepth limit of "
                   << max_limit << ", or 2^" << max_limit << " leapfrog steps."
                   << std::endl
@@ -115,7 +117,6 @@ int main(int argc, const char *argv[]) {
       if (n_divergent > 0) {
         has_errors = true;
         std::cout << n_divergent << " of " << num_samples << " ("
-                  << std::setprecision(2)
                   << 100 * static_cast<double>(n_divergent) / num_samples
                   << "%) transitions ended with a divergence." << std::endl
                   << "These divergent transitions indicate that HMC is not "

--- a/src/test/interface/example_output/corr_gauss.nom
+++ b/src/test/interface/example_output/corr_gauss.nom
@@ -1,5 +1,5 @@
 Checking sampler transitions treedepth.
-5 of 1000 (0.5%) transitions hit the maximum treedepth limit of 10, or 2^10 leapfrog steps.
+5 of 1000 (0.50%) transitions hit the maximum treedepth limit of 10, or 2^10 leapfrog steps.
 Trajectories that are prematurely terminated due to this limit will result in slow exploration.
 For optimal performance, increase this limit.
 

--- a/src/test/interface/example_output/corr_gauss_depth8.nom
+++ b/src/test/interface/example_output/corr_gauss_depth8.nom
@@ -1,5 +1,5 @@
 Checking sampler transitions treedepth.
-424 of 1000 (42%) transitions hit the maximum treedepth limit of 8, or 2^8 leapfrog steps.
+424 of 1000 (42.40%) transitions hit the maximum treedepth limit of 8, or 2^8 leapfrog steps.
 Trajectories that are prematurely terminated due to this limit will result in slow exploration.
 For optimal performance, increase this limit.
 

--- a/src/test/interface/example_output/eight_schools.nom
+++ b/src/test/interface/example_output/eight_schools.nom
@@ -2,13 +2,13 @@ Checking sampler transitions treedepth.
 Treedepth satisfactory for all transitions.
 
 Checking sampler transitions for divergences.
-7 of 1000 (0.7%) transitions ended with a divergence.
+7 of 1000 (0.70%) transitions ended with a divergence.
 These divergent transitions indicate that HMC is not fully able to explore the posterior distribution.
 Try increasing adapt delta closer to 1.
 If this doesn't remove all divergences, try to reparameterize the model.
 
 Checking E-BFMI - sampler transitions HMC potential energy.
-The E-BFMI, 0.26, is below the nominal threshold of 0.3 which suggests that HMC may have trouble exploring the target distribution.
+The E-BFMI, 0.26, is below the nominal threshold of 0.30 which suggests that HMC may have trouble exploring the target distribution.
 If possible, try to reparameterize the model.
 
 Effective sample size satisfactory.


### PR DESCRIPTION
#### Summary:

Fixes #997 by adding std::fixed to std::cout. Precision is also only set once at the top of the file.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
