### PR TITLE
Add log_prob to list of methods that check their output doesn't clobber their input

### DIFF
--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -47,7 +47,7 @@ inline constexpr auto get_arg_pointer(T &&x) {
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
-                                      Args &&... args) {
+                                      Args &&...args) {
   return get_arg_pointer(arg_list->arg(arg1), args...);
 }
 
@@ -63,7 +63,7 @@ inline constexpr auto get_arg_pointer(List &&arg_list, const char *arg1,
  */
 template <typename List, typename... Args>
 inline constexpr auto get_arg(List &&arg_list, const char *arg1,
-                              Args &&... args) {
+                              Args &&...args) {
   return internal::get_arg_pointer(arg_list.arg(arg1), args...);
 }
 
@@ -99,7 +99,7 @@ inline constexpr auto get_arg_val(Arg &&argument, const char *arg_name) {
  * @param args A parameter pack of names of arguments to index into
  */
 template <typename caster, typename List, typename... Args>
-inline constexpr auto get_arg_val(List &&arg_list, Args &&... args) {
+inline constexpr auto get_arg_val(List &&arg_list, Args &&...args) {
   auto *x = get_arg(arg_list, args...);
   if (x != nullptr) {
     return dynamic_cast<std::decay_t<caster> *>(x)->value();
@@ -650,32 +650,28 @@ void check_file_config(argument_parser &parser) {
       = get_arg_val<string_argument>(parser, "output", "diagnostic_file");
   file::validate_output_filename(diagnostic_file);
   auto user_method = parser.arg("method");
+
+  std::string input_file_name = "";
+  std::string input_file = "";
   if (user_method->arg("generate_quantities")) {
-    std::string input_file = get_arg_val<string_argument>(
+    input_file_name = "fitted_params";
+    input_file = get_arg_val<string_argument>(
         parser, "method", "generate_quantities", "fitted_params");
-    if (input_file.empty()) {
-      throw std::invalid_argument(
-          std::string("Argument fitted_params file - found empty string, "
-                      "expecting filename."));
-    }
-    if (input_file.compare(sample_file) == 0) {
-      std::stringstream msg;
-      msg << "Filename conflict, fitted_params file " << input_file
-          << " and output file names are identical, must be different."
-          << std::endl;
-      throw std::invalid_argument(msg.str());
-    }
+
   } else if (user_method->arg("laplace")) {
-    std::string input_file
+    input_file_name = "mode";
+    input_file
         = get_arg_val<string_argument>(parser, "method", "laplace", "mode");
-    if (input_file.empty()) {
-      throw std::invalid_argument(
-          std::string("Argument mode file - found empty string, "
-                      "expecting filename."));
-    }
+  } else if (user_method->arg("log_prob")) {
+    input_file_name = "constrained_params";
+    input_file = get_arg_val<string_argument>(parser, "method", "log_prob",
+                                              "constrained_params");
+  }
+
+  if (!input_file_name.empty()) {
     if (input_file.compare(sample_file) == 0) {
       std::stringstream msg;
-      msg << "Filename conflict, parameter modes file " << input_file
+      msg << "Filename conflict, " << input_file_name << " file " << input_file
           << " and output file names are identical, must be different."
           << std::endl;
       throw std::invalid_argument(msg.str());
@@ -695,7 +691,7 @@ template <typename T, typename... Ts>
 void init_filestream_writers(std::vector<T> &writers, unsigned int num_chains,
                              unsigned int id, std::string &filename,
                              std::string tag, std::string suffix, int sig_figs,
-                             Ts &&... args) {
+                             Ts &&...args) {
   writers.reserve(num_chains);
   auto filenames = file::make_filenames(filename, tag, suffix, num_chains, id);
 

--- a/src/test/interface/log_prob_test.cpp
+++ b/src/test/interface/log_prob_test.cpp
@@ -228,3 +228,15 @@ TEST_F(CmdStan, log_prob_unconstrained_bad_input) {
   run_command_output out = run_command(cmd);
   ASSERT_TRUE(out.hasError);
 }
+
+TEST_F(CmdStan, log_prob_conflict) {
+  std::stringstream ss;
+  ss << convert_model_path(bern_log_prob_model)
+     << " data file=" << convert_model_path(bern_data)
+     << " output file=" << convert_model_path(test_output)
+     << " method=log_prob constrained_params="
+     << convert_model_path(test_output);  // << " 2>&1";
+  std::string cmd = ss.str();
+  run_command_output out = run_command(cmd);
+  ASSERT_TRUE(out.hasError);
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Similar to `generate_quantities` and `laplace`, we should prevent the same CSV from being read and written to at the same time.

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
