### PR TITLE
Improve CI - Custom stanc binaries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ def setupCXX(CXX = env.CXX) {
     unstash 'CmdStanSetup'
 
     stanc3_bin_url_str = params.stanc3_bin_url != "nightly" ? "\nSTANC3_TEST_BIN_URL=${params.stanc3_bin_url}\n" : ""
-    writeFile(file: "make/local", text: "CXX=${CXX} ${stanc3_bin_url_str}")
+    writeFile(file: "make/local", text: "CXX=${CXX} \n${stanc3_bin_url_str}")
 }
 
 def runTests(String prefix = "") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,10 @@ def skipRemainingStages = false
 
 def setupCXX(CXX = env.CXX) {
     unstash 'CmdStanSetup'
-    writeFile(file: "make/local", text: "CXX = ${CXX}\n")
+
+    stanc3_bin_url = params.stanc3_bin_url ?: "nightly"
+    stanc3_bin_url_str = stanc3_bin_url != "nightly" ? "\nSTANC3_TEST_BIN_URL=${stanc3_bin_url}\n" : ""
+    writeFile(file: "make/local", text: "CXX=${CXX} ${stanc3_bin_url_str}")
 }
 
 def runTests(String prefix = "") {
@@ -50,6 +53,8 @@ pipeline {
                description: "Stan PR to test against. Will check out this PR in the downstream Stan repo.")
         string(defaultValue: '', name: 'math_pr',
                description: "Math PR to test against. Will check out this PR in the downstream Math repo.")
+        string(defaultValue: 'nightly', name: 'stanc3_bin_url',
+                  description: 'Custom stanc3 binary url')
     }
     environment {
         MAC_CXX = 'clang++'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,8 +7,7 @@ def skipRemainingStages = false
 def setupCXX(CXX = env.CXX) {
     unstash 'CmdStanSetup'
 
-    stanc3_bin_url = params.stanc3_bin_url ?: "nightly"
-    stanc3_bin_url_str = stanc3_bin_url != "nightly" ? "\nSTANC3_TEST_BIN_URL=${stanc3_bin_url}\n" : ""
+    stanc3_bin_url_str = params.stanc3_bin_url != "nightly" ? "\nSTANC3_TEST_BIN_URL=${params.stanc3_bin_url}\n" : ""
     writeFile(file: "make/local", text: "CXX=${CXX} ${stanc3_bin_url_str}")
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,7 +211,6 @@ pipeline {
                         sh "echo STAN_MPI=true >> make/local"
                         sh "echo CXX_TYPE=gcc >> make/local"
                         sh "make build-mpi > build-mpi.log 2>&1"
-                        sh "cat make/local" // Debug
                         sh runTests("./")
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,10 +207,11 @@ pipeline {
                         }
                     }
                     steps {
-                        setupCXX("${MPICXX}")
+                        setupCXX(MPICXX)
                         sh "echo STAN_MPI=true >> make/local"
                         sh "echo CXX_TYPE=gcc >> make/local"
                         sh "make build-mpi > build-mpi.log 2>&1"
+                        sh "cat make/local" // Debug
                         sh runTests("./")
                     }
                     post {


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:

Receive an additional argument when being called from upstream Pipelines like Stan.
Give the ability to use a custom stanc3 url for the binaries.

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
