### PR TITLE
Add CXX version to precompiled header name

### DIFF
--- a/make/program
+++ b/make/program
@@ -16,19 +16,19 @@ $(CMDSTAN_MAIN_O) : $(CMDSTAN_MAIN)
 ##
 # Precompiled model header
 ##
-$(STAN)src/stan/model/model_header$(STAN_FLAGS).d : $(STAN)src/stan/model/model_header.hpp
+$(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).d : $(STAN)src/stan/model/model_header.hpp
 	$(COMPILE.cpp) $(DEPFLAGS) $<
 
 ifneq ($(PRECOMPILED_MODEL_HEADER),)
-$(STAN)src/stan/model/model_header$(STAN_FLAGS).d : DEPTARGETS = -MT $(patsubst %.d,%.hpp.gch,$@) -MT $@
-$(STAN)src/stan/model/model_header$(STAN_FLAGS).hpp.gch : $(STAN)src/stan/model/model_header.hpp
+$(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).d : DEPTARGETS = -MT $(patsubst %.d,%.hpp.gch,$@) -MT $@
+$(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).hpp.gch : $(STAN)src/stan/model/model_header.hpp
 	@echo ''
 	@echo '--- Compiling pre-compiled header. This might take a few seconds. ---'
 	$(COMPILE.cpp) $< $(OUTPUT_OPTION)
 
 ifeq ($(CXX_TYPE),clang)
-CXXFLAGS_PROGRAM += -include-pch $(STAN)src/stan/model/model_header$(STAN_FLAGS).hpp.gch
-$(STAN_TARGETS) : %$(EXE) : $(STAN)src/stan/model/model_header$(STAN_FLAGS).hpp.gch
+CXXFLAGS_PROGRAM += -include-pch $(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).hpp.gch
+$(STAN_TARGETS) : %$(EXE) : $(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).hpp.gch
 endif
 endif
 
@@ -80,6 +80,6 @@ $(patsubst %$(EXE),%.d,$(STAN_TARGETS)) : DEPTARGETS += -MT $(patsubst %.d,%$(EX
 -include $(patsubst %$(EXE),%.d,$(STAN_TARGETS))
 -include $(patsubst %.cpp,%$(STAN_FLAGS).d,$(CMDSTAN_MAIN))
 ifeq ($(PRECOMPILED_HEADERS),true)
--include $(STAN)src/stan/model/model_header$(STAN_FLAGS).d
+-include $(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).d
 endif
 endif

--- a/makefile
+++ b/makefile
@@ -133,7 +133,7 @@ PRECOMPILED_HEADERS ?= true
 endif
 
 ifeq ($(PRECOMPILED_HEADERS),true)
-PRECOMPILED_MODEL_HEADER=$(STAN)src/stan/model/model_header$(STAN_FLAGS).hpp.gch
+PRECOMPILED_MODEL_HEADER=$(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).hpp.gch
 ifeq ($(CXX_TYPE),gcc)
 CXXFLAGS_PROGRAM+= -Wno-ignored-attributes $(CXXFLAGS_OPTIM) $(CXXFLAGS_FLTO)
 endif


### PR DESCRIPTION
This idea was discussed with @rok-cesnovar here: https://github.com/roualdes/bridgestan/issues/151#issuecomment-1624241349

#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This adds `CXX_MAJOR` and `CXX_MINOR` to the name of the precompiled header file when it is enabled. The goal is to prevent the annoying errors from clang updates etc.

#### Intended Effect:

Prevent clang updates from breaking PCH builds, see [cmdstanpy issues](https://github.com/stan-dev/cmdstanpy/issues?q=is%3Aissue+pch)

#### How to Verify:

#### Side Effects:

This could lead to several PCHs being made over time if the user doesn't run a `make clean-all` every now and then. This could cause the directory size to increase over time for an installation.

#### Documentation:

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
