### PR TITLE
Windows: Don't try to copy tbb.dll if TBB_TARGETS is undefined

### DIFF
--- a/make/program
+++ b/make/program
@@ -82,6 +82,7 @@ endif
 	$(LINK.cpp) $(subst \,/,$*.o) $(CMDSTAN_MAIN_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS) $(subst \,/,$(OUTPUT_OPTION))
 
 ifeq ($(OS),Windows_NT)
+ifneq(,$(TBB_TARGETS))
 ifeq (,$(findstring tbb.dll, $(notdir $(shell where tbb.dll))))
 	@echo 'Intel TBB is not in PATH.'
 	@echo 'Consider calling '
@@ -92,6 +93,7 @@ ifeq (,$(findstring tbb.dll, $(notdir $(shell where tbb.dll))))
 	else \
 		echo 'Using existing $(@D)/tbb.dll'; \
 	fi
+endif
 endif
 endif
 

--- a/make/program
+++ b/make/program
@@ -82,7 +82,7 @@ endif
 	$(LINK.cpp) $(subst \,/,$*.o) $(CMDSTAN_MAIN_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS) $(subst \,/,$(OUTPUT_OPTION))
 
 ifeq ($(OS),Windows_NT)
-ifneq(,$(TBB_TARGETS))
+ifneq (,$(TBB_TARGETS))
 ifeq (,$(findstring tbb.dll, $(notdir $(shell where tbb.dll))))
 	@echo 'Intel TBB is not in PATH.'
 	@echo 'Consider calling '


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This currently leads to the `cp` command failing with too-few-arguments. Usually when TBB_TARGETS is empty, the user is providing their own TBB, anyway.

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
