### PR TITLE
[WIP] Move ci to flatiron institute

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,10 @@ pipeline {
         string(defaultValue: '', name: 'math_pr',
                description: "Math PR to test against. Will check out this PR in the downstream Math repo.")
     }
+    environment {
+        CXX = 'clang++-6.0'
+        PARALLEL = 8
+    }
     stages {
         stage('Kill previous builds') {
             when {
@@ -53,7 +57,12 @@ pipeline {
             steps { script { utils.killOldBuilds() } }
         }
         stage('Clean & Setup') {
-            agent any
+            agent {
+                docker {
+                    image 'stanorg/ci:gpu'
+                    label 'linux'
+                }
+            }
             steps {
                 retry(3) { checkout scm }
                 sh 'git clean -xffd'
@@ -68,7 +77,12 @@ pipeline {
             post { always { deleteDir() }}
         }
         stage('Verify changes') {
-            agent { label 'linux' }
+            agent {
+                docker {
+                    image 'stanorg/ci:gpu'
+                    label 'linux'
+                }
+            }
             steps {
                 script {
 
@@ -86,10 +100,14 @@ pipeline {
             }
         }
         stage("Clang-format") {
-            agent any
+            agent {
+                docker {
+                    image 'stanorg/ci:gpu'
+                    label 'linux'
+                }
+            }
             steps {
                 sh "printenv"
-                deleteDir()
                 retry(3) { checkout scm }
                 withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
                     usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
@@ -168,7 +186,12 @@ pipeline {
                 }
 
                 stage('Linux interface tests with MPI') {
-                    agent { label 'linux && mpi'}
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu'
+                            label 'linux'
+                        }
+                    }
                     steps {
                         setupCXX("${MPICXX}")
                         sh "echo STAN_MPI=true >> make/local"
@@ -198,7 +221,12 @@ pipeline {
                 }
 
                 stage('Mac interface tests') {
-                    agent { label 'osx'}
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu'
+                            label 'osx'
+                        }
+                    }
                     steps {
                         setupCXX()
                         sh runTests("./")
@@ -235,7 +263,7 @@ pipeline {
                     steps {
                         script{
                             build(
-                                job: "CmdStan Performance Tests/downstream_tests",
+                                job: "Stan/CmdStan Performance Tests/downstream_tests",
                                 parameters: [
                                     string(name: 'cmdstan_pr', value: env.BRANCH_NAME),
                                     string(name: 'stan_pr', value: params.stan_pr),
@@ -250,16 +278,17 @@ pipeline {
             }
         }
     }
+    // Below lines are commented to avoid spamming emails during migration/debug
     post {
         success {
            script {
                if (env.BRANCH_NAME == "develop") {
-                   build job: "CmdStan Performance Tests/master", wait:false
+                   build job: "Stan/CmdStan Performance Tests/master", wait:false
                }
-               utils.mailBuildResults("SUCCESSFUL")
+               //utils.mailBuildResults("SUCCESSFUL")
            }
         }
-        unstable { script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com") } }
-        failure { script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com") } }
+        //unstable { script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com") } }
+        //failure { script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com") } }
     }
 }


### PR DESCRIPTION
## Summary

This PR will handle Jenkins CI migration to Flatiron Institute. Currently WIP until we iron out errors, plugins and other requirements.

## Tests

We will run mc-stan and flatiron Jenkins in parallel until it's stable and most of the main jobs are workings, after that we will decomission mc-stan and migrate entirely to Flatiron Institute.

## Side Effects

There may be side effects where two jobs would try to do the same objective like updating a submodule, will try to avoid this as much as possible.

## Release notes

## Copyright and Licensing


- [ ] Copyright holder: Toptal

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
