### PR TITLE
Add version header for CmdStan

### DIFF
--- a/src/cmdstan/version.hpp
+++ b/src/cmdstan/version.hpp
@@ -1,0 +1,31 @@
+#ifndef CMDSTAN_VERSION_HPP
+#define CMDSTAN_VERSION_HPP
+
+#include <string>
+
+#ifndef STAN_STRING_EXPAND
+#define STAN_STRING_EXPAND(s) #s
+#endif
+
+#ifndef STAN_STRING
+#define STAN_STRING(s) STAN_STRING_EXPAND(s)
+#endif
+
+#define CMDSTAN_MAJOR 2
+#define CMDSTAN_MINOR 33
+#define CMDSTAN_PATCH 1
+
+namespace cmdstan {
+
+/** Major version number for CmdStan package. */
+const std::string MAJOR_VERSION = STAN_STRING(CMDSTAN_MAJOR);
+
+/** Minor version number for CmdStan package. */
+const std::string MINOR_VERSION = STAN_STRING(CMDSTAN_MINOR);
+
+/** Patch version for CmdStan package. */
+const std::string PATCH_VERSION = STAN_STRING(CMDSTAN_PATCH);
+
+}  // namespace cmdstan
+
+#endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This PR adds a `version.hpp` header following the conventions of the [Stan](https://github.com/stan-dev/stan/blob/develop/src/stan/version.hpp) and [Math](https://github.com/stan-dev/math/blob/develop/stan/math/version.hpp) libraries

#### Intended Effect:

The CmdStan version is currently only recorded in the [Makefile](https://github.com/stan-dev/cmdstan/blob/2a9a6be331519d0f66c5e0a600070f372774c8fe/makefile#L152), which means that any downstream users need to also include the makefiles in order to identify the version of the CmdStan headers & sources.

This allows downstream users to identify the version of the CmdStan headers/sources without needing to include & parse the makefile, improves consistency with the Stan & Math libraries

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
