### PR TITLE
Fix: issue with GQ arg checks, const ref string passing

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -205,11 +205,11 @@ int command(int argc, const char *argv[]) {
       = get_vec_var_context(init, num_chains, id);
 
   if (get_arg_val<bool_argument>(parser, "output", "save_cmdstan_config")) {
-    auto filename = get_basename_suffix(
-                        get_arg_val<string_argument>(parser, "output", "file"))
-                        .first
-                    + "_config.json";
-    auto ofs_args = std::make_unique<std::ofstream>(filename);
+    auto config_filename = get_basename_suffix(get_arg_val<string_argument>(
+                                                   parser, "output", "file"))
+                               .first
+                           + "_config.json";
+    auto ofs_args = std::make_unique<std::ofstream>(config_filename);
     if (sig_figs > -1) {
       ofs_args->precision(sig_figs);
     }

--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -47,7 +47,7 @@ inline constexpr auto get_arg_pointer(T &&x) {
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
-                                      Args &&...args) {
+                                      Args &&... args) {
   return get_arg_pointer(arg_list->arg(arg1), args...);
 }
 
@@ -63,7 +63,7 @@ inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg(List &&arg_list, const char *arg1,
-                              Args &&...args) {
+                              Args &&... args) {
   return internal::get_arg_pointer(arg_list.arg(arg1), args...);
 }
 
@@ -94,7 +94,7 @@ inline constexpr auto get_arg_val(Arg &&argument, const char *arg_name) {
  * @param args A parameter pack of names of arguments to index into
  */
 template <typename caster, typename List, typename... Args>
-inline constexpr auto get_arg_val(List &&arg_list, Args &&...args) {
+inline constexpr auto get_arg_val(List &&arg_list, Args &&... args) {
   auto *x = get_arg(arg_list, args...);
   if (x != nullptr) {
     return dynamic_cast<std::decay_t<caster> *>(x)->value();
@@ -147,7 +147,7 @@ std::pair<std::string, std::string> get_basename_suffix(
  * @param fname name of file which exists and has read perms.
  * @return input stream
  */
-std::ifstream safe_open(const std::string& fname) {
+std::ifstream safe_open(const std::string &fname) {
   std::ifstream stream(fname.c_str());
   if (fname != "" && (stream.rdstate() & std::ifstream::failbit)) {
     std::stringstream msg;

--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -47,7 +47,7 @@ inline constexpr auto get_arg_pointer(T &&x) {
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
-                                      Args &&... args) {
+                                      Args &&...args) {
   return get_arg_pointer(arg_list->arg(arg1), args...);
 }
 
@@ -63,7 +63,7 @@ inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg(List &&arg_list, const char *arg1,
-                              Args &&... args) {
+                              Args &&...args) {
   return internal::get_arg_pointer(arg_list.arg(arg1), args...);
 }
 
@@ -94,7 +94,7 @@ inline constexpr auto get_arg_val(Arg &&argument, const char *arg_name) {
  * @param args A parameter pack of names of arguments to index into
  */
 template <typename caster, typename List, typename... Args>
-inline constexpr auto get_arg_val(List &&arg_list, Args &&... args) {
+inline constexpr auto get_arg_val(List &&arg_list, Args &&...args) {
   auto *x = get_arg(arg_list, args...);
   if (x != nullptr) {
     return dynamic_cast<std::decay_t<caster> *>(x)->value();
@@ -147,7 +147,7 @@ std::pair<std::string, std::string> get_basename_suffix(
  * @param fname name of file which exists and has read perms.
  * @return input stream
  */
-std::ifstream safe_open(const std::string fname) {
+std::ifstream safe_open(const std::string& fname) {
   std::ifstream stream(fname.c_str());
   if (fname != "" && (stream.rdstate() & std::ifstream::failbit)) {
     std::stringstream msg;
@@ -724,13 +724,13 @@ void check_file_config(argument_parser &parser) {
       throw std::invalid_argument(
           std::string("Argument fitted_params file - found empty string, "
                       "expecting filename."));
-      if (input_file.compare(sample_file) == 0) {
-        std::stringstream msg;
-        msg << "Filename conflict, fitted_params file " << input_file
-            << " and output file names are identical, must be different."
-            << std::endl;
-        throw std::invalid_argument(msg.str());
-      }
+    }
+    if (input_file.compare(sample_file) == 0) {
+      std::stringstream msg;
+      msg << "Filename conflict, fitted_params file " << input_file
+          << " and output file names are identical, must be different."
+          << std::endl;
+      throw std::invalid_argument(msg.str());
     }
   } else if (user_method->arg("laplace")) {
     std::string input_file
@@ -739,13 +739,13 @@ void check_file_config(argument_parser &parser) {
       throw std::invalid_argument(
           std::string("Argument mode file - found empty string, "
                       "expecting filename."));
-      if (input_file.compare(sample_file) == 0) {
-        std::stringstream msg;
-        msg << "Filename conflict, parameter modes file " << input_file
-            << " and output file names are identical, must be different."
-            << std::endl;
-        throw std::invalid_argument(msg.str());
-      }
+    }
+    if (input_file.compare(sample_file) == 0) {
+      std::stringstream msg;
+      msg << "Filename conflict, parameter modes file " << input_file
+          << " and output file names are identical, must be different."
+          << std::endl;
+      throw std::invalid_argument(msg.str());
     }
   }
 }

--- a/src/cmdstan/write_model.hpp
+++ b/src/cmdstan/write_model.hpp
@@ -5,7 +5,7 @@
 #include <string>
 
 namespace cmdstan {
-void write_model(stan::callbacks::writer &writer,
+void write_model(stan::callbacks::writer& writer,
                  const std::string& model_name) {
   writer("model = " + model_name);
 }

--- a/src/cmdstan/write_model.hpp
+++ b/src/cmdstan/write_model.hpp
@@ -6,7 +6,7 @@
 
 namespace cmdstan {
 void write_model(stan::callbacks::writer &writer,
-                 const std::string model_name) {
+                 const std::string& model_name) {
   writer("model = " + model_name);
 }
 }  // namespace cmdstan


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This fixes a couple issues which came up as warnings for me:

- the argument checking for GQ had a mismatched if-else which lead to one of the conditionals never being checked
- a few places we were passing std::strings by value where a const ref would work

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
