### PR TITLE
Improve missing submodule logic

### DIFF
--- a/make/command
+++ b/make/command
@@ -1,4 +1,3 @@
-ifeq ($(CMDSTAN_SUBMODULES),1)
 bin/cmdstan/stansummary.o : src/cmdstan/stansummary_helper.hpp
 bin/cmdstan/%.o : src/cmdstan/%.cpp
 	@mkdir -p $(dir $@)
@@ -11,5 +10,3 @@ bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : LDLIBS_MPI =
 bin/print$(EXE) bin/stansummary$(EXE) bin/diagnose$(EXE) : bin/%$(EXE) : bin/cmdstan/%.o $(TBB_TARGETS)
 	@mkdir -p $(dir $@)
 	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)
-
-endif

--- a/make/stanc
+++ b/make/stanc
@@ -9,7 +9,6 @@ endef
 
 # if nothing was set to $(OS) that means that the Stan Math submodule is missing
 OS ?= missing-submodules
-CMDSTAN_SUBMODULES = 1
 STANC_DL_RETRY = 5
 STANC_DL_DELAY = 10
 STANC3_TEST_BIN_URL ?=
@@ -38,14 +37,11 @@ else ifeq ($(OS),Linux)
   endif
  endif
 
-else ifeq ($(OS),missing-submodules)
- CMDSTAN_SUBMODULES = 0
 else
   $(error  Cannot detect OS properly. $n This will impede automatically downloading the correct stanc. $n Please visit https://github.com/stan-dev/stanc3/releases and download a stanc binary for your OS and place it in ./bin/stanc. $n )
 endif
 
-# bin/stanc build rules - requires stan, stan_math submodules in place
-ifeq ($(CMDSTAN_SUBMODULES),1)
+# bin/stanc build rules
 ifneq ($(STANC3),)
   # build stanc3 from local installation
   bin/stanc$(EXE) : $(call findfiles,$(STANC3)/src/,*.ml*) $(STANC#)
@@ -90,6 +86,5 @@ else
 	@mkdir -p $(dir $@)
 	curl -L https://github.com/stan-dev/stanc3/releases/download/$(STANC3_VERSION)/$(OS_TAG)$(ARCH_TAG)-stanc -o bin/stanc$(EXE) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
 	chmod +x bin/stanc$(EXE)
-endif
 endif
 # end bin/stanc build rules

--- a/makefile
+++ b/makefile
@@ -141,9 +141,9 @@ else
 PRECOMPILED_MODEL_HEADER=
 endif
 
--include $(MATH)make/compiler_flags
--include $(MATH)make/dependencies
--include $(MATH)make/libraries
+include $(MATH)make/compiler_flags
+include $(MATH)make/dependencies
+include $(MATH)make/libraries
 include make/stanc
 include make/program
 include make/tests
@@ -262,7 +262,6 @@ build-mpi: $(MPI_TARGETS)
 	@echo ''
 	@echo '--- boost mpi bindings built ---'
 
-ifeq ($(CMDSTAN_SUBMODULES),1)
 .PHONY: build
 build: bin/stanc$(EXE) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS) $(CMDSTAN_MAIN_O) $(PRECOMPILED_MODEL_HEADER) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE)
 	@echo ''
@@ -275,17 +274,6 @@ ifeq ($(OS),Windows_NT)
 		@echo 'to automatically update your user configuration.'
 endif
 	@echo '--- CmdStan v$(CMDSTAN_VERSION) built ---'
-else
-.PHONY: build
-build:
-	@echo 'ERROR: Missing Stan submodules.'
-	@echo 'Please run the following to fix:'
-	@echo ''
-	@echo 'git submodule update --init --recursive'
-	@echo ''
-	@echo 'And try building again'
-	@exit 1
-endif
 
 .PHONY: install-tbb
 install-tbb: $(TBB_TARGETS)
@@ -352,3 +340,20 @@ print-%  : ; @echo $* = $($*)
 
 .PHONY: clean-build
 clean-build: clean-all build
+
+
+##
+# This is only run if the `include` statements earlier fail to find a file.
+# We assume that means the submodule is missing
+##
+$(MATH)make/% :
+	@echo 'ERROR: Missing Stan submodules.'
+	@echo 'We tried to find the Stan Math submodule at:'
+	@echo '  $(MATH)'
+	@echo ''
+	@echo 'The most likely source of the problem is CmdStan was cloned without'
+	@echo 'the --recursive flag.  To fix this, run the following command:'
+	@echo '  git submodule update --init --recursive'
+	@echo ''
+	@echo 'And try building again'
+	@exit 1


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Implements the suggestions in #1216 to improve the error users see if they are missing the math submodule

#### Intended Effect:

The error goes from:

```shell
$ make examples/bernoulli/bernoulli

--- Compiling the main object file. This might take up to a minute. ---
g++    -c -o src/cmdstan/main.o src/cmdstan/main.cpp
src/cmdstan/main.cpp:1:10: fatal error: cmdstan/command.hpp: No such file or directory
    1 | #include <cmdstan/command.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [make/program:14: src/cmdstan/main.o] Error 1
```

to 

```shell
$ make examples/bernoulli/bernoulli
ERROR: Missing Stan submodules.
We tried to find the Stan Math submodule at:
  stan/lib/stan_math/

The most likely source of the problem is CmdStan was cloned without
the --recursive flag.  To fix this, run the following command:
  git submodule update --init --recursive

And try building again
makefile:31: stan/lib/stan_math/make/libraries: No such file or directory
make: *** [makefile:361: stan/lib/stan_math/make/libraries] Error 1
```

#### How to Verify:

Check out without the submodules

#### Side Effects:

By making these hard-includes, some debugging gets a bit harder (e.g., the `make print-*` commands fail). I tried to mitigate this by including the MATH path in the error that gets shown

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
