### PR TITLE
Move file-related helpers to own file, set badbit exceptions on ofstreams

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -279,11 +279,8 @@ int command(int argc, const char *argv[]) {
 
   if (get_arg_val<bool_argument>(parser, "output", "save_cmdstan_config")) {
     auto config_filename
-        = get_basename_suffix(output_file).first + "_config.json";
-    auto ofs_args = std::make_unique<std::ofstream>(config_filename);
-    if (sig_figs > -1) {
-      ofs_args->precision(sig_figs);
-    }
+        = file::get_basename_suffix(output_file).first + "_config.json";
+    auto ofs_args = file::safe_create(config_filename, sig_figs);
     stan::callbacks::json_writer<std::ostream> json_args(std::move(ofs_args));
     write_config(json_args, parser, model);
   }
@@ -345,10 +342,8 @@ int command(int argc, const char *argv[]) {
           save_single_paths, refresh, interrupt, logger, init_writer,
           sample_writers[0], diagnostic_json_writers[0], calculate_lp);
     } else {
-      auto output_filenames = make_filenames(output_file, "", ".csv", 1, id);
-      auto ofs = std::make_unique<std::ofstream>(output_filenames[0]);
-      if (sig_figs > -1)
-        ofs->precision(sig_figs);
+      auto output_filenames = file::make_filenames(output_file, "", ".csv", 1, id);
+      auto ofs = file::safe_create(output_filenames[0], sig_figs);
       stan::callbacks::unique_stream_writer<std::ofstream> pathfinder_writer(
           std::move(ofs), "# ");
       write_config(pathfinder_writer, parser, model);
@@ -427,7 +422,7 @@ int command(int argc, const char *argv[]) {
       params_r_ind = get_uparams_r(upars_file, model);
     } else if (cpars_file.length() > 0) {
       std::vector<std::string> param_names = get_constrained_param_names(model);
-      if (get_suffix(cpars_file) == ".csv") {
+      if (file::get_suffix(cpars_file) == ".csv") {
         stan::io::stan_csv fitted_params;
         size_t col_offset, num_rows, num_cols;
         parse_stan_csv(cpars_file, model, param_names, fitted_params,

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -342,7 +342,8 @@ int command(int argc, const char *argv[]) {
           save_single_paths, refresh, interrupt, logger, init_writer,
           sample_writers[0], diagnostic_json_writers[0], calculate_lp);
     } else {
-      auto output_filenames = file::make_filenames(output_file, "", ".csv", 1, id);
+      auto output_filenames
+          = file::make_filenames(output_file, "", ".csv", 1, id);
       auto ofs = file::safe_create(output_filenames[0], sig_figs);
       stan::callbacks::unique_stream_writer<std::ofstream> pathfinder_writer(
           std::move(ofs), "# ");

--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -47,7 +47,7 @@ inline constexpr auto get_arg_pointer(T &&x) {
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
-                                      Args &&...args) {
+                                      Args &&... args) {
   return get_arg_pointer(arg_list->arg(arg1), args...);
 }
 
@@ -63,7 +63,7 @@ inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg(List &&arg_list, const char *arg1,
-                              Args &&...args) {
+                              Args &&... args) {
   return internal::get_arg_pointer(arg_list.arg(arg1), args...);
 }
 
@@ -99,7 +99,7 @@ inline constexpr auto get_arg_val(Arg &&argument, const char *arg_name) {
  * @param args A parameter pack of names of arguments to index into
  */
 template <typename caster, typename List, typename... Args>
-inline constexpr auto get_arg_val(List &&arg_list, Args &&...args) {
+inline constexpr auto get_arg_val(List &&arg_list, Args &&... args) {
   auto *x = get_arg(arg_list, args...);
   if (x != nullptr) {
     return dynamic_cast<std::decay_t<caster> *>(x)->value();
@@ -107,8 +107,6 @@ inline constexpr auto get_arg_val(List &&arg_list, Args &&...args) {
     throw std::invalid_argument("encountered nullptr");
   }
 }
-
-
 
 using shared_context_ptr = std::shared_ptr<stan::io::var_context>;
 /**
@@ -193,7 +191,8 @@ context_vector get_vec_var_context(const std::string &file, size_t num_chains,
           << std::endl;
     }
 
-    auto filenames = file::make_filenames(file_name, "", file_ending, num_chains, id);
+    auto filenames
+        = file::make_filenames(file_name, "", file_ending, num_chains, id);
     auto &file_1 = filenames[0];
     std::fstream stream_1(file_1.c_str(), std::fstream::in);
     // if file_1 exists we'll assume num_chains of these files exist
@@ -696,7 +695,7 @@ template <typename T, typename... Ts>
 void init_filestream_writers(std::vector<T> &writers, unsigned int num_chains,
                              unsigned int id, std::string &filename,
                              std::string tag, std::string suffix, int sig_figs,
-                             Ts &&...args) {
+                             Ts &&... args) {
   writers.reserve(num_chains);
   auto filenames = file::make_filenames(filename, tag, suffix, num_chains, id);
 

--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -3,6 +3,7 @@
 
 #include <cmdstan/arguments/argument_parser.hpp>
 #include <cmdstan/arguments/arg_sample.hpp>
+#include <cmdstan/file.hpp>
 #include <stan/callbacks/unique_stream_writer.hpp>
 #include <stan/callbacks/json_writer.hpp>
 #include <stan/callbacks/writer.hpp>
@@ -46,7 +47,7 @@ inline constexpr auto get_arg_pointer(T &&x) {
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
-                                      Args &&... args) {
+                                      Args &&...args) {
   return get_arg_pointer(arg_list->arg(arg1), args...);
 }
 
@@ -62,7 +63,7 @@ inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg(List &&arg_list, const char *arg1,
-                              Args &&... args) {
+                              Args &&...args) {
   return internal::get_arg_pointer(arg_list.arg(arg1), args...);
 }
 
@@ -98,7 +99,7 @@ inline constexpr auto get_arg_val(Arg &&argument, const char *arg_name) {
  * @param args A parameter pack of names of arguments to index into
  */
 template <typename caster, typename List, typename... Args>
-inline constexpr auto get_arg_val(List &&arg_list, Args &&... args) {
+inline constexpr auto get_arg_val(List &&arg_list, Args &&...args) {
   auto *x = get_arg(arg_list, args...);
   if (x != nullptr) {
     return dynamic_cast<std::decay_t<caster> *>(x)->value();
@@ -107,134 +108,7 @@ inline constexpr auto get_arg_val(List &&arg_list, Args &&... args) {
   }
 }
 
-#if defined(WIN32) || defined(_WIN32) \
-    || defined(__WIN32) && !defined(__CYGWIN__)
-constexpr char PATH_SEPARATOR = '\\';
-#else
-constexpr char PATH_SEPARATOR = '/';
-#endif
 
-/**
- * Distinguish between dot char '.' used as suffix sep
- * and relative filepaths '.' and '..'
- */
-bool valid_dot_suffix(char prev, char current, char next) {
-  if (current != '.') {
-    return false;
-  }
-  if (prev == '\0' || next == '\0') {
-    return false;
-  }
-  if (prev == '.' || next == '.') {
-    return false;
-  }
-  if (prev == PATH_SEPARATOR || next == PATH_SEPARATOR) {
-    return false;
-  }
-  return true;
-}
-
-/**
- * Find start of filename suffix, if any.
- * Start search from end of string, quit at first path separator.
- *
- * @return index of suffix separator '.' , or std::string::npos if not found.
- */
-size_t find_dot_suffix(const std::string &input) {
-  if (input.empty()) {
-    return std::string::npos;
-  }
-  for (size_t i = input.size() - 1; i != 0; --i) {
-    if (input[i] == PATH_SEPARATOR)
-      return std::string::npos;
-    char prev = i < input.size() - 1 ? input[i + 1] : '\0';
-    char next = i > 0 ? input[i - 1] : '\0';
-    if (valid_dot_suffix(next, input[i], prev)) {
-      return i;
-    }
-  }
-  return std::string::npos;
-}
-
-/**
- * Get suffix
- *
- * @param filename
- * @return suffix
- */
-std::string get_suffix(const std::string &name) {
-  if (name.empty())
-    return "";
-  std::string filename = name;
-  size_t idx = name.find_last_of(PATH_SEPARATOR);
-  if (idx < name.size())
-    filename = name.substr(idx);
-  idx = find_dot_suffix(filename);
-  if (idx > filename.size())
-    return std::string();
-  else
-    return filename.substr(idx);
-}
-
-/**
- * Split name on last "." with at least one following char.
- * If suffix is good, return pair base, suffix including initial '.'.
- * Else return pair base, empty string.
- *
- * @param filename - name to split
- * @return pair of strings {base, suffix}
- */
-std::pair<std::string, std::string> get_basename_suffix(
-    const std::string &name) {
-  std::string base;
-  std::string suffix;
-  if (!name.empty()) {
-    suffix = get_suffix(name);
-    if (suffix.size() > 1) {
-      base = name.substr(0, name.size() - suffix.size());
-    } else {
-      base = name;
-      suffix = "";
-    }
-  }
-  return {base, suffix};
-}
-
-/**
- * Check that output filename isn't a directory name
- * or relative dir path.
- * Throws exception if output filename is invalid.
- *
- * @param fname candidate output filename
- */
-void validate_output_filename(const std::string &fname) {
-  std::string sep = std::string(1, cmdstan::PATH_SEPARATOR);
-  if (!fname.empty()
-      && (fname[fname.size() - 1] == PATH_SEPARATOR
-          || boost::algorithm::ends_with(fname, "..")
-          || boost::algorithm::ends_with(fname, sep + "."))) {
-    std::stringstream msg;
-    msg << "Ill-formed output filename " << fname << std::endl;
-    throw std::invalid_argument(msg.str());
-  }
-}
-
-/**
- * Opens input stream for file.
- * Throws exception if stream cannot be opened.
- *
- * @param fname name of file which exists and has read perms.
- * @return input stream
- */
-std::ifstream safe_open(const std::string &fname) {
-  std::ifstream stream(fname.c_str());
-  if (fname != "" && (stream.rdstate() & std::ifstream::failbit)) {
-    std::stringstream msg;
-    msg << "Can't open specified file, \"" << fname << "\"" << std::endl;
-    throw std::invalid_argument(msg.str());
-  }
-  return stream;
-}
 
 using shared_context_ptr = std::shared_ptr<stan::io::var_context>;
 /**
@@ -245,8 +119,8 @@ inline shared_context_ptr get_var_context(const std::string &file) {
   if (file.empty()) {
     return std::make_shared<stan::io::empty_var_context>();
   }
-  std::ifstream stream = safe_open(file);
-  if (get_suffix(file) == ".json") {
+  std::ifstream stream = file::safe_open(file);
+  if (file::get_suffix(file) == ".json") {
     stan::json::json_data var_context(stream);
     return std::make_shared<stan::json::json_data>(var_context);
   }
@@ -258,43 +132,6 @@ inline shared_context_ptr get_var_context(const std::string &file) {
       << std::endl;
   stan::io::dump var_context(stream);
   return std::make_shared<stan::io::dump>(var_context);
-}
-
-/**
- * Construct output file names given template filename,
- * adding tags and numbers as needed for per-chain outputs.
- * Output file types are either CSV or JSON.
- * Template filenames may already contain suffix ".csv" or "json".
- *
- * @param filename output or diagnostic filename, user-specified or default.
- * @param tag distinguishing tag
- * @param type suffix string corresponding to types CSV, JSON
- * @param num_chains number of names to return
- * @param id numbering offset
- */
-std::vector<std::string> make_filenames(const std::string &filename,
-                                        const std::string &tag,
-                                        const std::string &type,
-                                        unsigned int num_chains,
-                                        unsigned int id) {
-  std::pair<std::string, std::string> base_sfx;
-  base_sfx = get_basename_suffix(filename);
-  if (type != ".csv" || base_sfx.second.empty()) {
-    base_sfx.second = type;
-  }
-
-  std::vector<std::string> names(num_chains);
-  auto name_iterator = [num_chains, id](auto i) {
-    if (num_chains == 1) {
-      return std::string("");
-    } else {
-      return std::string("_" + std::to_string(i + id));
-    }
-  };
-  for (int i = 0; i < num_chains; ++i) {
-    names[i] = base_sfx.first + tag + name_iterator(i) + base_sfx.second;
-  }
-  return names;
 }
 
 using context_vector = std::vector<shared_context_ptr>;
@@ -356,7 +193,7 @@ context_vector get_vec_var_context(const std::string &file, size_t num_chains,
           << std::endl;
     }
 
-    auto filenames = make_filenames(file_name, "", file_ending, num_chains, id);
+    auto filenames = file::make_filenames(file_name, "", file_ending, num_chains, id);
     auto &file_1 = filenames[0];
     std::fstream stream_1(file_1.c_str(), std::fstream::in);
     // if file_1 exists we'll assume num_chains of these files exist
@@ -447,7 +284,7 @@ void parse_stan_csv(const std::string &fname,
                     size_t &num_rows, size_t &num_cols) {
   std::stringstream msg;
   // parse CSV contents
-  std::ifstream stream = safe_open(fname);
+  std::ifstream stream = file::safe_open(fname);
   stan::io::stan_csv_reader::read_metadata(stream, fitted_params.metadata,
                                            &msg);
   if (!stan::io::stan_csv_reader::read_header(stream, fitted_params.header,
@@ -587,7 +424,7 @@ Eigen::VectorXd get_laplace_mode_csv(const std::string &fname,
   // parse CSV file: header comments (config), header row, single data row
   std::string line;
   bool is_optimization = false;
-  std::ifstream in = safe_open(fname);
+  std::ifstream in = file::safe_open(fname);
   while (in.peek() == '#') {
     std::getline(in, line);
     if (boost::contains(line, "method = optimize"))
@@ -659,9 +496,9 @@ Eigen::VectorXd get_laplace_mode(const std::string &fname,
                                  const stan::model::model_base &model) {
   std::stringstream msg;
   Eigen::VectorXd theta_hat;
-  if (get_suffix(fname) == ".csv") {
+  if (file::get_suffix(fname) == ".csv") {
     theta_hat = get_laplace_mode_csv(fname, model);
-  } else if (get_suffix(fname) == ".json") {
+  } else if (file::get_suffix(fname) == ".json") {
     std::vector<double> unc_params
         = unconstrain_params_var_context(fname, model);
     theta_hat
@@ -809,10 +646,10 @@ unsigned int get_num_chains(argument_parser &parser) {
 void check_file_config(argument_parser &parser) {
   std::string sample_file
       = get_arg_val<string_argument>(parser, "output", "file");
-  validate_output_filename(sample_file);
+  file::validate_output_filename(sample_file);
   std::string diagnostic_file
       = get_arg_val<string_argument>(parser, "output", "diagnostic_file");
-  validate_output_filename(diagnostic_file);
+  file::validate_output_filename(diagnostic_file);
   auto user_method = parser.arg("method");
   if (user_method->arg("generate_quantities")) {
     std::string input_file = get_arg_val<string_argument>(
@@ -859,15 +696,12 @@ template <typename T, typename... Ts>
 void init_filestream_writers(std::vector<T> &writers, unsigned int num_chains,
                              unsigned int id, std::string &filename,
                              std::string tag, std::string suffix, int sig_figs,
-                             Ts &&... args) {
+                             Ts &&...args) {
   writers.reserve(num_chains);
-  auto filenames = make_filenames(filename, tag, suffix, num_chains, id);
+  auto filenames = file::make_filenames(filename, tag, suffix, num_chains, id);
 
   for (size_t i = 0; i < num_chains; ++i) {
-    auto ofs = std::make_unique<std::ofstream>(filenames[i]);
-    if (sig_figs > -1) {
-      ofs->precision(sig_figs);
-    }
+    auto ofs = file::safe_create(filenames[i], sig_figs);
     writers.emplace_back(std::move(ofs), std::forward<Ts>(args)...);
   }
 }

--- a/src/cmdstan/file.hpp
+++ b/src/cmdstan/file.hpp
@@ -161,7 +161,6 @@ std::vector<std::string> make_filenames(const std::string &filename,
   return names;
 }
 
-
 /**
  * Opens input stream for file.
  * Throws exception if stream cannot be opened.

--- a/src/cmdstan/file.hpp
+++ b/src/cmdstan/file.hpp
@@ -1,0 +1,202 @@
+#ifndef CMDSTAN_FILE_HPP
+#define CMDSTAN_FILE_HPP
+
+#include <boost/algorithm/string.hpp>
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+#include <memory>
+
+namespace cmdstan {
+namespace file {
+
+#if defined(WIN32) || defined(_WIN32) \
+    || defined(__WIN32) && !defined(__CYGWIN__)
+constexpr char PATH_SEPARATOR = '\\';
+#else
+constexpr char PATH_SEPARATOR = '/';
+#endif
+
+/**
+ * Distinguish between dot char '.' used as suffix sep
+ * and relative filepaths '.' and '..'
+ */
+bool valid_dot_suffix(char prev, char current, char next) {
+  if (current != '.') {
+    return false;
+  }
+  if (prev == '\0' || next == '\0') {
+    return false;
+  }
+  if (prev == '.' || next == '.') {
+    return false;
+  }
+  if (prev == PATH_SEPARATOR || next == PATH_SEPARATOR) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Find start of filename suffix, if any.
+ * Start search from end of string, quit at first path separator.
+ *
+ * @return index of suffix separator '.' , or std::string::npos if not found.
+ */
+size_t find_dot_suffix(const std::string &input) {
+  if (input.empty()) {
+    return std::string::npos;
+  }
+  for (size_t i = input.size() - 1; i != 0; --i) {
+    if (input[i] == PATH_SEPARATOR)
+      return std::string::npos;
+    char prev = i < input.size() - 1 ? input[i + 1] : '\0';
+    char next = i > 0 ? input[i - 1] : '\0';
+    if (valid_dot_suffix(next, input[i], prev)) {
+      return i;
+    }
+  }
+  return std::string::npos;
+}
+
+/**
+ * Get suffix
+ *
+ * @param filename
+ * @return suffix
+ */
+std::string get_suffix(const std::string &name) {
+  if (name.empty())
+    return "";
+  std::string filename = name;
+  size_t idx = name.find_last_of(PATH_SEPARATOR);
+  if (idx < name.size())
+    filename = name.substr(idx);
+  idx = find_dot_suffix(filename);
+  if (idx > filename.size())
+    return std::string();
+  else
+    return filename.substr(idx);
+}
+
+/**
+ * Split name on last "." with at least one following char.
+ * If suffix is good, return pair base, suffix including initial '.'.
+ * Else return pair base, empty string.
+ *
+ * @param filename - name to split
+ * @return pair of strings {base, suffix}
+ */
+std::pair<std::string, std::string> get_basename_suffix(
+    const std::string &name) {
+  std::string base;
+  std::string suffix;
+  if (!name.empty()) {
+    suffix = get_suffix(name);
+    if (suffix.size() > 1) {
+      base = name.substr(0, name.size() - suffix.size());
+    } else {
+      base = name;
+      suffix = "";
+    }
+  }
+  return {base, suffix};
+}
+
+/**
+ * Check that output filename isn't a directory name
+ * or relative dir path.
+ * Throws exception if output filename is invalid.
+ *
+ * @param fname candidate output filename
+ */
+void validate_output_filename(const std::string &fname) {
+  std::string sep = std::string(1, cmdstan::file::PATH_SEPARATOR);
+  if (!fname.empty()
+      && (fname[fname.size() - 1] == PATH_SEPARATOR
+          || boost::algorithm::ends_with(fname, "..")
+          || boost::algorithm::ends_with(fname, sep + "."))) {
+    std::stringstream msg;
+    msg << "Ill-formed output filename " << fname << std::endl;
+    throw std::invalid_argument(msg.str());
+  }
+}
+
+/**
+ * Construct output file names given template filename,
+ * adding tags and numbers as needed for per-chain outputs.
+ * Output file types are either CSV or JSON.
+ * Template filenames may already contain suffix ".csv" or "json".
+ *
+ * @param filename output or diagnostic filename, user-specified or default.
+ * @param tag distinguishing tag
+ * @param type suffix string corresponding to types CSV, JSON
+ * @param num_chains number of names to return
+ * @param id numbering offset
+ */
+std::vector<std::string> make_filenames(const std::string &filename,
+                                        const std::string &tag,
+                                        const std::string &type,
+                                        unsigned int num_chains,
+                                        unsigned int id) {
+  std::pair<std::string, std::string> base_sfx;
+  base_sfx = get_basename_suffix(filename);
+  if (type != ".csv" || base_sfx.second.empty()) {
+    base_sfx.second = type;
+  }
+
+  std::vector<std::string> names(num_chains);
+  auto name_iterator = [num_chains, id](auto i) {
+    if (num_chains == 1) {
+      return std::string("");
+    } else {
+      return std::string("_" + std::to_string(i + id));
+    }
+  };
+  for (int i = 0; i < num_chains; ++i) {
+    names[i] = base_sfx.first + tag + name_iterator(i) + base_sfx.second;
+  }
+  return names;
+}
+
+
+/**
+ * Opens input stream for file.
+ * Throws exception if stream cannot be opened.
+ *
+ * @param fname name of file which exists and has read perms.
+ * @return input stream
+ */
+std::ifstream safe_open(const std::string &fname) {
+  std::ifstream stream(fname.c_str());
+  if (fname != "" && (stream.rdstate() & std::ifstream::failbit)) {
+    std::stringstream msg;
+    msg << "Can't open specified file, \"" << fname << "\"" << std::endl;
+    throw std::invalid_argument(msg.str());
+  }
+  return stream;
+}
+
+/**
+ * Opens input stream for file and sets exception flags.
+ *
+ * @param fname name of file which exists and has read perms.
+ * @param sig_figs number of digits to print
+ * @return Unique pointer to the output stream
+ */
+std::unique_ptr<std::ofstream> safe_create(const std::string &fname,
+                                           int sig_figs) {
+  auto ofs = std::make_unique<std::ofstream>(fname.c_str());
+  ofs->exceptions(std::ofstream::badbit);
+  if (sig_figs > -1) {
+    ofs->precision(sig_figs);
+  }
+  return ofs;
+}
+
+}  // namespace file
+}  // namespace cmdstan
+
+#endif

--- a/src/cmdstan/stansummary.cpp
+++ b/src/cmdstan/stansummary.cpp
@@ -254,6 +254,7 @@ Options:
     // Write to csv file (optional)
     if (app.count("--csv_filename")) {
       std::ofstream csv_file(csv_filename.c_str(), std::ios_base::app);
+      csv_file.exceptions(std::ofstream::failbit | std::ofstream::badbit);
       csv_file << std::setprecision(app.count("--sig_figs") ? sig_figs : 6);
 
       write_header(header, column_widths, max_name_length, true, &csv_file);

--- a/src/test/interface/file_test.cpp
+++ b/src/test/interface/file_test.cpp
@@ -17,13 +17,13 @@
 using cmdstan::argument;
 using cmdstan::argument_parser;
 using cmdstan::check_file_config;
-using cmdstan::get_basename_suffix;
-using cmdstan::get_suffix;
-using cmdstan::make_filenames;
-using cmdstan::validate_output_filename;
+using cmdstan::file::make_filenames;
+using cmdstan::file::get_basename_suffix;
+using cmdstan::file::get_suffix;
+using cmdstan::file::validate_output_filename;
 
 TEST(CommandHelper, basename_suffix) {
-  std::string sep = std::string(1, cmdstan::PATH_SEPARATOR);
+  std::string sep = std::string(1, cmdstan::file::PATH_SEPARATOR);
 
   std::string fp1 = "foo" + sep + "bar" + sep + "baz.csv";
   EXPECT_EQ(get_suffix(fp1), ".csv");
@@ -62,7 +62,7 @@ TEST(CommandHelper, basename_suffix) {
 }
 
 TEST(CommandHelper, validate_output_filename) {
-  std::string sep = std::string(1, cmdstan::PATH_SEPARATOR);
+  std::string sep = std::string(1, cmdstan::file::PATH_SEPARATOR);
 
   std::string fp1 = "foo.bar";
   EXPECT_NO_THROW(validate_output_filename(fp1));
@@ -78,7 +78,7 @@ TEST(CommandHelper, validate_output_filename) {
 }
 
 TEST(CommandHelper, make_filenames) {
-  std::string sep = std::string(1, cmdstan::PATH_SEPARATOR);
+  std::string sep = std::string(1, cmdstan::file::PATH_SEPARATOR);
   unsigned int num_chains = 2;
   unsigned int id = 1;
 
@@ -123,7 +123,7 @@ TEST(CommandHelper, make_filenames) {
 }
 
 TEST(CommandHelper, check_filename_config_good) {
-  std::string sep = std::string(1, cmdstan::PATH_SEPARATOR);
+  std::string sep = std::string(1, cmdstan::file::PATH_SEPARATOR);
   std::vector<std::string> argv;
   argv.push_back("my_model");
   argv.push_back("sample");
@@ -146,7 +146,7 @@ TEST(CommandHelper, check_filename_config_good) {
 }
 
 TEST(CommandHelper, check_filename_config_bad) {
-  std::string sep = std::string(1, cmdstan::PATH_SEPARATOR);
+  std::string sep = std::string(1, cmdstan::file::PATH_SEPARATOR);
 
   std::vector<std::string> argv;
   argv.push_back("my_model");
@@ -169,7 +169,7 @@ TEST(CommandHelper, check_filename_config_bad) {
 }
 
 TEST(CommandHelper, check_filename_config_bad2) {
-  std::string sep = std::string(1, cmdstan::PATH_SEPARATOR);
+  std::string sep = std::string(1, cmdstan::file::PATH_SEPARATOR);
 
   std::vector<std::string> argv;
   argv.push_back("my_model");
@@ -192,7 +192,7 @@ TEST(CommandHelper, check_filename_config_bad2) {
 }
 
 TEST(CommandHelper, check_filename_config_bad3) {
-  std::string sep = std::string(1, cmdstan::PATH_SEPARATOR);
+  std::string sep = std::string(1, cmdstan::file::PATH_SEPARATOR);
 
   std::vector<std::string> argv;
   argv.push_back("my_model");

--- a/src/test/interface/file_test.cpp
+++ b/src/test/interface/file_test.cpp
@@ -17,9 +17,9 @@
 using cmdstan::argument;
 using cmdstan::argument_parser;
 using cmdstan::check_file_config;
-using cmdstan::file::make_filenames;
 using cmdstan::file::get_basename_suffix;
 using cmdstan::file::get_suffix;
+using cmdstan::file::make_filenames;
 using cmdstan::file::validate_output_filename;
 
 TEST(CommandHelper, basename_suffix) {


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This helps break up the large `command_helper.hpp` file by moving logic involving the filesystem to its own helper.

It also wraps up some common functionality around setting up an `ofstream` for writing into a new function, and sets `badbit` so that an exception [gets thrown on by any "Read/writing error on i/o operation"](https://cplusplus.com/reference/ios/ios/exceptions/). This closes https://github.com/stan-dev/stan/issues/2536


#### Intended Effect:

Clean up command_helper, add safeguards against things like running out of disk space.

#### How to Verify:

This is harder - I don't know how to write a test which mocks the disk running out of space.

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
