### PR TITLE
`Feature/1180 pathfinder single path csvs

### DIFF
--- a/src/cmdstan/arguments/arg_pathfinder.hpp
+++ b/src/cmdstan/arguments/arg_pathfinder.hpp
@@ -16,11 +16,11 @@ class arg_pathfinder : public arg_lbfgs {
 
     _subarguments.push_back(new arg_single_int_pos(
         "num_psis_draws", "Number of draws from PSIS sample", 1000));
+    _subarguments.push_back(
+        new arg_single_int_pos("num_paths", "Number of single pathfinders", 4));
     _subarguments.push_back(new arg_single_bool(
         "save_single_paths", "Output single-path pathfinder draws as CSV",
         false));
-    _subarguments.push_back(
-        new arg_single_int_pos("num_paths", "Number of single pathfinders", 4));
     _subarguments.push_back(new arg_single_int_pos(
         "max_lbfgs_iters", "Maximum number of LBFGS iterations", 1000));
     _subarguments.push_back(new arg_single_int_pos(

--- a/src/cmdstan/arguments/arg_pathfinder.hpp
+++ b/src/cmdstan/arguments/arg_pathfinder.hpp
@@ -17,6 +17,8 @@ class arg_pathfinder : public arg_lbfgs {
     _subarguments.push_back(new arg_single_int_pos(
         "num_psis_draws", "Number of draws from PSIS sample", 1000));
     _subarguments.push_back(
+        new arg_single_bool("save_single_paths", "Output single-path pathfinder draws as CSV", false));
+    _subarguments.push_back(
         new arg_single_int_pos("num_paths", "Number of single pathfinders", 4));
     _subarguments.push_back(new arg_single_int_pos(
         "max_lbfgs_iters", "Maximum number of LBFGS iterations", 1000));

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -195,8 +195,10 @@ int command(int argc, const char *argv[]) {
       diagnostic_csv_writers;
   std::vector<stan::callbacks::json_writer<std::ofstream>>
       diagnostic_json_writers;
+  stan::callbacks::unique_stream_writer<std::ofstream> pathfinder_writer;
+
   init_callbacks(parser, sample_writers, diagnostic_csv_writers,
-                 diagnostic_json_writers);
+                 diagnostic_json_writers, pathfinder_writer);
 
   // Setup initial parameter values - arg "init"
   // arg is either filename or init radius value
@@ -264,18 +266,6 @@ int command(int argc, const char *argv[]) {
           save_iterations, refresh, interrupt, logger, init_writer,
           sample_writers[0], diagnostic_json_writers[0]);
     } else {
-      std::string output_file
-          = get_arg_val<string_argument>(parser, "output", "file");
-      auto base_sfx = get_basename_suffix(output_file);
-      if (base_sfx.second.empty())
-        base_sfx.second = ".csv";
-      auto ofs = std::make_unique<std::ofstream>(base_sfx.first + "_pathfinder"
-                                                 + base_sfx.second);
-      if (sig_figs > -1) {
-        ofs->precision(sig_figs);
-      }
-      stan::callbacks::unique_stream_writer<std::ofstream> pathfinder_writer(
-          std::move(ofs), "# ");
       write_stan(pathfinder_writer);
       write_model(pathfinder_writer, model.model_name());
       write_datetime(pathfinder_writer);

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -195,10 +195,9 @@ int command(int argc, const char *argv[]) {
       diagnostic_csv_writers;
   std::vector<stan::callbacks::json_writer<std::ofstream>>
       diagnostic_json_writers;
-  stan::callbacks::unique_stream_writer<std::ofstream> pathfinder_writer;
 
   init_callbacks(parser, sample_writers, diagnostic_csv_writers,
-                 diagnostic_json_writers, pathfinder_writer);
+                 diagnostic_json_writers);
 
   // Setup initial parameter values - arg "init"
   // arg is either filename or init radius value
@@ -266,6 +265,12 @@ int command(int argc, const char *argv[]) {
           save_iterations, refresh, interrupt, logger, init_writer,
           sample_writers[0], diagnostic_json_writers[0]);
     } else {
+      std::vector<std::string> output_filenames =
+        make_filenames(get_arg_val<string_argument>(parser, "output", "file"), "", ".csv", 1, id);
+      auto ofs = std::make_unique<std::ofstream>(output_filenames[0]);
+      if (sig_figs > -1)
+        ofs->precision(sig_figs);
+      stan::callbacks::unique_stream_writer<std::ofstream> pathfinder_writer(std::move(ofs), "# ");
       write_stan(pathfinder_writer);
       write_model(pathfinder_writer, model.model_name());
       write_datetime(pathfinder_writer);

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -267,10 +267,11 @@ int command(int argc, const char *argv[]) {
           save_iterations, refresh, interrupt, logger, init_writer,
           sample_writers[0], diagnostic_json_writers[0]);
     } else {
-      std::vector<std::string> pf_names = make_filenames(
-          get_arg_val<string_argument>(parser, "output", "file"), "", ".csv", 1,
-          id);
-      auto ofs = std::make_unique<std::ofstream>(pf_names[0]);
+      auto ofs
+          = std::make_unique<std::ofstream>(
+              get_basename_suffix(
+                  get_arg_val<string_argument>(parser, "output", "file")).first
+              + ".csv");
       if (sig_figs > -1)
         ofs->precision(sig_figs);
       stan::callbacks::unique_stream_writer<std::ofstream> pathfinder_writer(

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -267,11 +267,11 @@ int command(int argc, const char *argv[]) {
           save_iterations, refresh, interrupt, logger, init_writer,
           sample_writers[0], diagnostic_json_writers[0]);
     } else {
-      auto ofs
-          = std::make_unique<std::ofstream>(
-              get_basename_suffix(
-                  get_arg_val<string_argument>(parser, "output", "file")).first
-              + ".csv");
+      auto ofs = std::make_unique<std::ofstream>(
+          get_basename_suffix(
+              get_arg_val<string_argument>(parser, "output", "file"))
+              .first
+          + ".csv");
       if (sig_figs > -1)
         ofs->precision(sig_figs);
       stan::callbacks::unique_stream_writer<std::ofstream> pathfinder_writer(

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -208,9 +208,11 @@ int command(int argc, const char *argv[]) {
     init = "";
   } catch (const std::logic_error &e) {
   }
+
   std::vector<std::shared_ptr<stan::io::var_context>> init_contexts
       = get_vec_var_context(init, num_chains);
   std::vector<std::string> model_compile_info = model.model_compile_info();
+
   for (int i = 0; i < num_chains; ++i) {
     write_stan(sample_writers[i]);
     write_model(sample_writers[i], model.model_name());
@@ -254,8 +256,8 @@ int command(int argc, const char *argv[]) {
         = get_arg_val<int_argument>(*pathfinder_arg, "num_psis_draws");
     int num_paths = get_arg_val<int_argument>(*pathfinder_arg, "num_paths");
     bool save_iterations
-        = !get_arg_val<string_argument>(parser, "output", "diagnostic_file")
-               .empty();
+        = get_arg_val<bool_argument>(*pathfinder_arg, "save_single_paths");
+
     if (num_paths == 1) {
       return_code = stan::services::pathfinder::pathfinder_lbfgs_single<
           false, stan::model::model_base>(
@@ -265,14 +267,19 @@ int command(int argc, const char *argv[]) {
           save_iterations, refresh, interrupt, logger, init_writer,
           sample_writers[0], diagnostic_json_writers[0]);
     } else {
-      std::vector<std::string> output_filenames = make_filenames(
+      std::vector<std::string> pf_names = make_filenames(
           get_arg_val<string_argument>(parser, "output", "file"), "", ".csv", 1,
           id);
-      auto ofs = std::make_unique<std::ofstream>(output_filenames[0]);
+      auto ofs = std::make_unique<std::ofstream>(pf_names[0]);
       if (sig_figs > -1)
         ofs->precision(sig_figs);
       stan::callbacks::unique_stream_writer<std::ofstream> pathfinder_writer(
           std::move(ofs), "# ");
+      std::cout << "L 280" << std::endl;
+      pathfinder_writer("# test");
+      for (int i = 0; i < num_paths; ++i) {
+        diagnostic_json_writers[i].write("test", "test");
+      }      
       write_stan(pathfinder_writer);
       write_model(pathfinder_writer, model.model_name());
       write_datetime(pathfinder_writer);

--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -769,8 +769,7 @@ void init_callbacks(
     std::vector<stan::callbacks::unique_stream_writer<std::ofstream>>
         &diag_csv_writers,
     std::vector<stan::callbacks::json_writer<std::ofstream>>
-    &diag_json_writers,
-    stan::callbacks::unique_stream_writer<std::ofstream> &pathfinder_writer) {
+    &diag_json_writers) {
   // bookkeeping
   auto user_method = parser.arg("method");
   unsigned int num_chains = get_num_chains(parser);
@@ -788,7 +787,7 @@ void init_callbacks(
                        "", ".csv", num_chains, id);
     if (save_single_paths) {
       output_filenames = make_filenames(get_arg_val<string_argument>(parser, "output", "file"),
-                       "_pathfinder", ".csv", num_chains, id);
+                       "_path", ".csv", num_chains, id);
     }
     for (int i = 0; i < num_chains; ++i) {
       auto ofs = std::make_unique<std::ofstream>(output_filenames[i]);
@@ -838,17 +837,6 @@ void init_callbacks(
       }
     }
   }
-  // CSV file for pathfinder PSIS sample
-  if (is_pathfinder && num_chains > 1) {
-    std::vector<std::string> output_filenames =
-      make_filenames(get_arg_val<string_argument>(parser, "output", "file"), "", ".csv", 1, id);
-    auto ofs = std::make_unique<std::ofstream>(output_filenames[0]);
-    if (sig_figs > -1)
-      ofs->precision(sig_figs);
-    stan::callbacks::unique_stream_writer<std::ofstream> tmp(std::move(ofs), "# ");
-    pathfinder_writer = std::move(tmp);
-  }
-
 }
 
 }  // namespace cmdstan

--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -744,9 +744,7 @@ std::vector<std::string> make_filenames(const std::string &filename,
                                         unsigned int id) {
   std::vector<std::string> names(num_chains);
   auto base_sfx = get_basename_suffix(filename);
-  if (base_sfx.second.empty()) {
-    base_sfx.second = type;
-  }
+  base_sfx.second = type;
   auto name_iterator = [num_chains, id](auto i) {
     if (num_chains == 1) {
       return std::string("");
@@ -768,72 +766,85 @@ void init_callbacks(
         &diag_csv_writers,
     std::vector<stan::callbacks::json_writer<std::ofstream>>
         &diag_json_writers) {
-  // bookkeeping
   auto user_method = parser.arg("method");
   unsigned int num_chains = get_num_chains(parser);
   unsigned int id = get_arg_val<int_argument>(parser, "id");
   int sig_figs = get_arg_val<int_argument>(parser, "output", "sig_figs");
   bool is_pathfinder = user_method->arg("pathfinder");
-  bool save_single_paths
-      = is_pathfinder && num_chains > 1
+  bool save_single_paths =  is_pathfinder
         && get_arg_val<bool_argument>(parser, "method", "pathfinder",
                                       "save_single_paths");
 
-  // output.csv files for all chains and single-path-pathfinder csv files
+  std::vector<std::string> output_filenames;
+  std::vector<std::string> diagnostic_filenames;
+
   sample_writers.reserve(num_chains);
-  if (!is_pathfinder || save_single_paths || num_chains == 1) {
-    std::vector<std::string> output_filenames
-        = make_filenames(get_arg_val<string_argument>(parser, "output", "file"),
-                         "", ".csv", num_chains, id);
-    if (save_single_paths) {
-      output_filenames = make_filenames(
-          get_arg_val<string_argument>(parser, "output", "file"), "_path",
-          ".csv", num_chains, id);
+  diag_csv_writers.reserve(num_chains);
+  diag_json_writers.reserve(num_chains);
+
+  // create no-op diagnostics writers by default
+  for (int i = 0; i < num_chains; ++i) {
+    diag_csv_writers.emplace_back(nullptr, "# ");
+    diag_json_writers.emplace_back(
+        stan::callbacks::json_writer<std::ofstream>());
+  }
+  // sample_writers for pathfinder - if saving or only single-path run
+  if (is_pathfinder && (!save_single_paths || num_chains > 1)) {
+    for (int i = 0; i < num_chains; ++i) {
+      sample_writers.emplace_back(nullptr, "# ");
     }
+  }
+
+  if (save_single_paths) {
+    sample_writers.clear();
+    diag_json_writers.clear();
+    if (num_chains == 1) {  // no multi-path outputs, don't need sfx "_path"
+      output_filenames = make_filenames(
+          get_arg_val<string_argument>(parser, "output", "file"),
+          "", ".csv", num_chains, id);
+      diagnostic_filenames = make_filenames(
+          get_arg_val<string_argument>(parser, "output", "file"),
+          "", ".json", num_chains, id);
+    } else {  // distinguish single, multi-path output files
+      output_filenames = make_filenames(
+          get_arg_val<string_argument>(parser, "output", "file"),
+          "_path", ".csv", num_chains, id);
+      diagnostic_filenames = make_filenames(
+          get_arg_val<string_argument>(parser, "output", "file"),
+          "_path", ".json", num_chains, id);
+    }
+    for (int i = 0; i < num_chains; ++i) {
+      auto ofs = std::make_unique<std::ofstream>(output_filenames[i]);
+      auto ofs_diag = std::make_unique<std::ofstream>(diagnostic_filenames[i]);
+      if (sig_figs > -1) {
+        ofs->precision(sig_figs);
+        ofs_diag->precision(sig_figs);
+      }
+      sample_writers.emplace_back(std::move(ofs), "# ");
+      stan::callbacks::json_writer<std::ofstream> jwriter(std::move(ofs_diag));
+      diag_json_writers.emplace_back(std::move(jwriter));
+    }
+  } else if (!is_pathfinder || num_chains == 1) {
+    output_filenames = make_filenames(
+        get_arg_val<string_argument>(parser, "output", "file"),
+        "", ".csv", num_chains, id);
     for (int i = 0; i < num_chains; ++i) {
       auto ofs = std::make_unique<std::ofstream>(output_filenames[i]);
       if (sig_figs > -1)
         ofs->precision(sig_figs);
       sample_writers.emplace_back(std::move(ofs), "# ");
     }
-  } else if (is_pathfinder && !save_single_paths) {
-    for (int i = 0; i < num_chains; ++i) {
-      sample_writers.emplace_back(nullptr, "# ");
-    }
   }
-  // diagnostic files for sampler (csv) and pathfinder (json)
-  diag_json_writers.reserve(num_chains);
-  diag_csv_writers.reserve(num_chains);
-  // create no-op writers by default
-  for (int i = 0; i < num_chains; ++i) {
-    diag_json_writers.emplace_back(
-        stan::callbacks::json_writer<std::ofstream>());
-  }
-  for (int i = 0; i < num_chains; ++i) {
-    diag_csv_writers.emplace_back(nullptr, "# ");
-  }
-  // create json, csv writers as needed.
-  std::string diagnostic_file
-      = get_arg_val<string_argument>(parser, "output", "diagnostic_file");
-  if (!diagnostic_file.empty()) {
-    std::vector<std::string> diag_filenames;
-    if (user_method->arg("pathfinder")) {
-      diag_json_writers.clear();
-      diag_filenames
-          = make_filenames(diagnostic_file, "", ".json", num_chains, id);
-      for (int i = 0; i < num_chains; ++i) {
-        auto ofs = std::make_unique<std::ofstream>(diag_filenames[i]);
-        if (sig_figs > -1)
-          ofs->precision(sig_figs);
-        stan::callbacks::json_writer<std::ofstream> jwriter(std::move(ofs));
-        diag_json_writers.emplace_back(std::move(jwriter));
-      }
-    } else {
+
+  if (!is_pathfinder) {
+    std::string diagnostic_file
+        = get_arg_val<string_argument>(parser, "output", "diagnostic_file");
+    if (!diagnostic_file.empty()) {
       diag_csv_writers.clear();
-      diag_filenames
-          = make_filenames(diagnostic_file, "", ".csv", num_chains, id);
+      diagnostic_filenames = make_filenames(diagnostic_file,
+                                            "", ".csv", num_chains, id);
       for (int i = 0; i < num_chains; ++i) {
-        auto ofs = std::make_unique<std::ofstream>(diag_filenames[i]);
+        auto ofs = std::make_unique<std::ofstream>(diagnostic_filenames[i]);
         if (sig_figs > -1)
           ofs->precision(sig_figs);
         diag_csv_writers.emplace_back(std::move(ofs), "# ");

--- a/src/test/interface/pathfinder_test.cpp
+++ b/src/test/interface/pathfinder_test.cpp
@@ -19,16 +19,18 @@ class CmdStan : public testing::Test {
     eight_schools_data
         = {"src", "test", "test-models", "eight_schools.data.json"};
     arg_output = {"test", "output"};
-    arg_diags = {"test", "output"};
+    arg_diags = {"test", "diagnostics"};
     output_csv = {"test", "output.csv"};
     output_json = {"test", "output.json"};
-    output_single_csv = {"test", "output_path_4.csv"};
-    output_single_json = {"test", "output_path_4.json"};
+    output_diags = {"test", "diagnostics.json"};
+    output_single_csv = {"test", "output_path_1.csv"};
+    output_single_json = {"test", "output_path_1.json"};
   }
 
   void TearDown() {
     std::remove(convert_model_path(output_csv).c_str());
     std::remove(convert_model_path(output_json).c_str());
+    std::remove(convert_model_path(output_diags).c_str());
     std::remove(convert_model_path(output_single_csv).c_str());
     std::remove(convert_model_path(output_single_json).c_str());
   }
@@ -41,6 +43,7 @@ class CmdStan : public testing::Test {
   std::vector<std::string> arg_diags;
   std::vector<std::string> output_csv;
   std::vector<std::string> output_json;
+  std::vector<std::string> output_diags;
   std::vector<std::string> output_single_csv;
   std::vector<std::string> output_single_json;
 };
@@ -117,6 +120,7 @@ TEST_F(CmdStan, pathfinder_save_single_default_num_paths) {
   run_command_output out = run_command(ss.str());
   ASSERT_FALSE(out.hasError);
   ASSERT_TRUE(file_exists(convert_model_path(output_csv)));
+  ASSERT_FALSE(file_exists(convert_model_path(output_json)));
   ASSERT_TRUE(file_exists(convert_model_path(output_single_csv)));
   ASSERT_TRUE(file_exists(convert_model_path(output_single_json)));
 
@@ -141,105 +145,78 @@ TEST_F(CmdStan, pathfinder_save_single_default_num_paths) {
   EXPECT_EQ(1, count_matches("\"1\" : {\"iter\" : 1,", single_json));
 }
 
-// TEST_F(CmdStan, pathfinder_single_good_plus) {
-//   std::stringstream ss;
-//   ss << convert_model_path(multi_normal_model)
-//      << " output refresh=0 file=" << convert_model_path(arg_output)
-//      << " method=pathfinder"
-//      << " num_paths=1"
-//      << " save_single_paths=1";
-//   run_command_output out = run_command(ss.str());
-//   ASSERT_FALSE(out.hasError);
+TEST_F(CmdStan, pathfinder_save_single_num_paths_1) {
+  std::stringstream ss;
+  ss << convert_model_path(multi_normal_model)
+     << " output refresh=0 file=" << convert_model_path(arg_output)
+     << " method=pathfinder"
+     << " num_paths=1 save_single_paths=1";
+  run_command_output out = run_command(ss.str());
+  ASSERT_FALSE(out.hasError);
+  ASSERT_TRUE(file_exists(convert_model_path(output_csv)));
+  ASSERT_TRUE(file_exists(convert_model_path(output_json)));
+  ASSERT_FALSE(file_exists(convert_model_path(output_single_csv)));
+  ASSERT_FALSE(file_exists(convert_model_path(output_single_json)));
+}
 
-//   std::fstream result_stream(convert_model_path(output_csv));
-//   std::stringstream result_sstream;
-//   result_sstream << result_stream.rdbuf();
-//   result_stream.close();
-//   std::string output = result_sstream.str();
-//   EXPECT_EQ(1, count_matches("# Elapsed Time:", output));
-//   EXPECT_EQ(1, count_matches(" seconds (Pathfinder)", output));
-//   EXPECT_EQ(1, count_matches("num_paths = 1", output));
-//   EXPECT_EQ(1, count_matches("save_single_paths = 1", output));
+TEST_F(CmdStan, pathfinder_save_single_num_paths_1_diag_file_arg) {
+  std::stringstream ss;
+  ss << convert_model_path(multi_normal_model)
+     << " output refresh=0 file=" << convert_model_path(arg_output)
+     << " diagnostic_file=" << convert_model_path(arg_diags)
+     << " method=pathfinder"
+     << " num_paths=1 save_single_paths=1";
+  run_command_output out = run_command(ss.str());
+  ASSERT_FALSE(out.hasError);
+  ASSERT_TRUE(file_exists(convert_model_path(output_csv)));
+  ASSERT_TRUE(file_exists(convert_model_path(output_diags)));
+  ASSERT_FALSE(file_exists(convert_model_path(output_json)));
+  ASSERT_FALSE(file_exists(convert_model_path(output_single_csv)));
+  ASSERT_FALSE(file_exists(convert_model_path(output_single_json)));
+}
 
-//   ASSERT_FALSE(file_exists(convert_model_path(output_save_single)));
-// }
+TEST_F(CmdStan, pathfinder_num_paths_8) {
+  std::stringstream ss;
+  ss << convert_model_path(multi_normal_model)
+     << " output refresh=0 file=" << convert_model_path(arg_output)
+     << " method=pathfinder"
+     << " num_paths=8";
+  run_command_output out = run_command(ss.str());
+  ASSERT_FALSE(out.hasError);
+  ASSERT_TRUE(file_exists(convert_model_path(output_csv)));
+  ASSERT_FALSE(file_exists(convert_model_path(output_single_csv)));
 
-// TEST_F(CmdStan, pathfinder_num_paths_8) {
-//   std::stringstream ss;
-//   ss << convert_model_path(multi_normal_model)
-//      << " output refresh=0 file=" << convert_model_path(arg_output)
-//      << " method=pathfinder"
-//      << " num_paths=8";
-//   run_command_output out = run_command(ss.str());
-//   ASSERT_FALSE(out.hasError);
-//   std::vector<std::string> test_psis_path = {"test", "output.csv"};
-//   std::fstream result_stream(convert_model_path(test_psis_path));
-//   std::stringstream result_sstream;
-//   result_sstream << result_stream.rdbuf();
-//   result_stream.close();
-//   std::string output = result_sstream.str();
-//   EXPECT_EQ(1, count_matches("num_paths = 8", output));
-//   EXPECT_EQ(1, count_matches("# Elapsed Time:", output));
-//   EXPECT_EQ(1, count_matches(" seconds (Pathfinders)", output));
-// }
+  std::fstream result_stream(convert_model_path(output_csv));
+  std::stringstream result_sstream;
+  result_sstream << result_stream.rdbuf();
+  result_stream.close();
+  std::string output = result_sstream.str();
+  EXPECT_EQ(1, count_matches(" seconds (Pathfinders)", output));
+  EXPECT_EQ(1, count_matches(" seconds (PSIS)", output));
+  EXPECT_EQ(1, count_matches("num_paths = 8", output));
+}
 
-// TEST_F(CmdStan, pathfinder_diagnostic_json) {
-//   std::stringstream ss;
-//   ss << convert_model_path(multi_normal_model)
-//      << " output refresh=0 file=" << convert_model_path(arg_output)
-//      << " diagnostic_file=" << convert_model_path(arg_diags)
-//      << " method=pathfinder";
-//   run_command_output out = run_command(ss.str());
-//   ASSERT_FALSE(out.hasError);
+TEST_F(CmdStan, pathfinder_lbfgs_iterations) {
+  std::stringstream ss;
+  ss << convert_model_path(eight_schools_model)
+     << " data file=" << convert_model_path(eight_schools_data)
+     << " random seed=12345"
+     << " output refresh=0 file=" << convert_model_path(arg_output)
+     << " method=pathfinder max_lbfgs_iters=3"
+     << " save_single_paths=1";
+  run_command_output out = run_command(ss.str());
+  ASSERT_FALSE(out.hasError);
+  ASSERT_TRUE(file_exists(convert_model_path(output_csv)));
+  ASSERT_TRUE(file_exists(convert_model_path(output_single_json)));
 
-//   std::fstream result_stream(convert_model_path(output_diags));
-//   std::stringstream result_sstream;
-//   result_sstream << result_stream.rdbuf();
-//   result_stream.close();
-//   std::string output = result_sstream.str();
-//   ASSERT_FALSE(output.empty());
-//   rapidjson::Document document;
-//   ASSERT_FALSE(document.Parse<0>(output.c_str()).HasParseError());
-// }
-
-// TEST_F(CmdStan, pathfinder_lbfgs_iterations) {
-//   std::stringstream ss;
-//   ss << convert_model_path(eight_schools_model)
-//      << " data file=" << convert_model_path(eight_schools_data)
-//      << " random seed=12345"
-//      << " output refresh=0 file=" << convert_model_path(arg_output)
-//      << " diagnostic_file=" << convert_model_path(arg_diags)
-//      << " method=pathfinder max_lbfgs_iters=3";
-//   run_command_output out = run_command(ss.str());
-//   ASSERT_FALSE(out.hasError);
-
-//   std::fstream result_stream(convert_model_path(output_diags));
-//   std::stringstream result_sstream;
-//   result_sstream << result_stream.rdbuf();
-//   result_stream.close();
-//   std::string output = result_sstream.str();
-//   ASSERT_FALSE(output.empty());
-//   rapidjson::Document document;
-//   ASSERT_FALSE(document.Parse<0>(output.c_str()).HasParseError());
-//   EXPECT_EQ(1, count_matches("\"3\" : {\"iter\" : 3,", output));
-//   EXPECT_EQ(0, count_matches("\"4\" : {\"iter\" : 4,", output));
-// }
-
-// TEST_F(CmdStan, pathfinder_num_paths_draws) {
-//   std::stringstream ss;
-//   ss << convert_model_path(eight_schools_model)
-//      << " data file=" << convert_model_path(eight_schools_data)
-//      << " output refresh=0 file=" << convert_model_path(arg_output)
-//      << " method=pathfinder num_draws=10 num_paths=2";
-//   run_command_output out = run_command(ss.str());
-//   ASSERT_FALSE(out.hasError);
-
-//   std::fstream result_stream(convert_model_path(output_csv));
-//   std::stringstream result_sstream;
-//   result_sstream << result_stream.rdbuf();
-//   result_stream.close();
-//   std::string output = result_sstream.str();
-//   ASSERT_FALSE(output.empty());
-//   EXPECT_EQ(1, count_matches("num_paths = 2", output));
-//   EXPECT_EQ(1, count_matches("num_draws = 10", output));
-// }
+  std::fstream result_stream(convert_model_path(output_single_json));
+  std::stringstream result_sstream;
+  result_sstream << result_stream.rdbuf();
+  result_stream.close();
+  std::string output = result_sstream.str();
+  ASSERT_FALSE(output.empty());
+  rapidjson::Document document;
+  ASSERT_FALSE(document.Parse<0>(output.c_str()).HasParseError());
+  EXPECT_EQ(1, count_matches("\"3\" : {\"iter\" : 3,", output));
+  EXPECT_EQ(0, count_matches("\"4\" : {\"iter\" : 4,", output));
+}

--- a/src/test/utility.hpp
+++ b/src/test/utility.hpp
@@ -9,6 +9,9 @@
 #include <string>
 #include <vector>
 
+#include <sys/stat.h>
+
+
 namespace cmdstan {
 namespace test {
 
@@ -280,6 +283,12 @@ int idx_first_match(const std::vector<std::string> &lines,
   }
   return idx;
 }
+
+bool file_exists(const std::string& filename) {
+    struct stat buffer;
+    return (stat(filename.c_str(), &buffer) == 0);
+}
+
 
 }  // namespace test
 }  // namespace cmdstan


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Added flag `save_single_path` to method `pathfinder`, per discussion in #1180 

#### Intended Effect:

Better user experience.

#### How to Verify:

Unit tests

#### Side Effects:

N/A

#### Documentation:

see PR https://github.com/stan-dev/docs/pull/651#

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
