### PR TITLE
Check string is nonempty before indexing

### DIFF
--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -209,9 +209,10 @@ std::pair<std::string, std::string> get_basename_suffix(
  */
 void validate_output_filename(const std::string &fname) {
   std::string sep = std::string(1, cmdstan::PATH_SEPARATOR);
-  if (fname[fname.size() - 1] == PATH_SEPARATOR
-      || boost::algorithm::ends_with(fname, "..")
-      || boost::algorithm::ends_with(fname, sep + ".")) {
+  if (!fname.empty()
+      && (fname[fname.size() - 1] == PATH_SEPARATOR
+          || boost::algorithm::ends_with(fname, "..")
+          || boost::algorithm::ends_with(fname, sep + "."))) {
     std::stringstream msg;
     msg << "Ill-formed output filename " << fname << std::endl;
     throw std::invalid_argument(msg.str());


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Resolves #1238. An unchecked indexing operation on an empty string introduced by #1228 causes a crash if compiled with `-Wp,-D_GLIBCXX_ASSERTIONS`, and possibly under other conditions

#### Intended Effect:

Resolves the crash

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
