### PR TITLE
Issue/1029 record fixed param as override

### DIFF
--- a/src/cmdstan/write_config.hpp
+++ b/src/cmdstan/write_config.hpp
@@ -23,6 +23,9 @@ inline void write_config(stan::callbacks::writer &writer,
   write_model(writer, model.model_name());
   write_datetime(writer);
   parser.print(writer);
+  if (model.num_params_r() == 0) {
+    writer("algorithm = fixed_param (force)");
+  }
   write_parallel_info(writer);
   write_opencl_device(writer);
   write_compile_info(writer, model);

--- a/src/test/interface/fixed_param_sampler_test.cpp
+++ b/src/test/interface/fixed_param_sampler_test.cpp
@@ -92,4 +92,12 @@ TEST(McmcFixedParamSampler, check_empty_but_algorithm_not_fixed_param) {
       = "Model contains no parameters, running fixed_param sampler";
   EXPECT_TRUE(
       boost::algorithm::contains(command_output.output, expected_message));
+
+  std::ifstream output_stream;
+  output_stream.open((convert_model_path(model_path) + ".csv").data());
+
+  stan::io::stan_csv parsed_output
+      = stan::io::stan_csv_reader::parse(output_stream, 0);
+
+  EXPECT_EQ("fixed_param (force)", parsed_output.metadata.algorithm);
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Add logic to the `write_config` method to record when `fixed_param` sampler is used.

#### Intended Effect:

Make it easy to identify StanCSV output files produced by sampler algorithm `fixed_param`, both by humans as well as by `stan_csv_reader`.

#### How to Verify:

Unit tests.

#### Side Effects:

N/A

#### Documentation:

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
