### PR TITLE
Implement calculate_lp, diagnostic args for laplace

### DIFF
--- a/src/cmdstan/arguments/arg_laplace.hpp
+++ b/src/cmdstan/arguments/arg_laplace.hpp
@@ -21,11 +21,15 @@ class arg_laplace : public categorical_argument {
         ""));
     _subarguments.push_back(
         new arg_single_bool("jacobian",
-                            "When true, include change-of-variables adjustment"
-                            " for constraining parameter transforms",
+                            "When true, include change-of-variables adjustment "
+                            "for constraining parameter transforms.",
                             true));
     _subarguments.push_back(new arg_single_int_nonneg(
         "draws", "Number of draws from the laplace approximation", 1000));
+    _subarguments.push_back(new arg_single_bool(
+        "calculate_lp",
+        "If true, calculate the log probability of the model at each draw.",
+        true));
   }
 };
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Exposes new arguments for `laplace` from https://github.com/stan-dev/stan/pull/3261.

`calculate_lp` is a boolean subarg of `laplace` which controls whether or not log_prob is called for each approximate draw. Default is true (existing behavior).

For the hessian and other information, I re-used the `diagnostic_file` argument of output. This matches with e.g. the JSON outputs of Pathfinder, but if we want a dedicated argument I can add one.

#### Intended Effect:

Expose new arguments to the `laplace` sample algorithm

#### How to Verify:

These are tested in the Stan implementation. I can add more here if desired.

#### Side Effects:

#### Documentation:

TBD

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
