### PR TITLE
Add error if num_chains is supplied to non-HMC algorithm

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -358,13 +358,13 @@ int command(int argc, const char *argv[]) {
         if (engine->value() != "nuts"
             && (metric->value() != "dense_e" || metric->value() == "diag_e")) {
           throw std::invalid_argument(
-              "num_chains can currently only be used for NUTS with adaptation "
-              "and dense_e or diag_e metric");
+              "Argument 'num_chains' can currently only be used for NUTS with "
+              "adaptation and dense_e or diag_e metric");
         }
       } else {
         throw std::invalid_argument(
-            "num_chains can currently only be used for HMC with adaptation "
-            "engaged");
+            "Argument 'num_chains' can currently only be used for HMC with "
+            "adaptation engaged");
       }
     }
   }
@@ -695,10 +695,17 @@ int command(int argc, const char *argv[]) {
         = dynamic_cast<bool_argument *>(adapt->arg("engaged"))->value();
 
     if (model.num_params_r() == 0 || algo->value() == "fixed_param") {
-      if (algo->value() != "fixed_param")
+      if (algo->value() != "fixed_param") {
         info(
             "Model contains no parameters, running fixed_param sampler, "
             "no updates to Markov chain");
+        if (num_chains > 1) {
+          throw std::invalid_argument(
+              "Argument 'num_chains' can currently only be used for HMC with "
+              "adaptation engaged. This model has no parameters, which "
+              "currently means only the fixed_param algorithm can be used");
+        }
+      }
       return_code = stan::services::sample::fixed_param(
           model, *(init_contexts[0]), random_seed, id, init_radius, num_samples,
           num_thin, refresh, interrupt, logger, init_writers[0],

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -361,6 +361,10 @@ int command(int argc, const char *argv[]) {
               "num_chains can currently only be used for NUTS with adaptation "
               "and dense_e or diag_e metric");
         }
+      } else {
+        throw std::invalid_argument(
+            "num_chains can currently only be used for HMC with adaptation "
+            "engaged");
       }
     }
   }


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run tests: `./runCmdStanTests.py src/test`
- [X] Declare copyright holder and open-source license: see below

#### Summary:

Adds an error thrown if `num_chains` was specified but the algorithm is not HMC with adaptation. 

#### Intended Effect:

Closes #1057 

#### How to Verify:

Try to run with `adapt engaged=0 num_chains=2` or `num_chains=2 algorithm=fixed_param ` and observe an error is thrown


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation
By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
