### PR TITLE
Make Pathfinder json test whitespace agnostic

### DIFF
--- a/makefile
+++ b/makefile
@@ -206,6 +206,7 @@ endif
 	@echo '      the nightly version.'
 	@echo '    STAN_CPP_OPTIMS: Turns on additonal compiler flags for performance.'
 	@echo '    STAN_NO_RANGE_CHECKS: Removes the range checks from the model for performance.'
+	@echo '    STAN_THREADS: Enable multi-threaded execution of the Stan model.'
 	@echo ''
 	@echo ''
 	@echo '  Example - bernoulli model: examples/bernoulli/bernoulli.stan'
@@ -295,9 +296,9 @@ endif
 ##
 # Clean up.
 ##
-.PHONY: clean clean-deps clean-manual clean-all clean-program
+.PHONY: clean clean-deps clean-all
 
-clean: clean-manual
+clean:
 	$(RM) -r test
 	$(RM) $(wildcard $(patsubst %.stan,%.d,$(TEST_MODELS)))
 	$(RM) $(wildcard $(patsubst %.stan,%.hpp,$(TEST_MODELS)))
@@ -316,15 +317,6 @@ clean-all: clean clean-deps clean-libraries
 	$(RM) $(wildcard $(STAN)src/stan/model/model_header*.hpp.gch)
 	$(RM) examples/bernoulli/bernoulli$(EXE) examples/bernoulli/bernoulli.o examples/bernoulli/bernoulli.d examples/bernoulli/bernoulli.hpp
 	$(RM) -r $(wildcard $(BOOST)/stage/lib $(BOOST)/bin.v2 $(BOOST)/tools/build/src/engine/bootstrap/ $(BOOST)/tools/build/src/engine/bin.* $(BOOST)/project-config.jam* $(BOOST)/b2 $(BOOST)/bjam $(BOOST)/bootstrap.log)
-
-clean-program:
-ifndef STANPROG
-	$(error STANPROG not set)
-endif
-	$(RM) "$(wildcard $(patsubst %.stan,%.d,$(basename ${STANPROG}).stan))"
-	$(RM) "$(wildcard $(patsubst %.stan,%.hpp,$(basename ${STANPROG}).stan))"
-	$(RM) "$(wildcard $(patsubst %.stan,%.o,$(basename ${STANPROG}).stan))"
-	$(RM) "$(wildcard $(patsubst %.stan,%$(EXE),$(basename ${STANPROG}).stan))"
 
 ##
 # Submodule related tasks

--- a/src/test/interface/pathfinder_test.cpp
+++ b/src/test/interface/pathfinder_test.cpp
@@ -112,6 +112,8 @@ TEST_F(CmdStan, pathfinder_single) {
   EXPECT_EQ(1, count_matches("save_single_paths = 0 (Default)", output));
 }
 
+bool is_whitespace(char c) { return c == ' ' || c == '\n'; }
+
 TEST_F(CmdStan, pathfinder_save_single_default_num_paths) {
   std::stringstream ss;
   ss << convert_model_path(multi_normal_model)
@@ -142,7 +144,10 @@ TEST_F(CmdStan, pathfinder_save_single_default_num_paths) {
 
   rapidjson::Document document;
   ASSERT_FALSE(document.Parse<0>(single_json.c_str()).HasParseError());
-  EXPECT_EQ(1, count_matches("\"1\" : {\"iter\" : 1,", single_json));
+  single_json.erase(
+      std::remove_if(single_json.begin(), single_json.end(), is_whitespace),
+      single_json.end());
+  EXPECT_EQ(1, count_matches("\"1\":{\"iter\":1,", single_json));
 }
 
 TEST_F(CmdStan, pathfinder_save_single_num_paths_1) {
@@ -233,6 +238,8 @@ TEST_F(CmdStan, pathfinder_lbfgs_iterations) {
   ASSERT_FALSE(output.empty());
   rapidjson::Document document;
   ASSERT_FALSE(document.Parse<0>(output.c_str()).HasParseError());
-  EXPECT_EQ(1, count_matches("\"3\" : {\"iter\" : 3,", output));
-  EXPECT_EQ(0, count_matches("\"4\" : {\"iter\" : 4,", output));
+  output.erase(std::remove_if(output.begin(), output.end(), is_whitespace),
+               output.end());
+  EXPECT_EQ(1, count_matches("\"3\":{\"iter\":3,", output));
+  EXPECT_EQ(0, count_matches("\"4\":{\"iter\":4,", output));
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Updates the Pathfinder tests which check the JSON output to be agnostic about the whitespace in said JSON. This unblocks https://github.com/stan-dev/stan/pull/3227

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
