### PR TITLE
Fix/1170 boost lexical cast

### DIFF
--- a/src/cmdstan/arguments/arg_seed.hpp
+++ b/src/cmdstan/arguments/arg_seed.hpp
@@ -3,6 +3,7 @@
 
 #include <cmdstan/arguments/singleton_argument.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <string>
 
 namespace cmdstan {
 
@@ -41,9 +42,9 @@ class arg_seed : public long_long_int_argument {
 
   std::string print_value() {
     if (_value == _default_value) {
-      return boost::lexical_cast<std::string>(_random_value);
+      return std::to_string(_random_value);
     } else {
-      return boost::lexical_cast<std::string>(_value);
+      return std::to_string(_value);
     }
   }
 };

--- a/src/cmdstan/arguments/arg_tolerance.hpp
+++ b/src/cmdstan/arguments/arg_tolerance.hpp
@@ -2,7 +2,6 @@
 #define CMDSTAN_ARGUMENTS_ARG_TOLERANCE_HPP
 
 #include <cmdstan/arguments/singleton_argument.hpp>
-#include <boost/lexical_cast.hpp>
 #include <string>
 
 namespace cmdstan {
@@ -14,7 +13,7 @@ class arg_tolerance : public real_argument {
     _name = name;
     _description = desc;
     _validity = "0 <= tol";
-    _default = boost::lexical_cast<std::string>(def);
+    _default = std::to_string(def);
     _default_value = def;
     _constrained = true;
     _good_value = 1.0;

--- a/src/cmdstan/arguments/arg_variational_adapt_engaged.hpp
+++ b/src/cmdstan/arguments/arg_variational_adapt_engaged.hpp
@@ -3,7 +3,7 @@
 
 #include <cmdstan/arguments/singleton_argument.hpp>
 #include <stan/services/experimental/advi/defaults.hpp>
-#include <boost/lexical_cast.hpp>
+#include <string>
 
 namespace cmdstan {
 
@@ -15,7 +15,7 @@ class arg_variational_adapt_engaged : public bool_argument {
     _name = "engaged";
     _description = adapt_engaged::description();
     _validity = "[0, 1]";
-    _default = boost::lexical_cast<std::string>(adapt_engaged::default_value());
+    _default = std::to_string(adapt_engaged::default_value());
     _default_value = adapt_engaged::default_value();
     _constrained = false;
     _good_value = adapt_engaged::default_value();

--- a/src/cmdstan/arguments/arg_variational_adapt_iter.hpp
+++ b/src/cmdstan/arguments/arg_variational_adapt_iter.hpp
@@ -3,7 +3,7 @@
 
 #include <cmdstan/arguments/singleton_argument.hpp>
 #include <stan/services/experimental/advi/defaults.hpp>
-#include <boost/lexical_cast.hpp>
+#include <string>
 
 namespace cmdstan {
 
@@ -15,8 +15,7 @@ class arg_variational_adapt_iter : public int_argument {
     _name = "iter";
     _description = adapt_iterations::description();
     _validity = "0 < iter";
-    _default
-        = boost::lexical_cast<std::string>(adapt_iterations::default_value());
+    _default = std::to_string(adapt_iterations::default_value());
     _default_value = adapt_iterations::default_value();
     _constrained = true;
     _good_value = adapt_iterations::default_value();

--- a/src/cmdstan/arguments/arg_variational_eta.hpp
+++ b/src/cmdstan/arguments/arg_variational_eta.hpp
@@ -3,7 +3,7 @@
 
 #include <cmdstan/arguments/singleton_argument.hpp>
 #include <stan/services/experimental/advi/defaults.hpp>
-#include <boost/lexical_cast.hpp>
+#include <string>
 
 namespace cmdstan {
 
@@ -15,7 +15,7 @@ class arg_variational_eta : public real_argument {
     _name = "eta";
     _description = eta::description();
     _validity = "0 < eta";
-    _default = boost::lexical_cast<std::string>(eta::default_value());
+    _default = std::to_string(eta::default_value());
     _default_value = eta::default_value();
     _constrained = true;
     _good_value = eta::default_value();

--- a/src/cmdstan/arguments/arg_variational_eval_elbo.hpp
+++ b/src/cmdstan/arguments/arg_variational_eval_elbo.hpp
@@ -2,7 +2,6 @@
 #define CMDSTAN_ARGUMENTS_VARIATIONAL_EVAL_ELBO_HPP
 
 #include <cmdstan/arguments/singleton_argument.hpp>
-#include <boost/lexical_cast.hpp>
 #include <string>
 
 namespace cmdstan {
@@ -14,7 +13,7 @@ class arg_variational_eval_elbo : public int_argument {
     _name = name;
     _description = desc;
     _validity = "0 < eval_elbo";
-    _default = boost::lexical_cast<std::string>(def);
+    _default = std::to_string(def);
     _default_value = def;
     _constrained = true;
     _good_value = 100.0;

--- a/src/cmdstan/arguments/arg_variational_iter.hpp
+++ b/src/cmdstan/arguments/arg_variational_iter.hpp
@@ -3,7 +3,7 @@
 
 #include <cmdstan/arguments/singleton_argument.hpp>
 #include <stan/services/experimental/advi/defaults.hpp>
-#include <boost/lexical_cast.hpp>
+#include <string>
 
 namespace cmdstan {
 
@@ -15,8 +15,7 @@ class arg_variational_iter : public int_argument {
     _name = "iter";
     _description = max_iterations::description();
     _validity = "0 < iter";
-    _default
-        = boost::lexical_cast<std::string>(max_iterations::default_value());
+    _default = std::to_string(max_iterations::default_value());
     _default_value = max_iterations::default_value();
     _constrained = true;
     _good_value = max_iterations::default_value();

--- a/src/cmdstan/arguments/arg_variational_num_samples.hpp
+++ b/src/cmdstan/arguments/arg_variational_num_samples.hpp
@@ -2,7 +2,6 @@
 #define CMDSTAN_ARGUMENTS_VARIATIONAL_NUM_SAMPLES_HPP
 
 #include <cmdstan/arguments/singleton_argument.hpp>
-#include <boost/lexical_cast.hpp>
 #include <string>
 
 namespace cmdstan {
@@ -14,7 +13,7 @@ class arg_variational_num_samples : public int_argument {
     _name = name;
     _description = desc;
     _validity = "0 < num_samples";
-    _default = boost::lexical_cast<std::string>(def);
+    _default = std::to_string(def);
     _default_value = def;
     _constrained = true;
     _good_value = 100.0;

--- a/src/cmdstan/arguments/arg_variational_output_samples.hpp
+++ b/src/cmdstan/arguments/arg_variational_output_samples.hpp
@@ -2,7 +2,6 @@
 #define CMDSTAN_ARGUMENTS_VARIATIONAL_OUTPUT_SAMPLES_HPP
 
 #include <cmdstan/arguments/singleton_argument.hpp>
-#include <boost/lexical_cast.hpp>
 #include <string>
 
 namespace cmdstan {
@@ -14,7 +13,7 @@ class arg_variational_output_samples : public int_argument {
     _name = name;
     _description = desc;
     _validity = "0 < output_samples";
-    _default = boost::lexical_cast<std::string>(def);
+    _default = std::to_string(def);
     _default_value = def;
     _constrained = true;
     _good_value = 1000.0;

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -56,7 +56,6 @@
 #include <stan/services/sample/hmc_static_unit_e_adapt.hpp>
 #include <stan/services/sample/standalone_gqs.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/lexical_cast.hpp>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -306,9 +305,9 @@ int command(int argc, const char *argv[]) {
   std::string init = get_arg_val<string_argument>(parser, "init");
   double init_radius = 2.0;
   try {
-    init_radius = boost::lexical_cast<double>(init);
+    init_radius = std::stod(init);
     init = "";
-  } catch (const boost::bad_lexical_cast &e) {
+  } catch (const std::logic_error &e) {
   }
   std::vector<std::shared_ptr<stan::io::var_context>> init_contexts
       = get_vec_var_context(init, num_chains);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Replace use of `boost::lexical_cast` with corresponding std::stoi, etc function whenever possible.

Templated class "singleton_argument" still uses boost.

#### Intended Effect:

avoid compiler warnings; improve efficiency.

#### How to Verify:

unit tests.

#### Side Effects:

none

#### Documentation:

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
