### PR TITLE
Update bernoulli example to remove comment suggesting deprecated syntax

### DIFF
--- a/examples/bernoulli/bernoulli.stan
+++ b/examples/bernoulli/bernoulli.stan
@@ -1,6 +1,6 @@
 data {
   int<lower=0> N;
-  array[N] int<lower=0,upper=1> y; // or int<lower=0,upper=1> y[N];
+  array[N] int<lower=0,upper=1> y;
 }
 parameters {
   real<lower=0,upper=1> theta;


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Bernoulli example file mentioned old array syntax in a comment, this should be removed. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
