### PR TITLE
Use unconstrain_array in CmdStan

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -188,6 +188,7 @@ pipeline {
                             aggregatingResults : false,
                             filters: [
                                 excludeFile('/lib/.*'),
+                                excludeFile('tbb/*')
                             ],
                             tools: [
                                 gcc4(id: "Windows_gcc4", name: "Windows interface tests@GCC4"),
@@ -226,6 +227,7 @@ pipeline {
                             aggregatingResults : false,
                             filters: [
                                 excludeFile('/lib/.*'),
+                                excludeFile('tbb/*')
                             ],
                             tools: [
                                 gcc4(id: "Linux_mpi_gcc4", name: "Linux interface tests with MPI@GCC4"),
@@ -256,6 +258,7 @@ pipeline {
                             aggregatingResults : false,
                             filters: [
                                 excludeFile('/lib/.*'),
+                                excludeFile('tbb/*')
                             ],
                             tools: [
                                 gcc4(id: "Mac_gcc4", name: "Mac interface tests@GCC4"),

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -388,7 +388,7 @@ int command(int argc, const char *argv[]) {
         params_r_ind = unconstrain_params_csv(model, fitted_params, col_offset,
                                               num_rows, num_cols);
       } else {
-        params_r_ind = get_cparams_r(cpars_file, model);
+        params_r_ind = {unconstrain_params_var_context(cpars_file, model)};
       }
     }
     try {

--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -41,7 +41,7 @@ inline constexpr auto get_arg_pointer(T &&x) {
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
-                                      Args &&...args) {
+                                      Args &&... args) {
   return get_arg_pointer(arg_list->arg(arg1), args...);
 }
 
@@ -57,7 +57,7 @@ inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg(List &&arg_list, const char *arg1,
-                              Args &&...args) {
+                              Args &&... args) {
   return internal::get_arg_pointer(arg_list.arg(arg1), args...);
 }
 
@@ -88,7 +88,7 @@ inline constexpr auto get_arg_val(Arg &&argument, const char *arg_name) {
  * @param args A parameter pack of names of arguments to index into
  */
 template <typename caster, typename List, typename... Args>
-inline constexpr auto get_arg_val(List &&arg_list, Args &&...args) {
+inline constexpr auto get_arg_val(List &&arg_list, Args &&... args) {
   auto *x = get_arg(arg_list, args...);
   if (x != nullptr) {
     return dynamic_cast<std::decay_t<caster> *>(x)->value();
@@ -534,7 +534,8 @@ Eigen::VectorXd get_laplace_mode(const std::string &fname,
   } else if (suffix(fname) == ".json") {
     std::vector<double> unc_params
         = unconstrain_params_var_context(fname, model);
-    theta_hat = Eigen::Map<Eigen::VectorXd>(unc_params.data(), unc_params.size());
+    theta_hat
+        = Eigen::Map<Eigen::VectorXd>(unc_params.data(), unc_params.size());
   } else {
     msg << "Mode file must be CSV or JSON, found " << fname << std::endl;
     throw std::invalid_argument(msg.str());

--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -41,7 +41,7 @@ inline constexpr auto get_arg_pointer(T &&x) {
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
-                                      Args &&... args) {
+                                      Args &&...args) {
   return get_arg_pointer(arg_list->arg(arg1), args...);
 }
 
@@ -57,7 +57,7 @@ inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg(List &&arg_list, const char *arg1,
-                              Args &&... args) {
+                              Args &&...args) {
   return internal::get_arg_pointer(arg_list.arg(arg1), args...);
 }
 
@@ -88,12 +88,12 @@ inline constexpr auto get_arg_val(Arg &&argument, const char *arg_name) {
  * @param args A parameter pack of names of arguments to index into
  */
 template <typename caster, typename List, typename... Args>
-inline constexpr auto get_arg_val(List &&arg_list, Args &&... args) {
+inline constexpr auto get_arg_val(List &&arg_list, Args &&...args) {
   auto *x = get_arg(arg_list, args...);
   if (x != nullptr) {
     return dynamic_cast<std::decay_t<caster> *>(x)->value();
   } else {
-    throw std::invalid_argument("encoutered nullptr");
+    throw std::invalid_argument("encountered nullptr");
   }
 }
 
@@ -360,7 +360,7 @@ void parse_stan_csv(const std::string &fname,
 
 /**
  * Apply model's "unconstrain_array" method to a vector of fitted parameters,
- * return correspondung unconstrained params.
+ * return corresponding unconstrained params.
  * Throws an exception if the unconstraining transform fails.
  *
  * @param model instantiated model
@@ -390,7 +390,7 @@ std::vector<double> unconstrain_params(const stan::model::model_base &model,
  * Given an instantiated model and parsed StanCSV output file,
  * apply model's "unconstrain_array" to the fitted parameters.
  * Returns a vector of vectors of parameters on the unconstrained scale.
- * Throws an exception if the unconstraining transform failes.
+ * Throws an exception if the unconstraining transform fails.
  *
  * @param model instantiated model
  * @param cparams vector of constrained param values
@@ -407,6 +407,36 @@ std::vector<std::vector<double>> unconstrain_params_csv(
     result.emplace_back(std::move(uparams));
   }
   return result;
+}
+
+/**
+ * Get constrained parameter values from JSON or Rdump file and
+ * return corresponding unconstrained params.
+ * Throws an exception if the unconstraining transform fails.
+ *
+ * @param fname name of file which exists and has read perms
+ * @param model Stan model
+ * @return vector of vectors of parameter estimates
+ */
+std::vector<double> unconstrain_params_var_context(
+    const std::string &fname, const stan::model::model_base &model) {
+  std::stringstream msg;
+  std::shared_ptr<stan::io::var_context> cpars_context = get_var_context(fname);
+  size_t num_upars = model.num_params_r();
+  std::vector<double> params(num_upars);
+  std::vector<int> dummy_params_i;
+  try {
+    model.transform_inits((*cpars_context), dummy_params_i, params, &msg);
+  } catch (const std::exception &e) {
+    std::stringstream msg2;
+    msg2 << e.what() << std::endl;
+    msg2 << "Bad or missing parameter values, cannot unconstrain.";
+    if (msg.str().length() > 0)
+      msg2 << "\n\t" << msg.str();
+    msg2 << std::endl;
+    throw std::invalid_argument(msg2.str());
+  }
+  return params;
 }
 
 /**
@@ -447,7 +477,7 @@ Eigen::VectorXd get_laplace_mode_csv(const std::string &fname,
     msg << "CSV file is not output from Stan optimization" << std::endl;
     throw std::invalid_argument(msg.str());
   }
-  // columns: algorithm outputs ending in "__", params, xparms, and gq vars
+  // columns: algorithm outputs ending in "__", params, txparms, and gq vars
   size_t col_offset = 0;
   for (auto name : names) {
     if (boost::algorithm::ends_with(name, "__")) {
@@ -489,42 +519,6 @@ Eigen::VectorXd get_laplace_mode_csv(const std::string &fname,
 }
 
 /**
- * Parse a JSON file of a set of parameter estimates on the
- * constrained scale and unconstrain them.
- * Helper function get_var_context throws exception if cannot
- * open or parse JSON file.
- *
- * @param fname name of file which exists and has read perms
- * @param model Stan model
- * @return Eigen vector of unconstrained parameter estimates
- */
-Eigen::VectorXd get_laplace_mode_json(const std::string &fname,
-                                      const stan::model::model_base &model) {
-  std::stringstream msg;
-  std::vector<std::string> param_names;
-  model.get_param_names(param_names);
-  std::vector<std::string> cparam_names;
-  model.constrained_param_names(cparam_names);
-  std::vector<double> cparams(cparam_names.size());
-
-  std::shared_ptr<stan::io::var_context> context = get_var_context(fname);
-  Eigen::Index offset = 0;
-  for (auto &&param_name : param_names) {
-    const auto param_vec = context->vals_r(param_name);
-    for (size_t i = 0; i < param_vec.size(); ++i) {
-      cparams[offset] = param_vec[i];
-      ++offset;
-    }
-  }
-  std::vector<double> uparams = unconstrain_params(model, cparams);
-  Eigen::VectorXd result(uparams.size());
-  for (size_t i = 0; i < uparams.size(); ++i) {
-    result(i) = uparams[i];
-  }
-  return result;
-}
-
-/**
  * Parse contents of file containing estimate of parameter modes.
  *
  * @param fname name of file which exists and has read perms
@@ -538,7 +532,9 @@ Eigen::VectorXd get_laplace_mode(const std::string &fname,
   if (suffix(fname) == ".csv") {
     theta_hat = get_laplace_mode_csv(fname, model);
   } else if (suffix(fname) == ".json") {
-    theta_hat = get_laplace_mode_json(fname, model);
+    std::vector<double> unc_params
+        = unconstrain_params_var_context(fname, model);
+    theta_hat = Eigen::Map<Eigen::VectorXd>(unc_params.data(), unc_params.size());
   } else {
     msg << "Mode file must be CSV or JSON, found " << fname << std::endl;
     throw std::invalid_argument(msg.str());
@@ -592,38 +588,6 @@ std::vector<std::vector<double>> get_uparams_r(
       params_r_ind[i][j] = *(u_params_r.data() + idx);
       ++idx;
     }
-  }
-  return params_r_ind;
-}
-
-/**
- * Get constrained parameter values from JSON or Rdump file and
- * return correspondung unconstrained params.
- * Throws an exception if the unconstraining transform fails.
- *
- * @param fname name of file which exists and has read perms
- * @param model Stan model
- * @return vector of vectors of parameter estimates
- */
-std::vector<std::vector<double>> get_cparams_r(
-    const std::string &fname, const stan::model::model_base &model) {
-  std::stringstream msg;
-  std::shared_ptr<stan::io::var_context> cpars_context = get_var_context(fname);
-  size_t num_upars = model.num_params_r();
-  std::vector<double> params(num_upars);
-  std::vector<std::vector<double>> params_r_ind = {params};
-  std::vector<int> dummy_params_i;
-  try {
-    model.transform_inits((*cpars_context), dummy_params_i, params_r_ind[0],
-                          &msg);
-  } catch (const std::exception &e) {
-    std::stringstream msg2;
-    msg2 << e.what() << std::endl;
-    msg2 << "Bad or missing parameter values, cannot unconstrain.";
-    if (msg.str().length() > 0)
-      msg2 << "\n\t" << msg.str();
-    msg2 << std::endl;
-    throw std::invalid_argument(msg2.str());
   }
   return params_r_ind;
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Follow on to stan-dev/stan#3179. This replaces the `array_var_context`/`transform_inits` combo with a call to `unconstrain_array`.

It also makes some related cleanups to existing calls of `transform_inits`, since now (as of https://github.com/stan-dev/stanc3/pull/1316), `transform_inits` now does validation on the var context it receives. 

I also fixed up a couple small typos and some other minor things in docstrings.

#### Intended Effect:

Clean up various ways of unconstraining parameters, with the express goal being to make tuples easier to handle by delegating more to the compiler.

#### How to Verify:

#### Side Effects:

None

#### Documentation:

Existing docstrings updated as apropriate

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
