### PR TITLE
Add MathematicStan link to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ There are separate repositories here on GitHub for interfaces:
 * [CmdStanR](https://github.com/stan-dev/cmdstanr) (a lightweight interface to CmdStan for R users)
 * [PyStan](https://github.com/stan-dev/pystan) (Python interface)
 * [RStan](https://github.com/stan-dev/rstan) (R interface)
+* [MathematicaStan](https://github.com/stan-dev/MathematicaStan) (Mathematica interface)
 
 ### Source Repository
 CmdStan's source-code repository is hosted here on GitHub.


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run tests: `./runCmdStanTests.py src/test` 
 No modified code, only one line of the README file is affected
- [X] Declare copyright holder and open-source license: see below

#### Summary:

I just added a link to the README file. This link points to the Mathematica interface to CmdStan I developped several years ago.

I just checked that MathematicaStan is still working as expected with :
- CmdStan 2.35.0
- Mathematica 11.2
- Linux (Debian) distrib 

#### Intended Effect:

Information about the existence of MathematicaStan  

#### How to Verify:

Read the modified README file 

#### Side Effects:

None 

#### Documentation:

None 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
