### PR TITLE
Fix `make-clean`

### DIFF
--- a/makefile
+++ b/makefile
@@ -283,8 +283,8 @@ clean: clean-tests
 	$(RM) bin/stanc$(EXE) bin/stansummary$(EXE) bin/print$(EXE) bin/diagnose$(EXE)
 	$(RM) -r bin/cmdstan
 	@echo '  removing cached compiler objects'
-	$(RM) $(wildcard src/cmdstan/main*.o) $(wildcard $(STAN)src/stan/model/model_header*.hpp.gch)
-	$(RM) -r $(STAN)src/stan/model/model_header.hpp.gch/
+	$(RM) $(wildcard src/cmdstan/main*.o)
+	$(RM) -r $(wildcard $(STAN)src/stan/model/model_header*.hpp.gch)
 	@echo '  removing built example model'
 	$(RM) examples/bernoulli/bernoulli$(EXE) examples/bernoulli/bernoulli.o examples/bernoulli/bernoulli.d examples/bernoulli/bernoulli.hpp $(wildcard examples/bernoulli/*.csv)
 

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -786,7 +786,7 @@ int command(int argc, const char *argv[]) {
           }
         }
       }  // end static HMC
-    }  // ---- sample end ---- //
+    }    // ---- sample end ---- //
   } else if (user_method->arg("variational")) {
     // ---- variational start ---- //
     list_argument *algo = dynamic_cast<list_argument *>(

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -786,7 +786,7 @@ int command(int argc, const char *argv[]) {
           }
         }
       }  // end static HMC
-    }    // ---- sample end ---- //
+    }  // ---- sample end ---- //
   } else if (user_method->arg("variational")) {
     // ---- variational start ---- //
     list_argument *algo = dynamic_cast<list_argument *>(
@@ -831,7 +831,7 @@ int command(int argc, const char *argv[]) {
   //////////////////////////////////////////////////
 
   stan::math::profile_map &profile_data = get_stan_profile_data();
-  if (profile_data.size() > 0) {
+  if (profile_data.begin() != profile_data.end()) {
     std::string profile_file_name
         = get_arg_val<string_argument>(parser, "output", "profile_file");
     std::fstream profile_stream(profile_file_name.c_str(), std::fstream::out);

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -831,7 +831,7 @@ int command(int argc, const char *argv[]) {
   //////////////////////////////////////////////////
 
   stan::math::profile_map &profile_data = get_stan_profile_data();
-  if (profile_data.begin() != profile_data.end()) {
+  if (profile_data.size() > 0) {
     std::string profile_file_name
         = get_arg_val<string_argument>(parser, "output", "profile_file");
     std::fstream profile_stream(profile_file_name.c_str(), std::fstream::out);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

After https://github.com/stan-dev/math/pull/3066, the profiling output file seems to always be created. 
The number returned by `profile_map.size()` seems to be garbage.

This reliably fixes the issue (and I confirmed that it also still creates the file when you _do_ want it), but I'm not sure if it points to something else being wrong.

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
