### PR TITLE
Split building of .o file from executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,6 @@ src/docs/**/*.pdf
 output.csv
 output*.csv
 *.d
+*.o
 # gdb
 .gdb_history

--- a/make/program
+++ b/make/program
@@ -51,13 +51,20 @@ endif
 
 %.d: %.hpp
 
-.PRECIOUS: %.hpp
-%$(EXE) : %.hpp $(CMDSTAN_MAIN_O) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS) $(PRECOMPILED_MODEL_HEADER)
+ifeq ($(KEEP_OBJECT), true)
+.PRECIOUS: %.o
+endif
+
+%.o : %.hpp
 	@echo ''
-	@echo '--- Compiling, linking C++ code ---'
+	@echo '--- Compiling C++ code ---'
 	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)
+
+%$(EXE) : %.o $(CMDSTAN_MAIN_O) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS) $(PRECOMPILED_MODEL_HEADER)
+	@echo ''
+	@echo '--- Linking model ---'
 	$(LINK.cpp) $(subst \,/,$*.o) $(CMDSTAN_MAIN_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS) $(subst \,/,$(OUTPUT_OPTION))
-	$(RM) $(subst  \,/,$*).o
+
 ifeq ($(OS),Windows_NT)
 ifeq (,$(findstring tbb.dll, $(notdir $(shell where tbb.dll))))
 	@echo 'Intel TBB is not in PATH.'

--- a/make/tests
+++ b/make/tests
@@ -58,8 +58,8 @@ TEST_MODELS := $(wildcard src/test/test-models/*.stan)
 
 .PHONY: test-models-hpp
 test-models-hpp:
+	$(MAKE) $(patsubst %.stan,%.hpp,$(TEST_MODELS))
 	$(MAKE) $(patsubst %.stan,%$(EXE),$(TEST_MODELS))
-
 ##
 # Tests that depend on compiled models
 ##


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Splits the make rule to build executables into two parts. This allows a more natural way to encode #1186, but also allows things like `make mymodel.o`, which would allow the same sort of thing and speed ups like https://github.com/stan-dev/stanc3/pull/1350

#### Intended Effect:

#### How to Verify:

#### Side Effects:
None
#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
