### PR TITLE
Fix typo in OpenCL command line argument code

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -155,8 +155,8 @@ int command(int argc, const char *argv[]) {
   int opencl_device_id = get_arg_val<int_argument>(parser, "opencl", "device");
   int opencl_platform_id
       = get_arg_val<int_argument>(parser, "opencl", "platform");
-  if ((opencl_device_id >= 0 && open_platform_id < 0)  // default value -1
-      || (opencl_device_id < 0 && open_platform_id >= 0)) {
+  if ((opencl_device_id >= 0 && opencl_platform_id < 0)  // default value -1
+      || (opencl_device_id < 0 && opencl_platform_id >= 0)) {
     std::cerr << "Please set both device and platform OpenCL IDs." << std::endl;
     return return_codes::NOT_OK;
   } else if (opencl_device_id >= 0) {  // opencl_platform_id >= 0 by above test


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes typo noted in #1140 

#### Intended Effect:

CmdStan compiles models when OpenCL is enabled.

#### How to Verify:

We should really have at least some bare minimum testing of this. @rok-cesnovar @serban-nicusor-toptal  - thoughts?

#### Side Effects:

None
#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
