### PR TITLE
stansummary: Allow decimals in --percentiles

### DIFF
--- a/src/cmdstan/stansummary.cpp
+++ b/src/cmdstan/stansummary.cpp
@@ -34,7 +34,7 @@ Options:
   -c, --csv_filename [file]   Write statistics to a csv file.
   -h, --help                  Produce help message, then exit.
   -p, --percentiles [values]  Percentiles to report as ordered set of
-                              comma-separated integers from (1,99), inclusive.
+                              comma-separated numbers from (0.1,99.9), inclusive.
                               Default is 5,50,95.
   -s, --sig_figs [n]          Significant figures reported. Default is 2.
                               Must be an integer from (1, 18), inclusive.

--- a/src/cmdstan/stansummary.cpp
+++ b/src/cmdstan/stansummary.cpp
@@ -97,16 +97,18 @@ Options:
     return return_codes::NOT_OK;
   }
   std::vector<std::string> percentiles;
-  boost::algorithm::trim(percentiles_spec);
-  boost::algorithm::split(percentiles, percentiles_spec, boost::is_any_of(", "),
-                          boost::token_compress_on);
   Eigen::VectorXd probs;
-  try {
-    probs = percentiles_to_probs(percentiles);
-  } catch (const std::invalid_argument &e) {
-    std::cout << "Option --percentiles " << percentiles_spec << ": " << e.what()
-              << std::endl;
-    return return_codes::NOT_OK;
+  boost::algorithm::trim(percentiles_spec);
+  if (!percentiles_spec.empty()) {
+    boost::algorithm::split(percentiles, percentiles_spec,
+                            boost::is_any_of(", "), boost::token_compress_on);
+    try {
+      probs = percentiles_to_probs(percentiles);
+    } catch (const std::invalid_argument &e) {
+      std::cout << "Option --percentiles " << percentiles_spec << ": "
+                << e.what() << std::endl;
+      return return_codes::NOT_OK;
+    }
   }
   if (app.count("--csv_filename")) {
     if (FILE *file = fopen(csv_filename.c_str(), "w")) {

--- a/src/cmdstan/stansummary_helper.hpp
+++ b/src/cmdstan/stansummary_helper.hpp
@@ -293,7 +293,7 @@ int matrix_index(std::vector<int> &index, const std::vector<int> &dims) {
  * @return vector of doubles
  */
 Eigen::VectorXd percentiles_to_probs(
-    const std::vector<std::string> percentiles) {
+    const std::vector<std::string> &percentiles) {
   Eigen::VectorXd probs(percentiles.size());
   int cur_pct = 0;
   double pct = 0;

--- a/src/cmdstan/stansummary_helper.hpp
+++ b/src/cmdstan/stansummary_helper.hpp
@@ -296,20 +296,20 @@ Eigen::VectorXd percentiles_to_probs(
     const std::vector<std::string> percentiles) {
   Eigen::VectorXd probs(percentiles.size());
   int cur_pct = 0;
-  int pct = 0;
+  double pct = 0;
   int i = 0;
   for (size_t i = 0; i < percentiles.size(); ++i) {
     try {
-      pct = std::stoi(percentiles[i]);
-      if (pct < 1 || pct > 99 || pct < cur_pct)
+      pct = std::stod(percentiles[i]);
+      if (!std::isfinite(pct) || pct < 0.1 || pct > 99.9 || pct < cur_pct)
         throw std::exception();
       cur_pct = pct;
     } catch (const std::exception &e) {
       throw std::invalid_argument(
-          "values must be in range (1,99)"
+          "values must be in range (0.1,99.9)"
           ", inclusive, and strictly increasing.");
     }
-    probs[i] = pct * 1.0 / 100.0;
+    probs[i] = pct / 100.0;
   }
   return probs;
 }

--- a/src/test/interface/stansummary_test.cpp
+++ b/src/test/interface/stansummary_test.cpp
@@ -193,11 +193,9 @@ TEST(CommandStansummary, percentiles) {
   pcts.push_back("infinity");
   EXPECT_THROW(percentiles_to_probs(pcts), std::invalid_argument);
 
-
   pcts.clear();
   pcts.push_back("nonsenseString");
   EXPECT_THROW(percentiles_to_probs(pcts), std::invalid_argument);
-
 }
 
 TEST(CommandStansummary, param_tests) {

--- a/src/test/interface/stansummary_test.cpp
+++ b/src/test/interface/stansummary_test.cpp
@@ -169,6 +169,37 @@ TEST(CommandStansummary, header_tests) {
   EXPECT_EQ(expect_csv, ss.str());
 }
 
+TEST(CommandStansummary, percentiles) {
+  std::vector<std::string> pcts;
+  pcts.push_back("2.5");
+  pcts.push_back("10");
+  pcts.push_back("50");
+  pcts.push_back("90");
+  pcts.push_back("97.5");
+  Eigen::VectorXd probs;
+  EXPECT_NO_THROW(probs = percentiles_to_probs(pcts));
+  EXPECT_FLOAT_EQ(probs[0], 0.025);
+  EXPECT_FLOAT_EQ(probs[4], 0.975);
+
+  pcts.clear();
+  pcts.push_back("120");
+  EXPECT_THROW(percentiles_to_probs(pcts), std::invalid_argument);
+
+  pcts.clear();
+  pcts.push_back("NAN");
+  EXPECT_THROW(percentiles_to_probs(pcts), std::invalid_argument);
+
+  pcts.clear();
+  pcts.push_back("infinity");
+  EXPECT_THROW(percentiles_to_probs(pcts), std::invalid_argument);
+
+
+  pcts.clear();
+  pcts.push_back("nonsenseString");
+  EXPECT_THROW(percentiles_to_probs(pcts), std::invalid_argument);
+
+}
+
 TEST(CommandStansummary, param_tests) {
   std::string path_separator;
   path_separator.push_back(get_path_separator());

--- a/src/test/interface/stansummary_test.cpp
+++ b/src/test/interface/stansummary_test.cpp
@@ -531,6 +531,44 @@ TEST(CommandStansummary, check_csv_output) {
     FAIL();
 }
 
+TEST(CommandStansummary, check_csv_output_no_percentiles) {
+  std::string csv_header = "name,Mean,MCSE,StdDev,N_Eff,N_Eff/s,R_hat";
+  std::string lp
+      = "\"lp__\",-7.2719,0.0365168,0.768874,443.328,19275.1,1.00037";
+
+  std::string path_separator;
+  path_separator.push_back(get_path_separator());
+  std::string command = "bin" + path_separator + "stansummary";
+  std::string csv_file = "src" + path_separator + "test" + path_separator
+                         + "interface" + path_separator + "example_output"
+                         + path_separator + "bernoulli_chain_1.csv";
+
+  std::string target_csv_file = "src" + path_separator + "test" + path_separator
+                                + "interface" + path_separator
+                                + "example_output" + path_separator
+                                + "tmp_test_target_csv_file.csv";
+  std::string arg_csv_file = "--csv_filename=" + target_csv_file;
+
+  std::string arg_percentiles = "-p \"\"";
+
+  run_command_output out = run_command(command + " " + arg_csv_file + " "
+                                       + csv_file + " " + arg_percentiles);
+  ASSERT_FALSE(out.hasError) << "\"" << out.command << "\" quit with an error";
+
+  std::ifstream target_stream(target_csv_file.c_str());
+  if (!target_stream.is_open())
+    FAIL();
+  std::string line;
+  std::getline(target_stream, line);
+  EXPECT_EQ(csv_header, line);
+  std::getline(target_stream, line);
+  EXPECT_EQ(lp, line);
+  target_stream.close();
+  int return_code = std::remove(target_csv_file.c_str());
+  if (return_code != 0)
+    FAIL();
+}
+
 TEST(CommandStansummary, check_csv_output_sig_figs) {
   std::string csv_header
       = "name,Mean,MCSE,StdDev,5%,50%,95%,N_Eff,N_Eff/s,R_hat";


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Closes #1114

The following kinds of arguments are now valid for stansummary:

`--percentiles 2.5,50,97.5` -- decimals are now allowed and processed correctly.
`--percentiles ""` -- empty argument omits percentiles entirely

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
