### PR TITLE
Properly re-build main.o when threading, etc enabled

### DIFF
--- a/make/program
+++ b/make/program
@@ -79,6 +79,9 @@ ifeq (,$(findstring tbb.dll, $(notdir $(shell where tbb.dll))))
 endif
 endif
 
+$(patsubst %.cpp,%$(STAN_FLAGS).d,$(CMDSTAN_MAIN)) : $(CMDSTAN_MAIN)
+	$(COMPILE.cpp) $(DEPFLAGS) $<
+
 ##
 # Dependencies file
 ##


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

The automatically generated `.d` files were not previously working for our main object file when a flag like STAN_THREADS=true was set. 

We're doing very nearly the same thing with the precompiled header already

#### Intended Effect:

Closes #998 

#### How to Verify:

- build bernoulli with STAN_THREADS
- edit a file in cmdstan's source directory
- re-run the same make command as step 1, see that a rebuild is triggered

#### Side Effects:

None

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
