### PR TITLE
Fix GCC's ability to find the precompiled header

### DIFF
--- a/make/program
+++ b/make/program
@@ -28,8 +28,8 @@ $(PRECOMPILED_MODEL_HEADER) : $(STAN)src/stan/model/model_header.hpp
 	$(COMPILE.cpp) $< $(OUTPUT_OPTION)
 
 ifeq ($(CXX_TYPE),clang)
-CXXFLAGS_PROGRAM += -include-pch $(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).hpp.gch
-$(STAN_TARGETS) : %$(EXE) : $(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).hpp.gch
+CXXFLAGS_PROGRAM += -include-pch $(PRECOMPILED_MODEL_HEADER)
+$(STAN_TARGETS) : %$(EXE) : $(PRECOMPILED_MODEL_HEADER)
 endif
 endif
 

--- a/make/program
+++ b/make/program
@@ -16,14 +16,15 @@ $(CMDSTAN_MAIN_O) : $(CMDSTAN_MAIN)
 ##
 # Precompiled model header
 ##
-$(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).d : $(STAN)src/stan/model/model_header.hpp
+$(patsub %.d,%.hpp.gch,$(PRECOMPILED_MODEL_HEADER)) : $(STAN)src/stan/model/model_header.hpp
 	$(COMPILE.cpp) $(DEPFLAGS) $<
 
 ifneq ($(PRECOMPILED_MODEL_HEADER),)
-$(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).d : DEPTARGETS = -MT $(patsubst %.d,%.hpp.gch,$@) -MT $@
-$(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).hpp.gch : $(STAN)src/stan/model/model_header.hpp
+$(patsub %.d,%.hpp.gch,$(PRECOMPILED_MODEL_HEADER)) : DEPTARGETS = -MT $(patsubst %.d,%.hpp.gch,$@) -MT $@
+$(PRECOMPILED_MODEL_HEADER) : $(STAN)src/stan/model/model_header.hpp
 	@echo ''
 	@echo '--- Compiling pre-compiled header. This might take a few seconds. ---'
+	@mkdir $(dir $@)
 	$(COMPILE.cpp) $< $(OUTPUT_OPTION)
 
 ifeq ($(CXX_TYPE),clang)

--- a/makefile
+++ b/makefile
@@ -132,7 +132,7 @@ PRECOMPILED_HEADERS ?= true
 endif
 
 ifeq ($(PRECOMPILED_HEADERS),true)
-PRECOMPILED_MODEL_HEADER=$(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).hpp.gch
+PRECOMPILED_MODEL_HEADER=$(STAN)src/stan/model/model_header.hpp.gch/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).hpp.gch
 ifeq ($(CXX_TYPE),gcc)
 CXXFLAGS_PROGRAM+= -Wno-ignored-attributes $(CXXFLAGS_OPTIM) $(CXXFLAGS_FLTO)
 endif
@@ -284,6 +284,7 @@ clean: clean-tests
 	$(RM) -r bin/cmdstan
 	@echo '  removing cached compiler objects'
 	$(RM) $(wildcard src/cmdstan/main*.o) $(wildcard $(STAN)src/stan/model/model_header*.hpp.gch)
+	$(RM) -r $(STAN)src/stan/model/model_header.hpp.gch/
 	@echo '  removing built example model'
 	$(RM) examples/bernoulli/bernoulli$(EXE) examples/bernoulli/bernoulli.o examples/bernoulli/bernoulli.d examples/bernoulli/bernoulli.hpp $(wildcard examples/bernoulli/*.csv)
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

In #1171 we added the version of the C++ compiler to the precompiled header file name. This works for clang, since we have to explicitly pass `-include-pch path/to/header`, but GCC does an implicit lookup. Since the filename didn't match, it failed. 

This paragraph in the GCC manual saves us, though:

> If you need to precompile the same header file for different languages, targets, or compiler options, you can instead make a directory named like all.h.gch, and put each precompiled header in the directory, perhaps using -o. It doesn’t matter what you call the files in the directory; every precompiled header in the directory is considered. The first precompiled header encountered in the directory that is valid for this compilation is used; they’re searched in no particular order. 

So we just use that folder instead. Clang still won't care, since we're giving it the path explicitly, but gcc compile times are now back to what you'd expect. 

#### Intended Effect:

#### How to Verify:

Compile with `PRECOMPILED_HEADERS=false` and then with them enabled, compare timings. 

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
