### PR TITLE
Makefile: TBB is a dependency of bin helpers

### DIFF
--- a/make/command
+++ b/make/command
@@ -2,13 +2,13 @@ ifeq ($(CMDSTAN_SUBMODULES),1)
 bin/cmdstan/stansummary.o : src/cmdstan/stansummary_helper.hpp
 bin/cmdstan/%.o : src/cmdstan/%.cpp
 	@mkdir -p $(dir $@)
-	$(COMPILE.cpp) -fvisibility=hidden $(OUTPUT_OPTION) $(LDLIBS) $<
+	$(COMPILE.cpp) -fvisibility=hidden $< $(OUTPUT_OPTION)
 
 .PRECIOUS: bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE)
 bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : CPPFLAGS_MPI =
 bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : LDFLAGS_MPI =
 bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : LDLIBS_MPI =
-bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : bin/%$(EXE) : bin/cmdstan/%.o
+bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : bin/%$(EXE) : bin/cmdstan/%.o $(TBB_TARGETS)
 	@mkdir -p $(dir $@)
 	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Currently, running `make bin/stansummary` without first running `make build` fails, because these link TBB but do not have it marked as a dependency.

This can, rarely, cause `make build` to fail, like in CI here: https://jenkins.flatironinstitute.org/blue/organizations/jenkins/Stan%2FStan/detail/downstream_tests/366/pipeline

#### Intended Effect:

Fix `make bin/stansummary`

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
