### PR TITLE
Use stringstream to format default values

### DIFF
--- a/src/cmdstan/arguments/arg_single_real_bounded.hpp
+++ b/src/cmdstan/arguments/arg_single_real_bounded.hpp
@@ -3,6 +3,7 @@
 
 #include <cmdstan/arguments/singleton_argument.hpp>
 #include <string>
+#include <sstream>
 
 /** Generic bounded real value argument */
 
@@ -21,7 +22,10 @@ class arg_single_real_bounded : public real_argument {
     _validity
         = std::to_string(lb).append(" <= ").append(name).append(" <= ").append(
             std::to_string(ub));
-    _default = std::to_string(def);
+
+    std::stringstream def_ss;
+    def_ss << def;
+    _default = def_ss.str();
     _default_value = def;
     _value = _default_value;
     _lb = lb;

--- a/src/cmdstan/arguments/arg_single_real_pos.hpp
+++ b/src/cmdstan/arguments/arg_single_real_pos.hpp
@@ -3,6 +3,7 @@
 
 #include <cmdstan/arguments/singleton_argument.hpp>
 #include <string>
+#include <sstream>
 
 /** Generic pos real value argument */
 
@@ -15,7 +16,10 @@ class arg_single_real_pos : public real_argument {
     _name = name;
     _description = desc;
     _validity = std::string("0 < ").append(name);
-    _default = std::to_string(def);
+
+    std::stringstream def_ss;
+    def_ss << def;
+    _default = def_ss.str();
     _default_value = def;
     _value = _default_value;
   }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

We use `std::to_string` to format default values (since #1172) but this does not print floating point numbers in scientific notation when required, see the [example on cppreference](https://en.cppreference.com/w/cpp/string/basic_string/to_string#Example) comparing `operator<<` and `std::to_string`

#### Intended Effect:

Closes #1214 

#### How to Verify:

`./bernoulli help-all | grep -E "tol_(obj|grad|param)=<double>" -A 3`

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
