### PR TITLE
Fix stansummary build detection, avoid crashing if no __ columns

### DIFF
--- a/make/command
+++ b/make/command
@@ -1,4 +1,6 @@
-bin/cmdstan/stansummary.o : src/cmdstan/stansummary_helper.hpp
+src/cmdstan/stansummary.d: DEPTARGETS = -MT bin/cmdstan/stansummary.o
+-include src/cmdstan/stansummary.d
+
 bin/cmdstan/%.o : src/cmdstan/%.cpp
 	@mkdir -p $(dir $@)
 	$(COMPILE.cpp) -fvisibility=hidden $< $(OUTPUT_OPTION)

--- a/make/program
+++ b/make/program
@@ -17,7 +17,7 @@ $(CMDSTAN_MAIN_O) : $(CMDSTAN_MAIN)
 # Precompiled model header
 ##
 ifneq ($(PRECOMPILED_MODEL_HEADER),)
-$(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER)) : DEPTARGETS = -MT $@
+$(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER)) : DEPTARGETS = -MT $(PRECOMPILED_MODEL_HEADER)
 $(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER)) : DEPFLAGS_OS = -M -E
 $(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER)) : $(STAN)src/stan/model/model_header.hpp
 	@mkdir -p $(dir $@)

--- a/src/cmdstan/stansummary.cpp
+++ b/src/cmdstan/stansummary.cpp
@@ -145,14 +145,18 @@ Options:
 
     // Get column headers for sampler, model params
     size_t max_name_length = 0;
-    size_t num_sampler_params = -1;  // don't count name 'lp__'
+    size_t num_sampler_params = 0;
     for (int i = 0; i < chains.num_params(); ++i) {
       if (chains.param_name(i).length() > max_name_length)
         max_name_length = chains.param_name(i).length();
       if (stan::io::ends_with("__", chains.param_name(i)))
         num_sampler_params++;
     }
-
+    // don't count name 'lp__'
+    if (num_sampler_params > 0) {
+      num_sampler_params--;
+    }
+    
     // Get column indices for the sampler params
     std::vector<int> sampler_params_idxes(num_sampler_params);
     std::iota(sampler_params_idxes.begin(), sampler_params_idxes.end(), 1);

--- a/src/cmdstan/stansummary.cpp
+++ b/src/cmdstan/stansummary.cpp
@@ -156,7 +156,7 @@ Options:
     if (num_sampler_params > 0) {
       num_sampler_params--;
     }
-    
+
     // Get column indices for the sampler params
     std::vector<int> sampler_params_idxes(num_sampler_params);
     std::iota(sampler_params_idxes.begin(), sampler_params_idxes.end(), 1);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes stansummary not rebuilding when a dependent file changes
Fixes stansummary crashing if it is run on a csv file without any `__` columns

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
