### PR TITLE
Add example of loading more Make config from another place to make/local.example

### DIFF
--- a/make/local.example
+++ b/make/local.example
@@ -30,3 +30,7 @@
 
 # Adding other arbitrary C++ compiler flags
 # CXXFLAGS+= -funroll-loops
+
+# Load more config from another location. Possibly useful on a shared system where
+# different users have different configurations.
+# -include $(HOME)/.config/stan/make.local


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

See https://github.com/stan-dev/stan/pull/3295#issuecomment-2202092142. Following #1282, this adds a note to the make/local.example file which explains how one could restore that functionality or a similar one if desired. 

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
