### PR TITLE
Cleanup/stan 3316 med abs deviation

### DIFF
--- a/src/cmdstan/stansummary_helper.hpp
+++ b/src/cmdstan/stansummary_helper.hpp
@@ -410,7 +410,7 @@ void get_stats(const stan::mcmc::chainset &chains,
     params(i, 0) = chains.mean(i_chains);
     params(i, 1) = chains.mcse_mean(i_chains);
     params(i, 2) = chains.sd(i_chains);
-    params(i, 3) = chains.max_abs_deviation(i_chains);
+    params(i, 3) = chains.med_abs_deviation(i_chains);
     Eigen::VectorXd quantiles = chains.quantiles(i_chains, probs);
     for (int j = 0; j < quantiles.size(); j++)
       params(i, 4 + j) = quantiles(j);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Once Stan PR #3316 goes in, this updates the function call accordingly.

#### Intended Effect:

Accurate names for diagnostic summary statistic - median absolute deviation is a measure of variance of the sample.

#### How to Verify:

Unit tests

#### Side Effects:

None

#### Documentation:

Will be done in separate PR on docs repo.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
