### PR TITLE
Improve 'make clean' target

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -81,3 +81,11 @@ test/interface/print_uninitialized_test$(EXE): src/test/test-models/print_uninit
 test/interface/arguments/argument_configuration_test$(EXE): src/test/test-models/test_model$(EXE)
 test/interface/stansummary_test$(EXE): bin/stansummary$(EXE)
 test/interface/variational_output_test$(EXE): src/test/test-models/variational_output$(EXE)
+
+.PHONY: clean-tests
+clean-tests:
+	$(RM) -r test
+	$(RM) $(wildcard $(patsubst %.stan,%.d,$(TEST_MODELS)))
+	$(RM) $(wildcard $(patsubst %.stan,%.hpp,$(TEST_MODELS)))
+	$(RM) $(wildcard $(patsubst %.stan,%.o,$(TEST_MODELS)))
+	$(RM) $(wildcard $(patsubst %.stan,%$(EXE),$(TEST_MODELS)))

--- a/makefile
+++ b/makefile
@@ -278,8 +278,7 @@ endif
 ##
 .PHONY: clean clean-deps clean-all
 
-clean:
-	$(RM) -r test
+clean: clean-tests
 	$(RM) -r bin
 	@echo '  removing cached compiler objects'
 	$(RM) $(wildcard src/cmdstan/main*.o) $(wildcard $(STAN)src/stan/model/model_header*.hpp.gch)

--- a/makefile
+++ b/makefile
@@ -279,7 +279,9 @@ endif
 .PHONY: clean clean-deps clean-all
 
 clean: clean-tests
-	$(RM) -r bin
+	@echo '  removing built CmdStan utilities'
+	$(RM) bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE)
+	$(RM) -r bin/cmdstan
 	@echo '  removing cached compiler objects'
 	$(RM) $(wildcard src/cmdstan/main*.o) $(wildcard $(STAN)src/stan/model/model_header*.hpp.gch)
 	@echo '  removing built example model'

--- a/makefile
+++ b/makefile
@@ -280,10 +280,11 @@ endif
 
 clean:
 	$(RM) -r test
-	$(RM) $(wildcard $(patsubst %.stan,%.d,$(TEST_MODELS)))
-	$(RM) $(wildcard $(patsubst %.stan,%.hpp,$(TEST_MODELS)))
-	$(RM) $(wildcard $(patsubst %.stan,%.o,$(TEST_MODELS)))
-	$(RM) $(wildcard $(patsubst %.stan,%$(EXE),$(TEST_MODELS)))
+	$(RM) -r bin
+	@echo '  removing cached compiler objects'
+	$(RM) $(wildcard src/cmdstan/main*.o) $(wildcard $(STAN)src/stan/model/model_header*.hpp.gch)
+	@echo '  removing built example model'
+	$(RM) examples/bernoulli/bernoulli$(EXE) examples/bernoulli/bernoulli.o examples/bernoulli/bernoulli.d examples/bernoulli/bernoulli.hpp $(wildcard examples/bernoulli/*.csv)
 
 clean-deps:
 	@echo '  removing dependency files'
@@ -292,11 +293,6 @@ clean-deps:
 	$(RM) $(call findfiles,src,*.dSYM) $(call findfiles,src/stan,*.dSYM) $(call findfiles,$(MATH)/stan,*.dSYM)
 
 clean-all: clean clean-deps clean-libraries
-	$(RM) bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE)
-	$(RM) -r src/cmdstan/main*.o bin/cmdstan
-	$(RM) $(wildcard $(STAN)src/stan/model/model_header*.hpp.gch)
-	$(RM) examples/bernoulli/bernoulli$(EXE) examples/bernoulli/bernoulli.o examples/bernoulli/bernoulli.d examples/bernoulli/bernoulli.hpp
-	$(RM) -r $(wildcard $(BOOST)/stage/lib $(BOOST)/bin.v2 $(BOOST)/tools/build/src/engine/bootstrap/ $(BOOST)/tools/build/src/engine/bin.* $(BOOST)/project-config.jam* $(BOOST)/b2 $(BOOST)/bjam $(BOOST)/bootstrap.log)
 
 ##
 # Submodule related tasks


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This makes it so `make clean` is actually useful, and `make clean-all` needs to be run far less often. 

#### Intended Effect:

Precompiled headers and object files will be deleted by `make clean`. To delete libraries like tbb/sundials, `make clean-all` is still useful. 

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
