### PR TITLE
Clean up test makefile dependencies

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -41,7 +41,7 @@ ifneq ($(filter test/%,$(MAKECMDGOALS)),)
 
 include src/cmdstan/main.d
 
-TEST_SRCS = $(wildcard src/test/*.cpp)
+TEST_SRCS = $(wildcard src/test/interface/*.cpp)
 TEST_DEPFILES := $(TEST_SRCS:src/test/%.cpp=test/%.d)
 $(TEST_DEPFILES):
 include $(wildcard $(TEST_DEPFILES))

--- a/make/tests
+++ b/make/tests
@@ -8,23 +8,11 @@ test/%$(EXE) : INC += $(INC_GTEST) -I $(RAPIDJSON)
 test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)
 	$(LINK.cpp) $(filter-out src/test/test-models/% src/%.csv bin/% test/%.hpp %.hpp-test,$^) $(LDLIBS) $(OUTPUT_OPTION)
 
-.PRECIOUS: test/%.o
-test/%.o : src/test/%.cpp src/test/utility.hpp $(wildcard src/cmdstan/*.hpp)
+# generates .d files as a side effect
+test/%.o : src/test/%.cpp src/test/utility.hpp
 	@mkdir -p $(dir $@)
-	$(COMPILE.cpp) $< $(OUTPUT_OPTION)
+	$(COMPILE.cpp) -MT $@ -MMD -MP -MF test/$*.d $(OUTPUT_OPTION) $<
 
-##
-# Customization for generating dependencies
-##
-src/test/%.d : src/test/%.hpp
-src/test/%.d : CXXFLAGS += $(CXXFLAGS_GTEST)
-src/test/%.d : CPPFLAGS += $(CPPFLAGS_GTEST)
-src/test/%.d : INC += $(INC_GTEST)
-src/test/%.d : test/%.o
-
-ifneq ($(filter test/%,$(MAKECMDGOALS)),)
--include $(patsubst test/%$(EXE),src/test/%.d,$(filter test/%,$(MAKECMDGOALS)))
-endif
 
 ############################################################
 #
@@ -43,49 +31,55 @@ endif
 	$(COMPILE.cpp) -O0 -include $^ -o $(DEV_NULL)
 
 test/dummy.cpp:
-	@mkdir -p test
 	@touch $@
 	@echo "int main() {return 0;}" >> $@
 
 .PHONY: test-headers
 test-headers: $(HEADER_TESTS)
 
-############################################################
-#
-# Target to generate C++ code for all test-models
-##
-TEST_MODELS := $(wildcard src/test/test-models/*.stan)
-
-ifneq ($(filter test-models-hpp,$(MAKECMDGOALS)),)
--include $(patsubst %.stan,%.d,$(TEST_MODELS))
+ifneq ($(filter test,$(MAKECMDGOALS)),)
 include src/cmdstan/main.d
-endif
 
-.PHONY: test-models-hpp
-test-models-hpp: $(patsubst %.stan,%.hpp,$(TEST_MODELS)) $(patsubst %.stan,%$(EXE),$(TEST_MODELS))
+TEST_SRCS = $(wildcard src/test/*.cpp)
+TEST_DEPFILES := $(TEST_SRCS:src/test/%.cpp=test/%.d)
+$(TEST_DEPFILES):
+include $(wildcard $(TEST_DEPFILES))
+endif
 
 ##
 # Tests that depend on compiled models
 ##
-test/interface/generated_quantities_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, bern_gq_model  bern_extra_model test_model))
-test/interface/log_prob_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, bern_log_prob_model bern_gq_model simplex_model))
-test/interface/laplace_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, multi_normal_model simple_jacobian_model simplex_model))
-test/interface/pathfind_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, multi_normal_model eight_schools))
-test/interface/command_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, printer domain_fail proper value_fail transformed_data_rng_test ndim_array))
-test/interface/metric_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, test_model proper))
-test/interface/csv_header_consistency_test$(EXE): src/test/test-models/csv_header_consistency$(EXE)
-test/interface/diagnose_test$(EXE): bin/diagnose$(EXE)
-test/interface/elapsed_time_test$(EXE): src/test/test-models/test_model$(EXE)
-test/interface/fixed_param_sampler_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, empty proper))
-test/interface/mpi_test$(EXE): $(addsuffix $(EXE),$(addprefix src/test/test-models/, proper))
-test/interface/model_output_test$(EXE): src/test/test-models/printer$(EXE)
-test/interface/optimization_output_test$(EXE): src/test/test-models/optimization_output$(EXE)
-test/interface/print_test$(EXE): bin/print$(EXE)
-test/interface/print_uninitialized_test$(EXE): src/test/test-models/print_uninitialized$(EXE)
-test/interface/arguments/argument_configuration_test$(EXE): src/test/test-models/test_model$(EXE)
-test/interface/stansummary_test$(EXE): bin/stansummary$(EXE)
-test/interface/variational_output_test$(EXE): src/test/test-models/variational_output$(EXE)
+define depends_on_test_models
+   | $(addsuffix $(EXE),$(addprefix src/test/test-models/,$(1)))
+endef
 
+test/interface/command_test$(EXE):                $(call depends_on_test_models, printer domain_fail proper value_fail transformed_data_rng_test ndim_array)
+test/interface/config_json_test$(EXE):            $(call depends_on_test_models, multi_normal_model)
+test/interface/csv_header_consistency_test$(EXE): $(call depends_on_test_models, csv_header_consistency)
+test/interface/datetime_test$(EXE):               $(call depends_on_test_models, test_model)
+test/interface/elapsed_time_test$(EXE):           $(call depends_on_test_models, test_model)
+test/interface/fixed_param_sampler_test$(EXE):    $(call depends_on_test_models, empty proper)
+test/interface/generated_quantities_test$(EXE):   $(call depends_on_test_models, bern_gq_model bern_extra_model gq_non_scalar test_model)
+test/interface/laplace_test$(EXE):                $(call depends_on_test_models, multi_normal_model simple_jacobian_model simplex_model)
+test/interface/log_prob_test$(EXE):               $(call depends_on_test_models, bern_log_prob_model bern_gq_model simplex_model)
+test/interface/metric_test$(EXE):                 $(call depends_on_test_models, test_model proper)
+test/interface/model_output_test$(EXE):           $(call depends_on_test_models, printer)
+test/interface/multi_chain_init_test$(EXE):       $(call depends_on_test_models, bern_gq_model)
+test/interface/multi_chain_test$(EXE):            $(call depends_on_test_models, test_model)
+test/interface/optimization_output_test$(EXE):    $(call depends_on_test_models, optimization_output simple_jacobian_model)
+test/interface/output_sig_figs_test$(EXE):        $(call depends_on_test_models, proper_sig_figs)
+test/interface/pathfinder_test$(EXE):             $(call depends_on_test_models, multi_normal_model eight_schools empty)
+test/interface/print_uninitialized_test$(EXE):    $(call depends_on_test_models, print_uninitialized)
+test/interface/save_metric_json_test$(EXE):       $(call depends_on_test_models, simplex_model multi_normal_model)
+test/interface/variational_output_test$(EXE):     $(call depends_on_test_models, variational_output)
+
+# these tests depend only on the bin/ executables, not any models
+test/interface/stansummary_test$(EXE):         bin/stansummary$(EXE)
+test/interface/diagnose_test$(EXE):            bin/diagnose$(EXE)
+test/interface/print_test$(EXE):               bin/print$(EXE)
+
+
+TEST_MODELS := $(wildcard src/test/test-models/*.stan)
 .PHONY: clean-tests
 clean-tests:
 	$(RM) -r test

--- a/make/tests
+++ b/make/tests
@@ -37,7 +37,8 @@ test/dummy.cpp:
 .PHONY: test-headers
 test-headers: $(HEADER_TESTS)
 
-ifneq ($(filter test,$(MAKECMDGOALS)),)
+ifneq ($(filter test/%,$(MAKECMDGOALS)),)
+
 include src/cmdstan/main.d
 
 TEST_SRCS = $(wildcard src/test/*.cpp)

--- a/runCmdStanTests.py
+++ b/runCmdStanTests.py
@@ -77,13 +77,6 @@ def makeBuild(j):
     doCommand(command)
 
 
-def makeTestModels(j):
-    if j == None:
-        command = 'make test-models-hpp'
-    else:
-        command = 'make -j%d test-models-hpp' % j
-    doCommand(command)
-
 def makeMathLibs(j):
     if j == None:
         command = 'make -f stan/lib/stan_math/make/standalone math-libs'
@@ -176,7 +169,6 @@ def main():
     makeBuild(j)
     if (isWin()):
         makeMathLibs(j)
-    makeTestModels(j)
 
     # pass 1:  call make to compile test targets
     for i in range(argsIdx,len(sys.argv)):

--- a/src/test/interface/command_test.cpp
+++ b/src/test/interface/command_test.cpp
@@ -1,6 +1,5 @@
-#include <cmdstan/command.hpp>
-#include <test/test-models/proper.hpp>
 #include <test/utility.hpp>
+#include <cmdstan/return_codes.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 #include <stan/services/error_codes.hpp>
 #include <boost/algorithm/string.hpp>

--- a/src/test/interface/metric_test.cpp
+++ b/src/test/interface/metric_test.cpp
@@ -1,7 +1,6 @@
-#include <cmdstan/command.hpp>
 #include <stan/callbacks/stream_writer.hpp>
+#include <cmdstan/return_codes.hpp>
 #include <stan/services/error_codes.hpp>
-#include <test/test-models/proper.hpp>
 #include <test/utility.hpp>
 #include <boost/math/policies/error_handling.hpp>
 #include <gtest/gtest.h>

--- a/src/test/interface/mpi_test.cpp
+++ b/src/test/interface/mpi_test.cpp
@@ -1,7 +1,5 @@
 #ifdef STAN_MPI
 
-#include <test/test-models/proper.hpp>
-#include <cmdstan/command.hpp>
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 

--- a/src/test/interface/tbb_threadpool_test.cpp
+++ b/src/test/interface/tbb_threadpool_test.cpp
@@ -1,5 +1,3 @@
-#include <cmdstan/command.hpp>
-#include <test/test-models/proper.hpp>
 #include <stan/math/prim/core/init_threadpool_tbb.hpp>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This cleans up some bad habits in how our makefile for the tests was written, to try to fix the odd dependency race condition we are seeing in the upstream tests for https://github.com/stan-dev/math/pull/3159.

#### Intended Effect:

Make tests build more reliably. 

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
