### PR TITLE
Fix 'Perhaps you meant' giving invalid suggestions

### DIFF
--- a/src/cmdstan/arguments/list_argument.hpp
+++ b/src/cmdstan/arguments/list_argument.hpp
@@ -117,7 +117,7 @@ class list_argument : public valued_argument {
 
     for (std::vector<argument *>::iterator it = _values.begin();
          it != _values.end(); ++it) {
-      std::string value_prefix = prefix + _name + "=" + (*it)->name() + " ";
+      std::string value_prefix = prefix + _name + "=";
       (*it)->find_arg(name, value_prefix, valid_paths);
     }
   }

--- a/src/test/interface/arguments/argument_parser_test.cpp
+++ b/src/test/interface/arguments/argument_parser_test.cpp
@@ -5,6 +5,8 @@
 #include <cmdstan/arguments/arg_random.hpp>
 #include <cmdstan/arguments/argument_parser.hpp>
 #include <stan/callbacks/writer.hpp>
+#include <stan/callbacks/stream_writer.hpp>
+#include <boost/algorithm/string.hpp>
 #include <stan/services/error_codes.hpp>
 #include <gtest/gtest.h>
 
@@ -36,6 +38,24 @@ class CmdStanArgumentsArgumentParser : public testing::Test {
     delete (parser);
   }
 
+  void check_suggestion(std::string suggestion) {
+    boost::trim(suggestion);
+    boost::replace_first(suggestion, "<double>",
+                         "1e-20");  // replace type with value
+    std::vector<std::string> args;
+    boost::split(args, suggestion, boost::is_any_of(" "));
+    args.insert(args.begin(), "foo");  // add model name
+
+    // convert to char** for parse_args
+    char const **argv_sug = new const char *[args.size()];
+    for (size_t i = 0; i < args.size(); i++) {
+      argv_sug[i] = args[i].c_str();
+    }
+
+    err_code = parser->parse_args(args.size(), argv_sug, writer, writer);
+    EXPECT_EQ(int(error_codes::OK), err_code);
+  }
+
   std::vector<argument *> valid_arguments;
   argument_parser *parser;
   int err_code;
@@ -64,4 +84,25 @@ TEST_F(CmdStanArgumentsArgumentParser, unrecognized_argument) {
 
   err_code = parser->parse_args(argc, argv, writer, writer);
   EXPECT_EQ(int(error_codes::USAGE), err_code);
+}
+
+TEST_F(CmdStanArgumentsArgumentParser, find_args) {
+  const char *argv[] = {"foo", "tol_grad=1e-20"};
+  int argc = 2;
+  std::stringstream err_stream;
+  stan::callbacks::stream_writer err_writer(err_stream);
+
+  err_code = parser->parse_args(argc, argv, writer, err_writer);
+  EXPECT_EQ(int(error_codes::USAGE), err_code);
+
+  std::string out;
+  std::getline(err_stream,
+               out);  // skip "tol_grad=1e-20 is either mistyped or misplaced."
+  std::getline(err_stream, out);  // skip "Perhaps you meant one of the following valid
+                         // configurations?"
+
+  std::getline(err_stream, out);  // first suggestion
+  check_suggestion(out);
+  std::getline(err_stream, out);  // second suggestion
+  check_suggestion(out);
 }

--- a/src/test/interface/arguments/argument_parser_test.cpp
+++ b/src/test/interface/arguments/argument_parser_test.cpp
@@ -98,8 +98,8 @@ TEST_F(CmdStanArgumentsArgumentParser, find_args) {
   std::string out;
   std::getline(err_stream,
                out);  // skip "tol_grad=1e-20 is either mistyped or misplaced."
-  std::getline(err_stream, out);  // skip "Perhaps you meant one of the following valid
-                         // configurations?"
+  std::getline(err_stream, out);  // skip "Perhaps you meant one of the
+                                  // following valid configurations?"
 
   std::getline(err_stream, out);  // first suggestion
   check_suggestion(out);

--- a/src/test/interface/arguments/argument_parser_test.cpp
+++ b/src/test/interface/arguments/argument_parser_test.cpp
@@ -38,13 +38,22 @@ class CmdStanArgumentsArgumentParser : public testing::Test {
     delete (parser);
   }
 
+  /**
+   * Given a sugestion from the parser, massage it into
+   * a form that looks like a command line input `argv`
+   * and then parse it and assert suggestion is accepted.
+   *
+   * Currently, this only replaces the `"<type>"` field
+   * which can occur in a suggestion with a value for
+   * double arguments, but it could be easily extended.
+   */
   void check_suggestion(std::string suggestion) {
     boost::trim(suggestion);
     boost::replace_first(suggestion, "<double>",
                          "1e-20");  // replace type with value
     std::vector<std::string> args;
     boost::split(args, suggestion, boost::is_any_of(" "));
-    args.insert(args.begin(), "foo");  // add model name
+    args.insert(args.begin(), "mymodel");  // add model name
 
     // convert to char** for parse_args
     char const **argv_sug = new const char *[args.size()];


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Closes #1118. Adds a test which checks that the suggestion given passes the argument parser.

#### Intended Effect:

"Perhaps you meant" suggestions work now.

#### How to Verify:

New output is:

```
$ ./bernoulli optimize tol_grad=1e-20
tol_grad=1e-20 is either mistyped or misplaced.
Perhaps you meant one of the following valid configurations?
  method=optimize algorithm=bfgs tol_grad=<double>
  method=optimize algorithm=lbfgs tol_grad=<double>
Failed to parse command arguments, cannot run model.
```

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
