### PR TITLE
[WIP] Move ci to flatiron institute

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "stan"]
 	path = stan
-        url = https://github.com/stan-dev/stan
+        url = https://github.com/stan-dev/stan.git

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
         stage('Clean & Setup') {
             agent {
                 docker {
-                    image 'stanorg/ci:alpine'
+                    image 'stanorg/ci:gpu'
                     label 'linux'
                 }
             }
@@ -79,7 +79,7 @@ pipeline {
         stage('Verify changes') {
             agent {
                 docker {
-                    image 'stanorg/ci:alpine'
+                    image 'stanorg/ci:gpu'
                     label 'linux'
                 }
             }
@@ -102,7 +102,7 @@ pipeline {
         stage("Clang-format") {
             agent {
                 docker {
-                    image 'stanorg/ci:alpine'
+                    image 'stanorg/ci:gpu'
                     label 'linux'
                 }
             }
@@ -188,7 +188,7 @@ pipeline {
                 stage('Linux interface tests with MPI') {
                     agent {
                         docker {
-                            image 'stanorg/ci:alpine'
+                            image 'stanorg/ci:gpu'
                             label 'linux'
                         }
                     }
@@ -223,7 +223,7 @@ pipeline {
                 stage('Mac interface tests') {
                     agent {
                         docker {
-                            image 'stanorg/ci:alpine'
+                            image 'stanorg/ci:gpu'
                             label 'osx'
                         }
                     }
@@ -251,7 +251,6 @@ pipeline {
                         }
                     }
                 }
-flatiron
 
                 stage('Upstream CmdStan Performance tests') {
                     when {
@@ -264,7 +263,7 @@ flatiron
                     steps {
                         script{
                             build(
-                                job: "CmdStan Performance Tests/downstream_tests",
+                                job: "Stan/CmdStan Performance Tests/downstream_tests",
                                 parameters: [
                                     string(name: 'cmdstan_pr', value: env.BRANCH_NAME),
                                     string(name: 'stan_pr', value: params.stan_pr),
@@ -284,7 +283,7 @@ flatiron
         success {
            script {
                if (env.BRANCH_NAME == "develop") {
-                   build job: "CmdStan Performance Tests/master", wait:false
+                   build job: "Stan/CmdStan Performance Tests/master", wait:false
                }
                //utils.mailBuildResults("SUCCESSFUL")
            }


### PR DESCRIPTION
## Summary

This PR will handle Jenkins CI migration to Flatiron Institute. Currently WIP until we iron out errors, plugins and other requirements.

## Tests

We will run mc-stan and flatiron Jenkins in parallel until it's stable and most of the main jobs are workings, after that we will decomission mc-stan and migrate entirely to Flatiron Institute.

## Side Effects

There may be side effects where two jobs would try to do the same objective like updating a submodule, will try to avoid this as much as possible.

## Release notes

## Copyright and Licensing


- [ ] Copyright holder: Toptal

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
