### PR TITLE
Widen tolerance in laplace_test.cpp for better seed independence

### DIFF
--- a/src/test/interface/laplace_test.cpp
+++ b/src/test/interface/laplace_test.cpp
@@ -173,10 +173,10 @@ TEST_F(CmdStan, laplace_jacobian_adjust) {
       = Eigen::Map<Eigen::Matrix<double, 1000, 3, Eigen::RowMajor>>(ptr2);
 
   double sigma_est1 = (sample1.col(2).array() / sample1.rows()).sum();
-  ASSERT_NEAR(3.1, sigma_est1, 0.1);
+  ASSERT_NEAR(3.1, sigma_est1, 0.15);
 
   double sigma_est2 = (sample2.col(2).array() / sample2.rows()).sum();
-  ASSERT_NEAR(3.1, sigma_est2, 0.1);
+  ASSERT_NEAR(3.1, sigma_est2, 0.15);
 
   for (int n = 0; n < 1000; ++n) {
     ASSERT_NE(sample1.coeff(n, 0), sample2.coeff(n, 0));


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run tests: `./runCmdStanTests.py src/test`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:

This makes the test less likely to fail if the behavior of the fixed seed changes, e.g. due to https://github.com/stan-dev/stan/pull/3287

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
