### PR TITLE
Improve help message in num_threads

### DIFF
--- a/src/cmdstan/arguments/arg_num_threads.hpp
+++ b/src/cmdstan/arguments/arg_num_threads.hpp
@@ -10,16 +10,18 @@ class arg_num_threads : public int_argument {
  public:
   arg_num_threads() : int_argument() {
     _name = "num_threads";
-    _description = std::string(
-        "Number of threads available to the program. For full effect, the "
-        "model must be compiled with STAN_THREADS=true.");
 #ifdef STAN_THREADS
+    _description = std::string("Number of threads available to the program.");
     _validity = "num_threads > 0 || num_threads == -1";
-#else
-    _validity = "num_threads == 1";
-#endif
     _default
         = "1 or the value of the STAN_NUM_THREADS environment variable if set.";
+#else
+    _description = std::string(
+        "Number of threads available to the program. To use this "
+        "argument, re-compile this model with STAN_THREADS=true.");
+    _validity = "num_threads == 1";
+    _default = "1";
+#endif
     _default_value = stan::math::internal::get_num_threads();
     _good_value = 1.0;
     _bad_value = -2.0;


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This uses the value of `STAN_THREADS` to more specifically target the message displayed for the `num_threads` argument. In particular, if the model was compiled without STAN_THREADS it now says specifically `To use this argument, re-compile this model with STAN_THREADS=true.`

#### Intended Effect:

`num_threads` argument is clearer for each compiled model.

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
