### PR TITLE
Improve error message when USER_HEADER is not found

### DIFF
--- a/make/program
+++ b/make/program
@@ -32,8 +32,21 @@ $(STAN_TARGETS) : %$(EXE) : $(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CX
 endif
 endif
 
-ifneq ($(findstring allow_undefined,$(STANCFLAGS))$(findstring allow-undefined,$(STANCFLAGS)),)
+ifneq ($(findstring allow-undefined,$(STANCFLAGS)),)
+
+USER_HEADER ?= $(dir $(STAN_TARGETS))user_header.hpp
 $(STAN_TARGETS) : CXXFLAGS_PROGRAM += -include $(USER_HEADER)
+##
+# Give a better error message if the USER_HEADER is not found
+##
+$(USER_HEADER):
+	@echo 'ERROR: Missing user header.'
+	@echo 'Because --allow-undefined is set, we need a C++ header file to include.'
+	@echo 'We tried to find the user header at:'
+	@echo '  $(USER_HEADER)'
+	@echo ''
+	@echo 'You can also set the USER_HEADER variable to the path of your C++ file.'
+	@exit 1
 endif
 
 ##
@@ -55,7 +68,7 @@ ifeq ($(KEEP_OBJECT), true)
 .PRECIOUS: %.o
 endif
 
-%.o : %.hpp
+%.o : %.hpp $(USER_HEADER)
 	@echo ''
 	@echo '--- Compiling C++ code ---'
 	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)

--- a/makefile
+++ b/makefile
@@ -24,7 +24,6 @@ MATH ?= $(STAN)lib/stan_math/
 RAPIDJSON ?= $(STAN)lib/rapidjson_1.1.0/
 CLI11 ?= lib/CLI11-1.9.1/
 INC_FIRST ?= -I src -I $(STAN)src -I $(RAPIDJSON) -I $(CLI11)
-USER_HEADER ?= $(dir $<)user_header.hpp
 
 ## Detect operating system
 ifneq ($(OS),Windows_NT)


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This is very similar to #1217 which added an error message for when the math submodules are not found. This improves the logic around the `USER_HEADER` variable to give an informative error when it is misspecified. 

#### Intended Effect:

Using the example [from the docs](https://mc-stan.org/docs/cmdstan-guide/external_code.html)

Before:

```
$ make examples/bernoulli/bernoulli STANCFLAGS=--allow-undefined # missing USER_HEADER=...

<command-line>: fatal error: examples/bernoulli/user_header.hpp: No such file or directory
compilation terminated.
```

After:

```
$ make examples/bernoulli/bernoulli STANCFLAGS=--allow-undefined # missing USER_HEADER=...

ERROR: Missing user header.
Because --allow-undefined is set, we need a C++ header file to include.
We tried to find the user header at:
  examples/bernoulli/user_header.hpp

You can also set the USER_HEADER variable to the path of your C++ file.
```



#### How to Verify:

Try the docs example

#### Side Effects:

This also makes it so that the model will be re-built if only the user header changes, which is great!

#### Documentation:

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
