### PR TITLE
Issue/1250 dont compile deprecated util print

### DIFF
--- a/makefile
+++ b/makefile
@@ -247,7 +247,7 @@ help-dev:
 	@echo ''
 	@echo 'Model related:'
 	@echo '- bin/stanc$(EXE): Download the Stan compiler binary.'
-	@echo '- bin/print$(EXE): Build the print utility. (deprecated)
+	@echo '- bin/print$(EXE): Build the print utility. (deprecated)'
 	@echo '- bin/stansummary$(EXE): Build the stansummary utility.'
 	@echo '- bin/diagnose$(EXE): Build the diagnose utility.'
 	@echo ''

--- a/makefile
+++ b/makefile
@@ -168,10 +168,9 @@ help:
 	@echo ''
 	@echo '    This target will:'
 	@echo '    1. Install the Stan compiler bin/stanc$(EXE) from stanc3 binaries.'
-	@echo '    2. Build the print utility bin/print$(EXE) (deprecated; will be removed in v3.0)'
-	@echo '    3. Build the stansummary utility bin/stansummary$(EXE)'
-	@echo '    4. Build the diagnose utility bin/diagnose$(EXE)'
-	@echo '    5. Build all libraries and object files compile and link an executable Stan program'
+	@echo '    2. Build the stansummary utility bin/stansummary$(EXE)'
+	@echo '    3. Build the diagnose utility bin/diagnose$(EXE)'
+	@echo '    4. Build all libraries and object files compile and link an executable Stan program'
 	@echo ''
 	@echo '    Note: to build using multiple cores, use the -j option to make, e.g., '
 	@echo '    for 4 cores:'
@@ -248,7 +247,7 @@ help-dev:
 	@echo ''
 	@echo 'Model related:'
 	@echo '- bin/stanc$(EXE): Download the Stan compiler binary.'
-	@echo '- bin/print$(EXE): Build the print utility. (deprecated)'
+	@echo '- bin/print$(EXE): Build the print utility. (deprecated)
 	@echo '- bin/stansummary$(EXE): Build the stansummary utility.'
 	@echo '- bin/diagnose$(EXE): Build the diagnose utility.'
 	@echo ''
@@ -263,7 +262,7 @@ build-mpi: $(MPI_TARGETS)
 	@echo '--- boost mpi bindings built ---'
 
 .PHONY: build
-build: bin/stanc$(EXE) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS) $(CMDSTAN_MAIN_O) $(PRECOMPILED_MODEL_HEADER) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE)
+build: bin/stanc$(EXE) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS) $(CMDSTAN_MAIN_O) $(PRECOMPILED_MODEL_HEADER) bin/stansummary$(EXE) bin/diagnose$(EXE)
 	@echo ''
 ifeq ($(OS),Windows_NT)
 		@echo 'NOTE: Please add $(TBB_BIN_ABSOLUTE_PATH) to your PATH variable.'


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

remove deprecated utility from CmdStan makefile target `build`

#### Intended Effect:

speed up the build process (a little)

#### How to Verify:

run:
```
make clean-all
make build
```

verify that no program `print` in  subdir `bin`.

#### Side Effects:

#### Documentation:

Makefile comments.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):   Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
