### PR TITLE
Remove existing stanc before copying built one if STANC make variable is used

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -51,7 +51,7 @@ ifneq ($(STANC3),)
   bin/stanc$(EXE) : $(call findfiles,$(STANC3)/src/,*.ml*) $(STANC#)
 	@mkdir -p $(dir $@)
 	cd $(STANC3) && echo "--- Rebuilding stanc ---\n" && dune build @install
-	cp $(STANC3)/_build/default/src/stanc/stanc.exe $@
+	test -f $(STANC3)/_build/default/src/stanc/stanc.exe && rm -f $@ && cp $(STANC3)/_build/default/src/stanc/stanc.exe $@ || exit 1
 else ifneq ($(STANC3_TEST_BIN_URL),)
 # download stanc3 build from specific branch
 ifeq ($(OS_TAG),windows)


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

When using the STANC make variable, after the first usage it will fail to update the stanc binary since the created binary is write protected. This adds logic to remove the existing one after it is rebuilt to allow copying

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
