### PR TITLE
[CI] Add new stage for updating downstream branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -310,6 +310,7 @@ pipeline {
                 //         docker {
                 //             image 'ellerbrock/alpine-bash-git'
                 //             label 'linux'
+                //             args '--entrypoint='
                 //         }
                 //     }
                 //     when {
@@ -351,7 +352,13 @@ pipeline {
                     // }
                     steps {
                         script {
-                            retry(3) { checkout scm }
+                            retry(3) { 
+                                checkout([
+                                    $class: 'GitSCM',
+                                    branches: [[name: '*/develop'], [name: '*/downstream_tests']],
+                                    userRemoteConfigs: scm.userRemoteConfigs
+                                ])
+                             }
                             withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
                                 usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
                                 sh """#!/bin/bash

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -305,38 +305,38 @@ pipeline {
         // }
         stage('Update downstream branches') {
             parallel {
-                stage('Update downstream_hotfix - master') {
-                    agent {
-                        docker {
-                            image 'alpine/git'
-                            label 'linux'
-                        }
-                    }
-                    when {
-                        beforeAgent true
-                        branch 'master'
-                    }
-                    steps {
-                        script {
-                            retry(3) { checkout scm }
-                            withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                                usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                                sh """#!/bin/bash
-                                    set -x
+                // stage('Update downstream_hotfix - master') {
+                //     agent {
+                //         docker {
+                //             image 'alpine/git'
+                //             label 'linux'
+                //         }
+                //     }
+                //     when {
+                //         beforeAgent true
+                //         branch 'master'
+                //     }
+                //     steps {
+                //         script {
+                //             retry(3) { checkout scm }
+                //             withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                //                 usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                //                 sh """#!/bin/bash
+                //                     set -x
 
-                                    git checkout downstream_hotfix
-                                    git reset --hard master
-                                    git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_hotfix
-                                """
-                            }
-                        }
-                    }
-                    post {
-                        always {
-                            deleteDir()
-                        }
-                    }
-                }
+                //                     git checkout downstream_hotfix
+                //                     git reset --hard master
+                //                     git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_hotfix
+                //                 """
+                //             }
+                //         }
+                //     }
+                //     post {
+                //         always {
+                //             deleteDir()
+                //         }
+                //     }
+                // }
                 stage('Update downstream_tests - develop') {
                     agent {
                         docker {
@@ -344,10 +344,10 @@ pipeline {
                             label 'linux'
                         }
                     }
-                    when {
-                        beforeAgent true
-                        branch 'develop'
-                    }
+                    // when {
+                    //     beforeAgent true
+                    //     branch 'develop'
+                    // }
                     steps {
                         script {
                             retry(3) { checkout scm }
@@ -358,7 +358,7 @@ pipeline {
 
                                     git checkout downstream_tests
                                     git reset --hard develop
-                                    git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_tests
+                                    # git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_tests
                                 """
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -342,6 +342,7 @@ pipeline {
                         docker {
                             image 'alpine/git'
                             label 'linux'
+                            args '--entrypoint='
                         }
                     }
                     // when {
@@ -358,6 +359,7 @@ pipeline {
 
                                     git checkout downstream_tests
                                     git reset --hard develop
+                                    git status
                                     # git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_tests
                                 """
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -303,6 +303,64 @@ pipeline {
 
             }
         }
+        stage('Update downstream branches') {
+            parallel {
+                stage('Update downstream_hotfix - master') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu'
+                            label 'linux'
+                        }
+                    }
+                    when {
+                        beforeAgent true
+                        branch 'master'
+                    }
+                    steps {
+                        script {
+                            retry(3) { checkout scm }
+                            sh """
+                                git checkout downstream_hotfix
+                                git reset --hard master
+                                git push origin downstream_hotfix
+                            """
+                        }
+                    }
+                    post {
+                        always {
+                            deleteDir()
+                        }
+                    }
+                }
+                stage('Update downstream_tests - develop') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu'
+                            label 'linux'
+                        }
+                    }
+                    when {
+                        beforeAgent true
+                        branch 'develop'
+                    }
+                    steps {
+                        script {
+                            retry(3) { checkout scm }
+                            sh """
+                                git checkout downstream_tests
+                                git reset --hard develop
+                                git push origin downstream_tests
+                            """
+                        }
+                    }
+                    post {
+                        always {
+                            deleteDir()
+                        }
+                    }
+                }
+            }
+        }
     }
     post {
         success {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -308,7 +308,7 @@ pipeline {
                 // stage('Update downstream_hotfix - master') {
                 //     agent {
                 //         docker {
-                //             image 'alpine/git'
+                //             image 'ellerbrock/alpine-bash-git'
                 //             label 'linux'
                 //         }
                 //     }
@@ -340,7 +340,7 @@ pipeline {
                 stage('Update downstream_tests - develop') {
                     agent {
                         docker {
-                            image 'alpine/git'
+                            image 'ellerbrock/alpine-bash-git'
                             label 'linux'
                             args '--entrypoint='
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -365,7 +365,7 @@ pipeline {
                                     set -x
 
                                     git checkout downstream_tests
-                                    git reset --hard develop
+                                    git reset --hard origin/develop
                                     git status
                                     # git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_tests
                                 """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -308,7 +308,7 @@ pipeline {
                 stage('Update downstream_hotfix - master') {
                     agent {
                         docker {
-                            image 'stanorg/ci:gpu'
+                            image 'alpine/git'
                             label 'linux'
                         }
                     }
@@ -319,11 +319,16 @@ pipeline {
                     steps {
                         script {
                             retry(3) { checkout scm }
-                            sh """
-                                git checkout downstream_hotfix
-                                git reset --hard master
-                                git push origin downstream_hotfix
-                            """
+                            withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                                usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                                sh """#!/bin/bash
+                                    set -x
+
+                                    git checkout downstream_hotfix
+                                    git reset --hard master
+                                    git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_hotfix
+                                """
+                            }
                         }
                     }
                     post {
@@ -335,7 +340,7 @@ pipeline {
                 stage('Update downstream_tests - develop') {
                     agent {
                         docker {
-                            image 'stanorg/ci:gpu'
+                            image 'alpine/git'
                             label 'linux'
                         }
                     }
@@ -346,11 +351,16 @@ pipeline {
                     steps {
                         script {
                             retry(3) { checkout scm }
-                            sh """
-                                git checkout downstream_tests
-                                git reset --hard develop
-                                git push origin downstream_tests
-                            """
+                            withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                                usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                                sh """#!/bin/bash
+                                    set -x
+
+                                    git checkout downstream_hotfix
+                                    git reset --hard master
+                                    git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_hotfix
+                                """
+                            }
                         }
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -367,7 +367,7 @@ pipeline {
                                     git checkout downstream_tests
                                     git reset --hard origin/develop
                                     git status
-                                    # git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_tests
+                                    git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_tests
                                 """
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -356,9 +356,9 @@ pipeline {
                                 sh """#!/bin/bash
                                     set -x
 
-                                    git checkout downstream_hotfix
-                                    git reset --hard master
-                                    git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_hotfix
+                                    git checkout downstream_tests
+                                    git reset --hard develop
+                                    git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_tests
                                 """
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,234 +75,234 @@ pipeline {
             }
             steps { script { utils.killOldBuilds() } }
         }
-        stage('Clean & Setup') {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                }
-            }
-            steps {
-                retry(3) { checkout scm }
-                sh 'git clean -xffd'
-                sh 'make stan-revert'
-                script {
-                    utils.checkout_pr("stan", "stan", params.stan_pr)
-                    utils.checkout_pr("math", "stan/lib/stan_math", params.math_pr)
-                }
+        // stage('Clean & Setup') {
+        //     agent {
+        //         docker {
+        //             image 'stanorg/ci:gpu'
+        //             label 'linux'
+        //         }
+        //     }
+        //     steps {
+        //         retry(3) { checkout scm }
+        //         sh 'git clean -xffd'
+        //         sh 'make stan-revert'
+        //         script {
+        //             utils.checkout_pr("stan", "stan", params.stan_pr)
+        //             utils.checkout_pr("math", "stan/lib/stan_math", params.math_pr)
+        //         }
 
-                stash 'CmdStanSetup'
-            }
-            post { always { deleteDir() }}
-        }
-        stage('Verify changes') {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                }
-            }
-            steps {
-                script {
-                    retry(3) { checkout scm }
-                    sh 'git clean -xffd'
+        //         stash 'CmdStanSetup'
+        //     }
+        //     post { always { deleteDir() }}
+        // }
+        // stage('Verify changes') {
+        //     agent {
+        //         docker {
+        //             image 'stanorg/ci:gpu'
+        //             label 'linux'
+        //         }
+        //     }
+        //     steps {
+        //         script {
+        //             retry(3) { checkout scm }
+        //             sh 'git clean -xffd'
 
-                    def paths = ['src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile'].join(" ")
-                    skipRemainingStages = utils.verifyChanges(paths)
-                }
-            }
-            post {
-                always {
-                    deleteDir()
-                }
-            }
-        }
-        stage("Clang-format") {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                }
-            }
-            steps {
-                retry(3) { checkout scm }
-                withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                    usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                    sh """#!/bin/bash
-                        set -x
-                        git checkout -b ${branchName()}
-                        clang-format --version
-                        find src -name '*.hpp' -o -name '*.cpp' | xargs -n20 -P${env.PARALLEL} clang-format -i
-                        if [[ `git diff` != "" ]]; then
-                            git add src
-                            git commit -m "[Jenkins] auto-formatting by `clang-format --version`"
-                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/cmdstan.git ${branchName()}
-                            echo "Exiting build because clang-format found changes."
-                            echo "Those changes are now found on stan-dev/cmdstan under branch ${branchName()}"
-                            echo "Please 'git pull' before continuing to develop."
-                            exit 1
-                        fi
-                    """
-                }
-            }
-            post {
-                always { deleteDir() }
-                failure {
-                    script {
-                        emailext (
-                            subject: "[StanJenkins] Autoformattted: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
-                            body: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' " +
-                                "has been autoformatted and the changes committed " +
-                                "to your branch, if permissions allowed." +
-                                "Please pull these changes before continuing." +
-                                "\n\n" +
-                                "See https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms" +
-                                " for setting up the autoformatter locally.\n"+
-                            "(Check console output at ${env.BUILD_URL})",
-                            recipientProviders: [[$class: 'RequesterRecipientProvider']],
-                            to: "${env.CHANGE_AUTHOR_EMAIL}"
-                        )
-                    }
-                }
-            }
-        }
-        stage('Parallel tests') {
-            when {
-                expression {
-                    !skipRemainingStages
-                }
-            }
-            parallel {
-                stage('Windows interface tests') {
-                    agent { label 'windows' }
-                    steps {
-                        setupCXX(WIN_CXX)
-                        runWinTests()
-                    }
-                    post {
-                        always {
+        //             def paths = ['src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile'].join(" ")
+        //             skipRemainingStages = utils.verifyChanges(paths)
+        //         }
+        //     }
+        //     post {
+        //         always {
+        //             deleteDir()
+        //         }
+        //     }
+        // }
+        // stage("Clang-format") {
+        //     agent {
+        //         docker {
+        //             image 'stanorg/ci:gpu'
+        //             label 'linux'
+        //         }
+        //     }
+        //     steps {
+        //         retry(3) { checkout scm }
+        //         withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+        //             usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+        //             sh """#!/bin/bash
+        //                 set -x
+        //                 git checkout -b ${branchName()}
+        //                 clang-format --version
+        //                 find src -name '*.hpp' -o -name '*.cpp' | xargs -n20 -P${env.PARALLEL} clang-format -i
+        //                 if [[ `git diff` != "" ]]; then
+        //                     git add src
+        //                     git commit -m "[Jenkins] auto-formatting by `clang-format --version`"
+        //                     git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/cmdstan.git ${branchName()}
+        //                     echo "Exiting build because clang-format found changes."
+        //                     echo "Those changes are now found on stan-dev/cmdstan under branch ${branchName()}"
+        //                     echo "Please 'git pull' before continuing to develop."
+        //                     exit 1
+        //                 fi
+        //             """
+        //         }
+        //     }
+        //     post {
+        //         always { deleteDir() }
+        //         failure {
+        //             script {
+        //                 emailext (
+        //                     subject: "[StanJenkins] Autoformattted: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
+        //                     body: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' " +
+        //                         "has been autoformatted and the changes committed " +
+        //                         "to your branch, if permissions allowed." +
+        //                         "Please pull these changes before continuing." +
+        //                         "\n\n" +
+        //                         "See https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms" +
+        //                         " for setting up the autoformatter locally.\n"+
+        //                     "(Check console output at ${env.BUILD_URL})",
+        //                     recipientProviders: [[$class: 'RequesterRecipientProvider']],
+        //                     to: "${env.CHANGE_AUTHOR_EMAIL}"
+        //                 )
+        //             }
+        //         }
+        //     }
+        // }
+        // stage('Parallel tests') {
+        //     when {
+        //         expression {
+        //             !skipRemainingStages
+        //         }
+        //     }
+        //     parallel {
+        //         stage('Windows interface tests') {
+        //             agent { label 'windows' }
+        //             steps {
+        //                 setupCXX(WIN_CXX)
+        //                 runWinTests()
+        //             }
+        //             post {
+        //                 always {
 
-                            recordIssues id: "Windows",
-                            name: "Windows interface tests",
-                            enabledForFailure: true,
-                            aggregatingResults : false,
-                            filters: [
-                                excludeFile('/lib/.*'),
-                                excludeFile('tbb/*'),
-                                excludeFile('stan/lib/stan_math/lib/*')
-                            ],
-                            tools: [
-                                gcc4(id: "Windows_gcc4", name: "Windows interface tests@GCC4"),
-                                clang(id: "Windows_clang", name: "Windows interface tests@CLANG")
-                            ],
-                            blameDisabled: false,
-                            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-                            healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
-                            referenceJobName: env.BRANCH_NAME
+        //                     recordIssues id: "Windows",
+        //                     name: "Windows interface tests",
+        //                     enabledForFailure: true,
+        //                     aggregatingResults : false,
+        //                     filters: [
+        //                         excludeFile('/lib/.*'),
+        //                         excludeFile('tbb/*'),
+        //                         excludeFile('stan/lib/stan_math/lib/*')
+        //                     ],
+        //                     tools: [
+        //                         gcc4(id: "Windows_gcc4", name: "Windows interface tests@GCC4"),
+        //                         clang(id: "Windows_clang", name: "Windows interface tests@CLANG")
+        //                     ],
+        //                     blameDisabled: false,
+        //                     qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+        //                     healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+        //                     referenceJobName: env.BRANCH_NAME
 
-                            deleteDirWin()
-                        }
-                    }
-                }
+        //                     deleteDirWin()
+        //                 }
+        //             }
+        //         }
 
-                stage('Linux interface tests with MPI') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:gpu'
-                            label 'linux'
-                        }
-                    }
-                    steps {
-                        setupCXX(MPICXX)
-                        sh "echo STAN_MPI=true >> make/local"
-                        sh "echo CXX_TYPE=gcc >> make/local"
-                        sh "make build-mpi > build-mpi.log 2>&1"
-                        sh runTests("./")
-                    }
-                    post {
-                        always {
+        //         stage('Linux interface tests with MPI') {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:gpu'
+        //                     label 'linux'
+        //                 }
+        //             }
+        //             steps {
+        //                 setupCXX(MPICXX)
+        //                 sh "echo STAN_MPI=true >> make/local"
+        //                 sh "echo CXX_TYPE=gcc >> make/local"
+        //                 sh "make build-mpi > build-mpi.log 2>&1"
+        //                 sh runTests("./")
+        //             }
+        //             post {
+        //                 always {
 
-                            recordIssues id: "Linux_mpi",
-                            name: "Linux interface tests with MPI",
-                            enabledForFailure: true,
-                            aggregatingResults : false,
-                            filters: [
-                                excludeFile('/lib/.*'),
-                                excludeFile('tbb/*'),
-                                excludeFile('stan/lib/stan_math/lib/*')
-                            ],
-                            tools: [
-                                gcc4(id: "Linux_mpi_gcc4", name: "Linux interface tests with MPI@GCC4"),
-                                clang(id: "Linux_mpi_clang", name: "Linux interface tests with MPI@CLANG")
-                            ],
-                            blameDisabled: false,
-                            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-                            healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
-                            referenceJobName: env.BRANCH_NAME
+        //                     recordIssues id: "Linux_mpi",
+        //                     name: "Linux interface tests with MPI",
+        //                     enabledForFailure: true,
+        //                     aggregatingResults : false,
+        //                     filters: [
+        //                         excludeFile('/lib/.*'),
+        //                         excludeFile('tbb/*'),
+        //                         excludeFile('stan/lib/stan_math/lib/*')
+        //                     ],
+        //                     tools: [
+        //                         gcc4(id: "Linux_mpi_gcc4", name: "Linux interface tests with MPI@GCC4"),
+        //                         clang(id: "Linux_mpi_clang", name: "Linux interface tests with MPI@CLANG")
+        //                     ],
+        //                     blameDisabled: false,
+        //                     qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+        //                     healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+        //                     referenceJobName: env.BRANCH_NAME
 
-                            deleteDir()
-                        }
-                    }
-                }
+        //                     deleteDir()
+        //                 }
+        //             }
+        //         }
 
-                stage('Mac interface tests') {
-                    agent { label 'osx' }
-                    steps {
-                        setupCXX(MAC_CXX)
-                        sh runTests("python3 ./")
-                    }
-                    post {
-                        always {
+        //         stage('Mac interface tests') {
+        //             agent { label 'osx' }
+        //             steps {
+        //                 setupCXX(MAC_CXX)
+        //                 sh runTests("python3 ./")
+        //             }
+        //             post {
+        //                 always {
 
-                            recordIssues id: "Mac",
-                            name: "Mac interface tests",
-                            enabledForFailure: true,
-                            aggregatingResults : false,
-                            filters: [
-                                excludeFile('/lib/.*'),
-                                excludeFile('tbb/*'),
-                                excludeFile('stan/lib/stan_math/lib/*')
-                            ],
-                            tools: [
-                                gcc4(id: "Mac_gcc4", name: "Mac interface tests@GCC4"),
-                                clang(id: "Mac_clang", name: "Mac interface tests@CLANG")
-                            ],
-                            blameDisabled: false,
-                            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-                            healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
-                            referenceJobName: env.BRANCH_NAME
+        //                     recordIssues id: "Mac",
+        //                     name: "Mac interface tests",
+        //                     enabledForFailure: true,
+        //                     aggregatingResults : false,
+        //                     filters: [
+        //                         excludeFile('/lib/.*'),
+        //                         excludeFile('tbb/*'),
+        //                         excludeFile('stan/lib/stan_math/lib/*')
+        //                     ],
+        //                     tools: [
+        //                         gcc4(id: "Mac_gcc4", name: "Mac interface tests@GCC4"),
+        //                         clang(id: "Mac_clang", name: "Mac interface tests@CLANG")
+        //                     ],
+        //                     blameDisabled: false,
+        //                     qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+        //                     healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+        //                     referenceJobName: env.BRANCH_NAME
 
-                            deleteDir()
-                        }
-                    }
-                }
+        //                     deleteDir()
+        //                 }
+        //             }
+        //         }
 
-                stage('Upstream CmdStan Performance tests') {
-                    when {
-                            expression {
-                                env.BRANCH_NAME ==~ /PR-\d+/ ||
-                                env.BRANCH_NAME == "downstream_tests" ||
-                                env.BRANCH_NAME == "downstream_hotfix"
-                            }
-                        }
-                    steps {
-                        script{
-                            build(
-                                job: "Stan/CmdStan Performance Tests/downstream_tests",
-                                parameters: [
-                                    string(name: 'cmdstan_pr', value: env.BRANCH_NAME),
-                                    string(name: 'stan_pr', value: params.stan_pr),
-                                    string(name: 'math_pr', value: params.math_pr),
-                                    string(name: 'stanc3_bin_url', value: params.stanc3_bin_url)
-                                ],
-                                wait:true
-                            )
-                        }
-                    }
-                }
+        //         stage('Upstream CmdStan Performance tests') {
+        //             when {
+        //                     expression {
+        //                         env.BRANCH_NAME ==~ /PR-\d+/ ||
+        //                         env.BRANCH_NAME == "downstream_tests" ||
+        //                         env.BRANCH_NAME == "downstream_hotfix"
+        //                     }
+        //                 }
+        //             steps {
+        //                 script{
+        //                     build(
+        //                         job: "Stan/CmdStan Performance Tests/downstream_tests",
+        //                         parameters: [
+        //                             string(name: 'cmdstan_pr', value: env.BRANCH_NAME),
+        //                             string(name: 'stan_pr', value: params.stan_pr),
+        //                             string(name: 'math_pr', value: params.math_pr),
+        //                             string(name: 'stanc3_bin_url', value: params.stanc3_bin_url)
+        //                         ],
+        //                         wait:true
+        //                     )
+        //                 }
+        //             }
+        //         }
 
-            }
-        }
+        //     }
+        // }
         stage('Update downstream branches') {
             parallel {
                 stage('Update downstream_hotfix - master') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,269 +75,276 @@ pipeline {
             }
             steps { script { utils.killOldBuilds() } }
         }
-        // stage('Clean & Setup') {
-        //     agent {
-        //         docker {
-        //             image 'stanorg/ci:gpu'
-        //             label 'linux'
-        //         }
-        //     }
-        //     steps {
-        //         retry(3) { checkout scm }
-        //         sh 'git clean -xffd'
-        //         sh 'make stan-revert'
-        //         script {
-        //             utils.checkout_pr("stan", "stan", params.stan_pr)
-        //             utils.checkout_pr("math", "stan/lib/stan_math", params.math_pr)
-        //         }
+        stage('Clean & Setup') {
+            agent {
+                docker {
+                    image 'stanorg/ci:gpu'
+                    label 'linux'
+                }
+            }
+            steps {
+                retry(3) { checkout scm }
+                sh 'git clean -xffd'
+                sh 'make stan-revert'
+                script {
+                    utils.checkout_pr("stan", "stan", params.stan_pr)
+                    utils.checkout_pr("math", "stan/lib/stan_math", params.math_pr)
+                }
 
-        //         stash 'CmdStanSetup'
-        //     }
-        //     post { always { deleteDir() }}
-        // }
-        // stage('Verify changes') {
-        //     agent {
-        //         docker {
-        //             image 'stanorg/ci:gpu'
-        //             label 'linux'
-        //         }
-        //     }
-        //     steps {
-        //         script {
-        //             retry(3) { checkout scm }
-        //             sh 'git clean -xffd'
+                stash 'CmdStanSetup'
+            }
+            post { always { deleteDir() }}
+        }
+        stage('Verify changes') {
+            agent {
+                docker {
+                    image 'stanorg/ci:gpu'
+                    label 'linux'
+                }
+            }
+            steps {
+                script {
+                    retry(3) { checkout scm }
+                    sh 'git clean -xffd'
 
-        //             def paths = ['src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile'].join(" ")
-        //             skipRemainingStages = utils.verifyChanges(paths)
-        //         }
-        //     }
-        //     post {
-        //         always {
-        //             deleteDir()
-        //         }
-        //     }
-        // }
-        // stage("Clang-format") {
-        //     agent {
-        //         docker {
-        //             image 'stanorg/ci:gpu'
-        //             label 'linux'
-        //         }
-        //     }
-        //     steps {
-        //         retry(3) { checkout scm }
-        //         withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-        //             usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-        //             sh """#!/bin/bash
-        //                 set -x
-        //                 git checkout -b ${branchName()}
-        //                 clang-format --version
-        //                 find src -name '*.hpp' -o -name '*.cpp' | xargs -n20 -P${env.PARALLEL} clang-format -i
-        //                 if [[ `git diff` != "" ]]; then
-        //                     git add src
-        //                     git commit -m "[Jenkins] auto-formatting by `clang-format --version`"
-        //                     git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/cmdstan.git ${branchName()}
-        //                     echo "Exiting build because clang-format found changes."
-        //                     echo "Those changes are now found on stan-dev/cmdstan under branch ${branchName()}"
-        //                     echo "Please 'git pull' before continuing to develop."
-        //                     exit 1
-        //                 fi
-        //             """
-        //         }
-        //     }
-        //     post {
-        //         always { deleteDir() }
-        //         failure {
-        //             script {
-        //                 emailext (
-        //                     subject: "[StanJenkins] Autoformattted: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
-        //                     body: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' " +
-        //                         "has been autoformatted and the changes committed " +
-        //                         "to your branch, if permissions allowed." +
-        //                         "Please pull these changes before continuing." +
-        //                         "\n\n" +
-        //                         "See https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms" +
-        //                         " for setting up the autoformatter locally.\n"+
-        //                     "(Check console output at ${env.BUILD_URL})",
-        //                     recipientProviders: [[$class: 'RequesterRecipientProvider']],
-        //                     to: "${env.CHANGE_AUTHOR_EMAIL}"
-        //                 )
-        //             }
-        //         }
-        //     }
-        // }
-        // stage('Parallel tests') {
-        //     when {
-        //         expression {
-        //             !skipRemainingStages
-        //         }
-        //     }
-        //     parallel {
-        //         stage('Windows interface tests') {
-        //             agent { label 'windows' }
-        //             steps {
-        //                 setupCXX(WIN_CXX)
-        //                 runWinTests()
-        //             }
-        //             post {
-        //                 always {
+                    def paths = ['src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile'].join(" ")
+                    skipRemainingStages = utils.verifyChanges(paths)
+                }
+            }
+            post {
+                always {
+                    deleteDir()
+                }
+            }
+        }
+        stage("Clang-format") {
+            agent {
+                docker {
+                    image 'stanorg/ci:gpu'
+                    label 'linux'
+                }
+            }
+            steps {
+                retry(3) { checkout scm }
+                withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                    usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                    sh """#!/bin/bash
+                        set -x
+                        git checkout -b ${branchName()}
+                        clang-format --version
+                        find src -name '*.hpp' -o -name '*.cpp' | xargs -n20 -P${env.PARALLEL} clang-format -i
+                        if [[ `git diff` != "" ]]; then
+                            git add src
+                            git commit -m "[Jenkins] auto-formatting by `clang-format --version`"
+                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/cmdstan.git ${branchName()}
+                            echo "Exiting build because clang-format found changes."
+                            echo "Those changes are now found on stan-dev/cmdstan under branch ${branchName()}"
+                            echo "Please 'git pull' before continuing to develop."
+                            exit 1
+                        fi
+                    """
+                }
+            }
+            post {
+                always { deleteDir() }
+                failure {
+                    script {
+                        emailext (
+                            subject: "[StanJenkins] Autoformattted: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
+                            body: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' " +
+                                "has been autoformatted and the changes committed " +
+                                "to your branch, if permissions allowed." +
+                                "Please pull these changes before continuing." +
+                                "\n\n" +
+                                "See https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms" +
+                                " for setting up the autoformatter locally.\n"+
+                            "(Check console output at ${env.BUILD_URL})",
+                            recipientProviders: [[$class: 'RequesterRecipientProvider']],
+                            to: "${env.CHANGE_AUTHOR_EMAIL}"
+                        )
+                    }
+                }
+            }
+        }
+        stage('Parallel tests') {
+            when {
+                expression {
+                    !skipRemainingStages
+                }
+            }
+            parallel {
+                stage('Windows interface tests') {
+                    agent { label 'windows' }
+                    steps {
+                        setupCXX(WIN_CXX)
+                        runWinTests()
+                    }
+                    post {
+                        always {
 
-        //                     recordIssues id: "Windows",
-        //                     name: "Windows interface tests",
-        //                     enabledForFailure: true,
-        //                     aggregatingResults : false,
-        //                     filters: [
-        //                         excludeFile('/lib/.*'),
-        //                         excludeFile('tbb/*'),
-        //                         excludeFile('stan/lib/stan_math/lib/*')
-        //                     ],
-        //                     tools: [
-        //                         gcc4(id: "Windows_gcc4", name: "Windows interface tests@GCC4"),
-        //                         clang(id: "Windows_clang", name: "Windows interface tests@CLANG")
-        //                     ],
-        //                     blameDisabled: false,
-        //                     qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-        //                     healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
-        //                     referenceJobName: env.BRANCH_NAME
+                            recordIssues id: "Windows",
+                            name: "Windows interface tests",
+                            enabledForFailure: true,
+                            aggregatingResults : false,
+                            filters: [
+                                excludeFile('/lib/.*'),
+                                excludeFile('tbb/*'),
+                                excludeFile('stan/lib/stan_math/lib/*')
+                            ],
+                            tools: [
+                                gcc4(id: "Windows_gcc4", name: "Windows interface tests@GCC4"),
+                                clang(id: "Windows_clang", name: "Windows interface tests@CLANG")
+                            ],
+                            blameDisabled: false,
+                            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                            healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+                            referenceJobName: env.BRANCH_NAME
 
-        //                     deleteDirWin()
-        //                 }
-        //             }
-        //         }
+                            deleteDirWin()
+                        }
+                    }
+                }
 
-        //         stage('Linux interface tests with MPI') {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:gpu'
-        //                     label 'linux'
-        //                 }
-        //             }
-        //             steps {
-        //                 setupCXX(MPICXX)
-        //                 sh "echo STAN_MPI=true >> make/local"
-        //                 sh "echo CXX_TYPE=gcc >> make/local"
-        //                 sh "make build-mpi > build-mpi.log 2>&1"
-        //                 sh runTests("./")
-        //             }
-        //             post {
-        //                 always {
+                stage('Linux interface tests with MPI') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu'
+                            label 'linux'
+                        }
+                    }
+                    steps {
+                        setupCXX(MPICXX)
+                        sh "echo STAN_MPI=true >> make/local"
+                        sh "echo CXX_TYPE=gcc >> make/local"
+                        sh "make build-mpi > build-mpi.log 2>&1"
+                        sh runTests("./")
+                    }
+                    post {
+                        always {
 
-        //                     recordIssues id: "Linux_mpi",
-        //                     name: "Linux interface tests with MPI",
-        //                     enabledForFailure: true,
-        //                     aggregatingResults : false,
-        //                     filters: [
-        //                         excludeFile('/lib/.*'),
-        //                         excludeFile('tbb/*'),
-        //                         excludeFile('stan/lib/stan_math/lib/*')
-        //                     ],
-        //                     tools: [
-        //                         gcc4(id: "Linux_mpi_gcc4", name: "Linux interface tests with MPI@GCC4"),
-        //                         clang(id: "Linux_mpi_clang", name: "Linux interface tests with MPI@CLANG")
-        //                     ],
-        //                     blameDisabled: false,
-        //                     qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-        //                     healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
-        //                     referenceJobName: env.BRANCH_NAME
+                            recordIssues id: "Linux_mpi",
+                            name: "Linux interface tests with MPI",
+                            enabledForFailure: true,
+                            aggregatingResults : false,
+                            filters: [
+                                excludeFile('/lib/.*'),
+                                excludeFile('tbb/*'),
+                                excludeFile('stan/lib/stan_math/lib/*')
+                            ],
+                            tools: [
+                                gcc4(id: "Linux_mpi_gcc4", name: "Linux interface tests with MPI@GCC4"),
+                                clang(id: "Linux_mpi_clang", name: "Linux interface tests with MPI@CLANG")
+                            ],
+                            blameDisabled: false,
+                            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                            healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+                            referenceJobName: env.BRANCH_NAME
 
-        //                     deleteDir()
-        //                 }
-        //             }
-        //         }
+                            deleteDir()
+                        }
+                    }
+                }
 
-        //         stage('Mac interface tests') {
-        //             agent { label 'osx' }
-        //             steps {
-        //                 setupCXX(MAC_CXX)
-        //                 sh runTests("python3 ./")
-        //             }
-        //             post {
-        //                 always {
+                stage('Mac interface tests') {
+                    agent { label 'osx' }
+                    steps {
+                        setupCXX(MAC_CXX)
+                        sh runTests("python3 ./")
+                    }
+                    post {
+                        always {
 
-        //                     recordIssues id: "Mac",
-        //                     name: "Mac interface tests",
-        //                     enabledForFailure: true,
-        //                     aggregatingResults : false,
-        //                     filters: [
-        //                         excludeFile('/lib/.*'),
-        //                         excludeFile('tbb/*'),
-        //                         excludeFile('stan/lib/stan_math/lib/*')
-        //                     ],
-        //                     tools: [
-        //                         gcc4(id: "Mac_gcc4", name: "Mac interface tests@GCC4"),
-        //                         clang(id: "Mac_clang", name: "Mac interface tests@CLANG")
-        //                     ],
-        //                     blameDisabled: false,
-        //                     qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-        //                     healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
-        //                     referenceJobName: env.BRANCH_NAME
+                            recordIssues id: "Mac",
+                            name: "Mac interface tests",
+                            enabledForFailure: true,
+                            aggregatingResults : false,
+                            filters: [
+                                excludeFile('/lib/.*'),
+                                excludeFile('tbb/*'),
+                                excludeFile('stan/lib/stan_math/lib/*')
+                            ],
+                            tools: [
+                                gcc4(id: "Mac_gcc4", name: "Mac interface tests@GCC4"),
+                                clang(id: "Mac_clang", name: "Mac interface tests@CLANG")
+                            ],
+                            blameDisabled: false,
+                            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                            healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+                            referenceJobName: env.BRANCH_NAME
 
-        //                     deleteDir()
-        //                 }
-        //             }
-        //         }
+                            deleteDir()
+                        }
+                    }
+                }
 
-        //         stage('Upstream CmdStan Performance tests') {
-        //             when {
-        //                     expression {
-        //                         env.BRANCH_NAME ==~ /PR-\d+/ ||
-        //                         env.BRANCH_NAME == "downstream_tests" ||
-        //                         env.BRANCH_NAME == "downstream_hotfix"
-        //                     }
-        //                 }
-        //             steps {
-        //                 script{
-        //                     build(
-        //                         job: "Stan/CmdStan Performance Tests/downstream_tests",
-        //                         parameters: [
-        //                             string(name: 'cmdstan_pr', value: env.BRANCH_NAME),
-        //                             string(name: 'stan_pr', value: params.stan_pr),
-        //                             string(name: 'math_pr', value: params.math_pr),
-        //                             string(name: 'stanc3_bin_url', value: params.stanc3_bin_url)
-        //                         ],
-        //                         wait:true
-        //                     )
-        //                 }
-        //             }
-        //         }
+                stage('Upstream CmdStan Performance tests') {
+                    when {
+                            expression {
+                                env.BRANCH_NAME ==~ /PR-\d+/ ||
+                                env.BRANCH_NAME == "downstream_tests" ||
+                                env.BRANCH_NAME == "downstream_hotfix"
+                            }
+                        }
+                    steps {
+                        script{
+                            build(
+                                job: "Stan/CmdStan Performance Tests/downstream_tests",
+                                parameters: [
+                                    string(name: 'cmdstan_pr', value: env.BRANCH_NAME),
+                                    string(name: 'stan_pr', value: params.stan_pr),
+                                    string(name: 'math_pr', value: params.math_pr),
+                                    string(name: 'stanc3_bin_url', value: params.stanc3_bin_url)
+                                ],
+                                wait:true
+                            )
+                        }
+                    }
+                }
 
-        //     }
-        // }
+            }
+        }
         stage('Update downstream branches') {
             parallel {
-                // stage('Update downstream_hotfix - master') {
-                //     agent {
-                //         docker {
-                //             image 'ellerbrock/alpine-bash-git'
-                //             label 'linux'
-                //             args '--entrypoint='
-                //         }
-                //     }
-                //     when {
-                //         beforeAgent true
-                //         branch 'master'
-                //     }
-                //     steps {
-                //         script {
-                //             retry(3) { checkout scm }
-                //             withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                //                 usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                //                 sh """#!/bin/bash
-                //                     set -x
+                stage('Update downstream_hotfix - master') {
+                    agent {
+                        docker {
+                            image 'ellerbrock/alpine-bash-git'
+                            label 'linux'
+                            args '--entrypoint='
+                        }
+                    }
+                    when {
+                        beforeAgent true
+                        branch 'master'
+                    }
+                    steps {
+                        script {
+                            retry(3) { 
+                                checkout([
+                                    $class: 'GitSCM',
+                                    branches: [[name: '*/master'], [name: '*/downstream_hotfix']],
+                                    userRemoteConfigs: scm.userRemoteConfigs
+                                ])
+                             }
+                            withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                                usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                                sh """#!/bin/bash
+                                    set -x
 
-                //                     git checkout downstream_hotfix
-                //                     git reset --hard master
-                //                     git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_hotfix
-                //                 """
-                //             }
-                //         }
-                //     }
-                //     post {
-                //         always {
-                //             deleteDir()
-                //         }
-                //     }
-                // }
+                                    git checkout downstream_hotfix
+                                    git reset --hard origin/master
+                                    git status
+                                    git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_hotfix
+                                """
+                            }
+                        }
+                    }
+                    post {
+                        always {
+                            deleteDir()
+                        }
+                    }
+                }
                 stage('Update downstream_tests - develop') {
                     agent {
                         docker {
@@ -346,10 +353,10 @@ pipeline {
                             args '--entrypoint='
                         }
                     }
-                    // when {
-                    //     beforeAgent true
-                    //     branch 'develop'
-                    // }
+                    when {
+                        beforeAgent true
+                        branch 'develop'
+                    }
                     steps {
                         script {
                             retry(3) { 


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:

We have two branches `downstream_hotfix` ( mirroring master ) and `downstream_tests` ( mirroring develop ) that are used in CI and are not synced anymore. Might be since we migrated to Flatiron.
This PR introduces a new stage that will update the downstream branches.

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
