### PR TITLE
Properly handle size-zero JSON arrays as input

### DIFF
--- a/src/cmdstan/io/json/json_data.hpp
+++ b/src/cmdstan/io/json/json_data.hpp
@@ -270,7 +270,13 @@ class json_data : public stan::io::var_context {
     for (size_t i = 0; i < dims.size(); ++i) {
       num_elements *= dims[i];
     }
-    if (num_elements == 0)
+
+    size_t num_elements_expected = 1;
+    for (size_t i = 0; i < dims_declared.size(); ++i) {
+      num_elements_expected *= dims_declared[i];
+    }
+
+    if (num_elements == 0 && num_elements_expected == 0)
       return;
 
     if (dims.size() != dims_declared.size()) {


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes #1092. 

#### Intended Effect:

When validating JSON dimensions we currently assume a size-zero object is valid always. This is only true if the expected size is also zero. 

#### How to Verify:

Model:
```stan
data {
  int n;
  array[n, n] real x;
}
```

Data 1 (should produce error, not segfault):
```json
{
  "n": 1,
  "x": [  ]
}
```

Data 2 (should succeed):

```json
{
  "n": 0,
  "x": [  ]
}
```

#### Side Effects:

None

#### Documentation:

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
