### PR TITLE
Add option to keep object file after compiling model

### DIFF
--- a/make/program
+++ b/make/program
@@ -57,7 +57,9 @@ endif
 	@echo '--- Compiling, linking C++ code ---'
 	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)
 	$(LINK.cpp) $(subst \,/,$*.o) $(CMDSTAN_MAIN_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS) $(subst \,/,$(OUTPUT_OPTION))
+ifneq ($(KEEP_OBJECT), true)
 	$(RM) $(subst  \,/,$*).o
+endif
 ifeq ($(OS),Windows_NT)
 ifeq (,$(findstring tbb.dll, $(notdir $(shell where tbb.dll))))
 	@echo 'Intel TBB is not in PATH.'


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This PR adds a makeflag `KEEP_OBJECT` to allow keeping the `.o` object file when compiling a model.

When exposing model methods (`log_prob`, etc) in `cmdstanr` we end up having to compile a given model twice - once via `cmdstan` to generate the executable and once via Rcpp to expose the `stan_model` typedef to generate a model pointer. If we can still have access to the object file, we can instead just link against it and skip the additional compilation.

#### Intended Effect:

Reduce unnecessary compilation when exposing model methods in `cmdstanr`

#### How to Verify:

Add `KEEP_OBJECT=true` to `make/local`

#### Side Effects:

N/A

#### Documentation:

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
