### PR TITLE
Format double arguments with std::stringstream

### DIFF
--- a/src/cmdstan/arguments/singleton_argument.hpp
+++ b/src/cmdstan/arguments/singleton_argument.hpp
@@ -3,6 +3,7 @@
 
 #include <cmdstan/arguments/valued_argument.hpp>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -29,6 +30,14 @@ void from_string(std::string &src, bool &dest) {
 void from_string(std::string &src, std::string &dest) { dest = src; }
 
 std::string to_string(std::string &src) { return src; }
+
+std::string to_string(double &src) {
+  // better handling of precision than std::to_string
+  std::stringstream ss;
+  ss << src;
+  return ss.str();
+ }
+
 template <typename T>
 std::string to_string(T &src) {
   return std::to_string(src);

--- a/src/cmdstan/arguments/singleton_argument.hpp
+++ b/src/cmdstan/arguments/singleton_argument.hpp
@@ -36,7 +36,7 @@ std::string to_string(double &src) {
   std::stringstream ss;
   ss << src;
   return ss.str();
- }
+}
 
 template <typename T>
 std::string to_string(T &src) {


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes #1242 

#### Intended Effect:

The example in #1242 now prints:
```
$ ./bernoulli optimize algorithm=lbfgs tol_obj=1e-11 data file=bernoulli.data.json
method = optimize
  optimize
    algorithm = lbfgs (Default)
      lbfgs
        init_alpha = 0.001 (Default)
        tol_obj = 1e-11
```

#### How to Verify:
Run the above

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
