### PR TITLE
Replace usage of killOldBuilds with disableConcurrentBuilds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,10 @@ String branchName() { isPR() ? env.CHANGE_BRANCH :env.BRANCH_NAME }
 
 pipeline {
     agent none
-    options { skipDefaultCheckout() }
+    options {
+        skipDefaultCheckout()
+        disableConcurrentBuilds(abortPrevious: true)
+    }
     parameters {
         string(defaultValue: '', name: 'stan_pr',
                description: "Stan PR to test against. Will check out this PR in the downstream Stan repo.")
@@ -67,14 +70,6 @@ pipeline {
         GIT_COMMITTER_EMAIL = 'mc.stanislaw@gmail.com'
     }
     stages {
-        stage('Kill previous builds') {
-            when {
-                not { branch 'develop' }
-                not { branch 'master' }
-                not { branch 'downstream_tests' }
-            }
-            steps { script { utils.killOldBuilds() } }
-        }
         stage('Clean & Setup') {
             agent {
                 docker {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
     agent none
     options {
         skipDefaultCheckout()
-        disableConcurrentBuilds(abortPrevious: true)
+        disableConcurrentBuilds(abortPrevious: env.BRANCH_NAME != "downstream_tests" || env.BRANCH_NAME != "downstream_hotfix")
     }
     parameters {
         string(defaultValue: '', name: 'stan_pr',


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:

Due to some Jenkins changes, we have to migrate away from the old way of killing concurrent builds.


#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
