### PR TITLE
Allow adapt engaged=1, num_warmup=0 for fixed_param sampling

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -563,7 +563,8 @@ int command(int argc, const char *argv[]) {
     list_argument *algo = dynamic_cast<list_argument *>(
         parser.arg("method")->arg("sample")->arg("algorithm"));
     std::string algo_name = algo->value();
-    bool use_fixed_param = model.num_params_r() == 0 || algo_name == "fixed_param";
+    bool use_fixed_param
+        = model.num_params_r() == 0 || algo_name == "fixed_param";
 
     bool adapt_engaged = get_arg_val<bool_argument>(parser, "method", "sample",
                                                     "adapt", "engaged");


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Closes #1276

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
