### PR TITLE
Allow xattr -d to fail

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -70,7 +70,7 @@ else ifneq ($(STANC_XATTR),)
     bin/stanc$(EXE) :
 	cp bin/mac-stanc bin/stanc$(EXE)
 	chmod +x bin/stanc
-	xattr -d com.apple.quarantine bin/stanc
+	-xattr -d com.apple.quarantine bin/stanc
 
 else ifneq (,$(wildcard bin/$(OS_TAG)-stanc))
 # use release stanc3 binary (Windows, Linux & MacOS releases before Catalina)


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Some Mac users on the forum are seeing the following error when building:
```
xattr -d com.apple.quarantine bin/stanc
xattr: bin/stanc: No such xattr: com.apple.quarantine
```

Seen in the following:

- https://discourse.mc-stan.org/t/unable-to-install-cmdstanr-on-mac-ventura-m1-macbook-air/29471/10
- https://discourse.mc-stan.org/t/issues-with-cmdstan-install-on-macos-ventura-w-intel-chip/29327/3

This PR simply updates the `stanc` makefile to allow that command to fail without aborting the entire build

#### Intended Effect:

Avoid build errors for some M1 mac users

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
