### PR TITLE
Stop swallowing exceptions in log_prob method

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -433,6 +433,9 @@ int command(int argc, const char *argv[]) {
                              sample_writers[0].get_stream());
       return_code = return_codes::OK;
     } catch (const std::exception &e) {
+      msg << "Error during log_prob calculation:" << std::endl;
+      msg << e.what() << std::endl;
+      logger.error(msg.str());
       return_code = return_codes::NOT_OK;
     }
     // ---- log_prob end ---- //


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

If the model throws an exception, currently `log_prob` gives no output to indicate this. 

#### Intended Effect:

The exception message is now printed.

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
