### PR TITLE
Fix stepsize_jitter being set to stepsize

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -517,7 +517,7 @@ int command(int argc, const char *argv[]) {
       double stepsize = get_arg_val<real_argument>(
           parser, "method", "sample", "algorithm", "hmc", "stepsize");
       double jitter = get_arg_val<real_argument>(
-          parser, "method", "sample", "algorithm", "hmc", "stepsize");
+          parser, "method", "sample", "algorithm", "hmc", "stepsize_jitter");
       list_argument *hmc_engine
           = dynamic_cast<list_argument *>(algo->arg("hmc")->arg("engine"));
       std::string engine = hmc_engine->value();


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Reported here: https://discourse.mc-stan.org/t/step-size-continues-to-change-during-the-sampling-period-when-stepsize-1/

#1193 introduced what looks like a copy paste error I missed in review where the `jitter` argument was set to the value of the `stepsize` argument. 

#### Intended Effect:

Resolve the above bug

#### How to Verify:

See examples on forum

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
