### PR TITLE
Prevent pathfinder when 0 parameters, warn if too many PSIS requested

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -306,6 +306,18 @@ int command(int argc, const char *argv[]) {
     int num_draws = get_arg_val<int_argument>(*pathfinder_arg, "num_draws");
     int num_psis_draws
         = get_arg_val<int_argument>(*pathfinder_arg, "num_psis_draws");
+
+    if (num_psis_draws > num_draws * num_chains) {
+      logger.warn(
+          "Warning: Number of PSIS draws is larger than the total number of "
+          "draws returned by the single Pathfinders. This is likely "
+          "unintentional and leads to re-sampling from the same draws.");
+    }
+    if (model.num_params_r() == 0) {
+      throw std::invalid_argument(
+          "Model has 0 parameters, cannot run Pathfinder.");
+    }
+
     if (num_chains == 1) {
       save_single_paths = save_single_paths || !diagnostic_file.empty();
       return_code = stan::services::pathfinder::pathfinder_lbfgs_single<

--- a/src/test/interface/pathfinder_test.cpp
+++ b/src/test/interface/pathfinder_test.cpp
@@ -17,6 +17,7 @@ class CmdStan : public testing::Test {
     eight_schools_model = {"src", "test", "test-models", "eight_schools"};
     eight_schools_data
         = {"src", "test", "test-models", "eight_schools.data.json"};
+    empty_model = {"src", "test", "test-models", "empty"};
     arg_output = {"test", "output"};
     arg_diags = {"test", "diagnostics"};
     output_csv = {"test", "output.csv"};
@@ -38,6 +39,7 @@ class CmdStan : public testing::Test {
   std::vector<std::string> multi_normal_model;
   std::vector<std::string> eight_schools_model;
   std::vector<std::string> eight_schools_data;
+  std::vector<std::string> empty_model;
   std::vector<std::string> arg_output;
   std::vector<std::string> arg_diags;
   std::vector<std::string> output_csv;
@@ -240,4 +242,22 @@ TEST_F(CmdStan, pathfinder_lbfgs_iterations) {
                output.end());
   EXPECT_EQ(1, count_matches("\"3\":{\"iter\":3,", output));
   EXPECT_EQ(0, count_matches("\"4\":{\"iter\":4,", output));
+}
+
+TEST_F(CmdStan, pathfinder_empty_model) {
+  std::stringstream ss;
+  ss << convert_model_path(empty_model) << " method=pathfinder";
+  run_command_output out = run_command(ss.str());
+  ASSERT_TRUE(out.hasError);
+  EXPECT_EQ(1, count_matches("Model has 0 parameters", out.output));
+}
+
+TEST_F(CmdStan, pathfinder_too_many_PSIS_draws) {
+  std::stringstream ss;
+  ss << convert_model_path(multi_normal_model) << " method=pathfinder"
+     << " num_paths=1 num_draws=10 num_psis_draws=11";
+  run_command_output out = run_command(ss.str());
+  ASSERT_FALSE(out.hasError);
+  EXPECT_EQ(
+      1, count_matches("Warning: Number of PSIS draws is larger", out.output));
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Closes #1208: warning when more PSIS draws are requested than total number of draws from single-pathfinders
Closes #1220: disallows pathfinder when the model has no parameters.

Arguably these could be put in the stan-dev/stan repo. I'm open to either

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation
By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
