### PR TITLE
Fix dependency detection for precompiled header

### DIFF
--- a/make/program
+++ b/make/program
@@ -18,6 +18,7 @@ $(CMDSTAN_MAIN_O) : $(CMDSTAN_MAIN)
 ##
 ifneq ($(PRECOMPILED_MODEL_HEADER),)
 $(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER)) : DEPTARGETS = -MT $@
+$(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER)) : DEPFLAGS_OS = -M -E
 $(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER)) : $(STAN)src/stan/model/model_header.hpp
 	@mkdir -p $(dir $@)
 	$(COMPILE.cpp) $(DEPFLAGS) $<

--- a/make/program
+++ b/make/program
@@ -16,11 +16,13 @@ $(CMDSTAN_MAIN_O) : $(CMDSTAN_MAIN)
 ##
 # Precompiled model header
 ##
-$(patsub %.d,%.hpp.gch,$(PRECOMPILED_MODEL_HEADER)) : $(STAN)src/stan/model/model_header.hpp
+ifneq ($(PRECOMPILED_MODEL_HEADER),)
+$(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER)) : DEPTARGETS = -MT $@
+$(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER)) : $(STAN)src/stan/model/model_header.hpp
 	$(COMPILE.cpp) $(DEPFLAGS) $<
 
-ifneq ($(PRECOMPILED_MODEL_HEADER),)
-$(patsub %.d,%.hpp.gch,$(PRECOMPILED_MODEL_HEADER)) : DEPTARGETS = -MT $(patsubst %.d,%.hpp.gch,$@) -MT $@
+-include $(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER))
+
 $(PRECOMPILED_MODEL_HEADER) : $(STAN)src/stan/model/model_header.hpp
 	@echo ''
 	@echo '--- Compiling pre-compiled header. This might take a few seconds. ---'
@@ -103,7 +105,4 @@ ifneq (,$(STAN_TARGETS))
 $(patsubst %$(EXE),%.d,$(STAN_TARGETS)) : DEPTARGETS += -MT $(patsubst %.d,%$(EXE),$@) -include $< -include $(CMDSTAN_MAIN)
 -include $(patsubst %$(EXE),%.d,$(STAN_TARGETS))
 -include $(patsubst %.cpp,%$(STAN_FLAGS).d,$(CMDSTAN_MAIN))
-ifeq ($(PRECOMPILED_HEADERS),true)
--include $(STAN)src/stan/model/model_header$(STAN_FLAGS)_$(CXX_MAJOR)_$(CXX_MINOR).d
-endif
 endif

--- a/make/program
+++ b/make/program
@@ -19,9 +19,8 @@ $(CMDSTAN_MAIN_O) : $(CMDSTAN_MAIN)
 ifneq ($(PRECOMPILED_MODEL_HEADER),)
 $(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER)) : DEPTARGETS = -MT $@
 $(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER)) : $(STAN)src/stan/model/model_header.hpp
+	@mkdir -p $(dir $@)
 	$(COMPILE.cpp) $(DEPFLAGS) $<
-
--include $(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER))
 
 $(PRECOMPILED_MODEL_HEADER) : $(STAN)src/stan/model/model_header.hpp
 	@echo ''
@@ -105,4 +104,7 @@ ifneq (,$(STAN_TARGETS))
 $(patsubst %$(EXE),%.d,$(STAN_TARGETS)) : DEPTARGETS += -MT $(patsubst %.d,%$(EXE),$@) -include $< -include $(CMDSTAN_MAIN)
 -include $(patsubst %$(EXE),%.d,$(STAN_TARGETS))
 -include $(patsubst %.cpp,%$(STAN_FLAGS).d,$(CMDSTAN_MAIN))
+ifneq (,$(PRECOMPILED_MODEL_HEADER))
+-include $(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER))
+endif
 endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes the generation of a `.d` file which allows make to automatically re-build the precompiled header. 

This only really matters for developers who are editing the files it contains, but it would be nice to merge before the release. 

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
