### PR TITLE
More information on system error

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -70,6 +70,7 @@ test/interface/multi_chain_test$(EXE):            $(call depends_on_test_models,
 test/interface/optimization_output_test$(EXE):    $(call depends_on_test_models, optimization_output simple_jacobian_model)
 test/interface/output_sig_figs_test$(EXE):        $(call depends_on_test_models, proper_sig_figs)
 test/interface/pathfinder_test$(EXE):             $(call depends_on_test_models, multi_normal_model eight_schools empty)
+test/interface/permissions_test$(EXE):            $(call depends_on_test_models, test_model)
 test/interface/print_uninitialized_test$(EXE):    $(call depends_on_test_models, print_uninitialized)
 test/interface/save_metric_json_test$(EXE):       $(call depends_on_test_models, simplex_model multi_normal_model)
 test/interface/variational_output_test$(EXE):     $(call depends_on_test_models, variational_output)

--- a/src/cmdstan/file.hpp
+++ b/src/cmdstan/file.hpp
@@ -272,7 +272,7 @@ std::ifstream safe_open(const std::string &fname) {
 std::unique_ptr<std::ofstream> safe_create(const std::string &fname,
                                            int sig_figs) {
   auto ofs = std::make_unique<std::ofstream>(fname.c_str());
-  ofs->exceptions(std::ofstream::badbit);
+  ofs->exceptions(std::ofstream::badbit | std::ofstream::failbit);
   if (sig_figs > -1) {
     ofs->precision(sig_figs);
   }

--- a/src/cmdstan/main.cpp
+++ b/src/cmdstan/main.cpp
@@ -1,3 +1,7 @@
+#include <stdexcept>
+#include <iostream>
+#include <cerrno>
+
 #include <cmdstan/command.hpp>
 #include <stan/services/error_codes.hpp>
 
@@ -8,6 +12,11 @@ int main(int argc, const char *argv[]) {
       return cmdstan::return_codes::OK;
     else
       return cmdstan::return_codes::NOT_OK;
+  } catch (std::system_error &e) {
+    // system_error is thrown by std::ofstream but the
+    // message is not always helpful, so we also print errno
+    std::cerr << e.what() << ": " << std::strerror(errno) << std::endl;
+    return cmdstan::return_codes::NOT_OK;
   } catch (const std::exception &e) {
     std::cerr << e.what() << std::endl;
     return cmdstan::return_codes::NOT_OK;

--- a/src/test/interface/generated_quantities_test.cpp
+++ b/src/test/interface/generated_quantities_test.cpp
@@ -29,7 +29,7 @@ class CmdStan : public testing::Test {
     bern_fitted_params_thin
         = {"src", "test", "test-models", "bern_fitted_params_thin.csv"};
     default_file_path = {"src", "test", "test-models", "output.csv"};
-    dev_null_path = {"/dev", "null"};
+    dummy_output = {"test", "ignored.csv"};
     gq_non_scalar_model = {"src", "test", "test-models", "gq_non_scalar"};
     gq_non_scalar_fitted_params
         = {"src", "test", "test-models", "gq_non_scalar_fitted_params.csv"};
@@ -45,7 +45,7 @@ class CmdStan : public testing::Test {
   std::vector<std::string> bern_variational_params;
   std::vector<std::string> bern_fitted_params_thin;
   std::vector<std::string> default_file_path;
-  std::vector<std::string> dev_null_path;
+  std::vector<std::string> dummy_output;
   std::vector<std::string> gq_non_scalar_model;
   std::vector<std::string> gq_non_scalar_fitted_params;
   std::vector<std::string> test_model;
@@ -55,19 +55,19 @@ TEST_F(CmdStan, generate_quantities_good) {
   std::stringstream ss;
   ss << convert_model_path(bern_gq_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=generate_quantities fitted_params="
      << convert_model_path(bern_fitted_params);
   std::string cmd = ss.str();
   run_command_output out = run_command(cmd);
-  ASSERT_FALSE(out.hasError);
+  ASSERT_FALSE(out.hasError) << out.output;
 }
 
 TEST_F(CmdStan, generate_quantities_good_multi) {
   std::stringstream ss;
   ss << convert_model_path(bern_gq_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=generate_quantities fitted_params="
      << convert_model_path(bern_fitted_params_multi) << " num_chains=4";
   std::string cmd = ss.str();
@@ -79,7 +79,7 @@ TEST_F(CmdStan, generate_quantities_good_multi_comma) {
   std::stringstream ss;
   ss << convert_model_path(bern_gq_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=generate_quantities fitted_params="
      << convert_model_path(bern_fitted_params) << ","
      << convert_model_path(bern_fitted_params) << " num_chains=2";
@@ -115,7 +115,7 @@ TEST_F(CmdStan, generate_quantities_same_in_out_multi_path_diff) {
 TEST_F(CmdStan, generate_quantities_non_scalar_good) {
   std::stringstream ss;
   ss << convert_model_path(gq_non_scalar_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=generate_quantities fitted_params="
      << convert_model_path(gq_non_scalar_fitted_params);
   std::string cmd = ss.str();
@@ -126,7 +126,7 @@ TEST_F(CmdStan, generate_quantities_non_scalar_good) {
 TEST_F(CmdStan, generate_quantities_no_data_arg) {
   std::stringstream ss;
   ss << convert_model_path(bern_gq_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=generate_quantities fitted_params="
      << convert_model_path(bern_fitted_params) << " 2>&1";
   std::string cmd = ss.str();
@@ -137,7 +137,7 @@ TEST_F(CmdStan, generate_quantities_no_data_arg) {
 TEST_F(CmdStan, generate_quantities_no_fitted_params_arg) {
   std::stringstream ss;
   ss << convert_model_path(bern_gq_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=generate_quantities 2>&1";
   std::string cmd = ss.str();
   run_command_output out = run_command(cmd);
@@ -148,7 +148,7 @@ TEST_F(CmdStan, generate_quantities_missing_fitted_params) {
   std::stringstream ss;
   ss << convert_model_path(bern_extra_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=generate_quantities fitted_params="
      << convert_model_path(bern_fitted_params) << " 2>&1";
   std::string cmd = ss.str();
@@ -159,7 +159,7 @@ TEST_F(CmdStan, generate_quantities_missing_fitted_params) {
 TEST_F(CmdStan, generate_quantities_wrong_csv) {
   std::stringstream ss;
   ss << convert_model_path(test_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=generate_quantities fitted_params="
      << convert_model_path(bern_fitted_params) << " 2>&1";
   std::string cmd = ss.str();

--- a/src/test/interface/laplace_test.cpp
+++ b/src/test/interface/laplace_test.cpp
@@ -22,7 +22,7 @@ class CmdStan : public testing::Test {
     multi_normal_mode_json
         = {"src", "test", "test-models", "multi_normal_mode.json"};
     default_file_path = {"src", "test", "test-models", "output.csv"};
-    dev_null_path = {"/dev", "null"};
+    dummy_output = {"test", "ignored.csv"};
     wrong_csv = {"src", "test", "test-models", "bern_fitted_params.csv"};
     simple_jacobian_model
         = {"src", "test", "test-models", "simple_jacobian_model"};
@@ -36,7 +36,7 @@ class CmdStan : public testing::Test {
         = {"src", "test", "test-models", "simplex_mode_bad.csv"};
   }
   std::vector<std::string> default_file_path;
-  std::vector<std::string> dev_null_path;
+  std::vector<std::string> dummy_output;
   std::vector<std::string> simple_jacobian_model;
   std::vector<std::string> simple_jacobian_mode_json;
   std::vector<std::string> multi_normal_model;
@@ -56,14 +56,14 @@ class CmdStan : public testing::Test {
 TEST_F(CmdStan, laplace_good) {
   std::stringstream ss;
   ss << convert_model_path(multi_normal_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=laplace mode=" << convert_model_path(multi_normal_mode_csv);
   run_command_output out = run_command(ss.str());
   ASSERT_FALSE(out.hasError);
 
   ss.str(std::string());
   ss << convert_model_path(multi_normal_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=laplace mode=" << convert_model_path(multi_normal_mode_json);
   out = run_command(ss.str());
   ASSERT_FALSE(out.hasError);
@@ -72,7 +72,7 @@ TEST_F(CmdStan, laplace_good) {
 TEST_F(CmdStan, laplace_no_mode_arg) {
   std::stringstream ss;
   ss << convert_model_path(multi_normal_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=laplace 2>&1";
   std::string cmd = ss.str();
   run_command_output out = run_command(cmd);
@@ -82,7 +82,7 @@ TEST_F(CmdStan, laplace_no_mode_arg) {
 TEST_F(CmdStan, laplace_wrong_mode_file) {
   std::stringstream ss;
   ss << convert_model_path(multi_normal_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=laplace mode=" << convert_model_path(wrong_csv);
   std::string cmd = ss.str();
   run_command_output out = run_command(cmd);
@@ -92,7 +92,7 @@ TEST_F(CmdStan, laplace_wrong_mode_file) {
 TEST_F(CmdStan, laplace_missing_mode) {
   std::stringstream ss;
   ss << convert_model_path(multi_normal_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=laplace mode="
      << " 2>&1";
   std::string cmd = ss.str();
@@ -103,7 +103,7 @@ TEST_F(CmdStan, laplace_missing_mode) {
 TEST_F(CmdStan, laplace_bad_draws_arg) {
   std::stringstream ss;
   ss << convert_model_path(multi_normal_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=laplace mode=" << convert_model_path(multi_normal_mode_csv)
      << " draws=0 2>&1";
   std::string cmd = ss.str();
@@ -114,7 +114,7 @@ TEST_F(CmdStan, laplace_bad_draws_arg) {
 TEST_F(CmdStan, laplace_bad_csv_file) {
   std::stringstream ss;
   ss << convert_model_path(multi_normal_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=laplace mode="
      << convert_model_path(multi_normal_mode_csv_bad_config)
      << " draws=10 2>&1";
@@ -124,7 +124,7 @@ TEST_F(CmdStan, laplace_bad_csv_file) {
 
   ss.str(std::string());
   ss << convert_model_path(multi_normal_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=laplace mode="
      << convert_model_path(multi_normal_mode_csv_bad_names) << " draws=10 2>&1";
   cmd = ss.str();
@@ -133,7 +133,7 @@ TEST_F(CmdStan, laplace_bad_csv_file) {
 
   ss.str(std::string());
   ss << convert_model_path(multi_normal_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " method=laplace mode="
      << convert_model_path(multi_normal_mode_csv_bad_values)
      << " draws=10 2>&1";

--- a/src/test/interface/log_prob_test.cpp
+++ b/src/test/interface/log_prob_test.cpp
@@ -30,7 +30,6 @@ class CmdStan : public testing::Test {
                                        "bern_unconstrained_params_short.json"};
     bern_constrained_params_short
         = {"src", "test", "test-models", "bern_constrained_params_short.json"};
-    dev_null_path = {"/dev", "null"};
     test_output = {"test", "output.csv"};
     simplex_model = {"src", "test", "test-models", "simplex_model"};
     simplex_constrained_bad_csv
@@ -48,7 +47,6 @@ class CmdStan : public testing::Test {
   std::vector<std::string> bern_constrained_params_csv;
   std::vector<std::string> bern_unconstrained_params_short;
   std::vector<std::string> bern_constrained_params_short;
-  std::vector<std::string> dev_null_path;
   std::vector<std::string> test_output;
   std::vector<std::string> simplex_model;
   std::vector<std::string> simplex_constrained_csv;
@@ -166,7 +164,7 @@ TEST_F(CmdStan, log_prob_no_params) {
   std::stringstream ss;
   ss << convert_model_path(bern_log_prob_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(test_output)
      << " method=log_prob";
   std::string cmd = ss.str();
   run_command_output out = run_command(cmd);
@@ -177,7 +175,7 @@ TEST_F(CmdStan, log_prob_constrained_bad_input) {
   std::stringstream ss;
   ss << convert_model_path(bern_log_prob_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(test_output)
      << " method=log_prob constrained_params="
      << convert_model_path(bern_constrained_params_short);
   std::string cmd = ss.str();
@@ -209,7 +207,7 @@ TEST_F(CmdStan, log_prob_constrained_simplex) {
 TEST_F(CmdStan, log_prob_constrained_bad_simplex) {
   std::stringstream ss;
   ss << convert_model_path(simplex_model)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(test_output)
      << " method=log_prob constrained_params="
      << convert_model_path(simplex_constrained_bad_csv);
   std::string cmd = ss.str();
@@ -221,7 +219,7 @@ TEST_F(CmdStan, log_prob_unconstrained_bad_input) {
   std::stringstream ss;
   ss << convert_model_path(bern_log_prob_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(test_output)
      << " method=log_prob unconstrained_params="
      << convert_model_path(bern_unconstrained_params_short);
   std::string cmd = ss.str();

--- a/src/test/interface/multi_chain_init_test.cpp
+++ b/src/test/interface/multi_chain_init_test.cpp
@@ -21,10 +21,10 @@ class CmdStan : public testing::Test {
     init3_data = {"src", "test", "test-models", "bern_init2.R"};
     init_bad_data = {"src", "test", "test-models", "bern_init_bad.json"};
     init_bad_2_data = {"src", "test", "test-models", "bern_init_bad_2.json"};
-    dev_null_path = {"/dev", "null"};
+    dummy_output = {"test", "ignored.csv"};
   }
   std::vector<std::string> bern_model;
-  std::vector<std::string> dev_null_path;
+  std::vector<std::string> dummy_output;
   std::vector<std::string> bern_data;
   std::vector<std::string> init_data;
   std::vector<std::string> init2_data;
@@ -38,7 +38,7 @@ TEST_F(CmdStan, multi_chain_single_init_file_good) {
   std::stringstream ss;
   ss << convert_model_path(bern_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " init=" << convert_model_path(init_data)
      << " method=sample num_chains=2";
   std::string cmd = ss.str();
@@ -50,7 +50,7 @@ TEST_F(CmdStan, multi_chain_multi_init_file_good) {
   std::stringstream ss;
   ss << convert_model_path(bern_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " init=" << convert_model_path(init2_data)
      << " method=sample num_chains=4";
   std::string cmd = ss.str();
@@ -62,7 +62,7 @@ TEST_F(CmdStan, multi_chain_multi_init_file_comma_good) {
   std::stringstream ss;
   ss << convert_model_path(bern_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " init=" << convert_model_path(init_data) << ","
      << convert_model_path(init2_3_data) << " method=sample num_chains=2";
   std::string cmd = ss.str();
@@ -74,7 +74,7 @@ TEST_F(CmdStan, multi_chain_multi_init_file_id_good) {
   std::stringstream ss;
   ss << convert_model_path(bern_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " init=" << convert_model_path(init2_data) << " id=2"
      << " method=sample num_chains=2";
   std::string cmd = ss.str();
@@ -87,7 +87,7 @@ TEST_F(CmdStan, multi_chain_multi_init_file_id_bad) {
   std::stringstream ss;
   ss << convert_model_path(bern_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " init=" << convert_model_path(init2_data) << " id=4"
      << " method=sample num_chains=3";
   std::string cmd = ss.str();
@@ -101,7 +101,7 @@ TEST_F(CmdStan, multi_chain_multi_init_file_comma_missing) {
   std::stringstream ss;
   ss << convert_model_path(bern_model)
      << " data file=" << convert_model_path(bern_data) << " output file="
-     << convert_model_path(dev_null_path)
+     << convert_model_path(dummy_output)
      //  second init file does not exist
      << " init=" << convert_model_path(init2_data) << ","
      << convert_model_path(init2_data) << " method=sample num_chains=2";
@@ -115,7 +115,7 @@ TEST_F(CmdStan, multi_chain_multi_init_file_comma_wrong_number) {
   std::stringstream ss;
   ss << convert_model_path(bern_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " init=" << convert_model_path(init_data) << ","
      << convert_model_path(init2_3_data) << " method=sample num_chains=3";
   std::string cmd = ss.str();
@@ -130,7 +130,7 @@ TEST_F(CmdStan, multi_chain_multi_init_file_actually_used) {
   std::stringstream ss;
   ss << convert_model_path(bern_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " init=" << convert_model_path(init_bad_data)
      << " method=sample num_chains=2";
   std::string cmd = ss.str();
@@ -144,7 +144,7 @@ TEST_F(CmdStan, multi_chain_multi_init_file_actually_used_comma) {
   std::stringstream ss;
   ss << convert_model_path(bern_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " init=" << convert_model_path(init_data) << ","
      << convert_model_path(init_bad_2_data) << " method=sample num_chains=2";
   std::string cmd = ss.str();
@@ -157,7 +157,7 @@ TEST_F(CmdStan, multi_chain_multi_init_file_R) {
   std::stringstream ss;
   ss << convert_model_path(bern_model)
      << " data file=" << convert_model_path(bern_data)
-     << " output file=" << convert_model_path(dev_null_path)
+     << " output file=" << convert_model_path(dummy_output)
      << " init=" << convert_model_path(init3_data)
      << " method=sample num_chains=4";
   std::string cmd = ss.str();

--- a/src/test/interface/pathfinder_test.cpp
+++ b/src/test/interface/pathfinder_test.cpp
@@ -13,7 +13,6 @@ using cmdstan::test::run_command_output;
 class CmdStan : public testing::Test {
  public:
   void SetUp() {
-    dev_null_path = {"/dev", "null"};
     multi_normal_model = {"src", "test", "test-models", "multi_normal_model"};
     eight_schools_model = {"src", "test", "test-models", "eight_schools"};
     eight_schools_data
@@ -36,7 +35,6 @@ class CmdStan : public testing::Test {
     std::remove(convert_model_path(output_single_json).c_str());
   }
 
-  std::vector<std::string> dev_null_path;
   std::vector<std::string> multi_normal_model;
   std::vector<std::string> eight_schools_model;
   std::vector<std::string> eight_schools_data;

--- a/src/test/interface/permissions_test.cpp
+++ b/src/test/interface/permissions_test.cpp
@@ -1,23 +1,20 @@
-#include <cmdstan/stansummary_helper.hpp>
-#include <stan/io/stan_csv_reader.hpp>
-#include <stan/services/error_codes.hpp>
 #include <test/utility.hpp>
 #include <gtest/gtest.h>
 
 using cmdstan::test::convert_model_path;
+using cmdstan::test::run_command;
+using cmdstan::test::temporary_unwritable_file;
 
-TEST(interface, unwritable_file) {
-  std::string model = convert_model_path(
-      std::vector{"src", "test", "test-models", "test_model"});
-  std::string output
-      = convert_model_path(std::vector{"test", "output_unwritable.csv"});
+TEST(interface, fails_when_output_is_unwritable) {
+  // makes a file without the w bit set
+  temporary_unwritable_file file(
+      convert_model_path(std::vector{"test", "output_unwritable.csv"}));
 
-  cmdstan::test::temporary_unwritable_file guard(output);
+  std::string command = convert_model_path(std::vector{
+                            "src", "test", "test-models", "test_model"})
+                        + " sample output file=" + file.filename;
 
-  std::string command
-      = model + " sample num_warmup=1 num_samples=1 output file=" + output;
-
-  cmdstan::test::run_command_output out = cmdstan::test::run_command(command);
+  auto out = run_command(command);
   EXPECT_IN_STRING("Permission denied", out.output);
   EXPECT_TRUE(out.hasError);
 }

--- a/src/test/interface/permissions_test.cpp
+++ b/src/test/interface/permissions_test.cpp
@@ -18,3 +18,19 @@ TEST(interface, fails_when_output_is_unwritable) {
   EXPECT_IN_STRING("Permission denied", out.output);
   EXPECT_TRUE(out.hasError);
 }
+
+TEST(interface, fails_when_output_is_unwritable_multi) {
+  temporary_unwritable_file file1(
+      convert_model_path(std::vector{"test", "output_unwritable_1.csv"}));
+  temporary_unwritable_file file2(
+      convert_model_path(std::vector{"test", "output_unwritable_2.csv"}));
+
+  std::string command = convert_model_path(std::vector{
+                            "src", "test", "test-models", "test_model"})
+                        + " sample num_chains=2 output file=" + file1.filename
+                        + "," + file2.filename;
+
+  auto out = run_command(command);
+  EXPECT_IN_STRING("Permission denied", out.output);
+  EXPECT_TRUE(out.hasError);
+}

--- a/src/test/interface/permissions_test.cpp
+++ b/src/test/interface/permissions_test.cpp
@@ -1,0 +1,23 @@
+#include <cmdstan/stansummary_helper.hpp>
+#include <stan/io/stan_csv_reader.hpp>
+#include <stan/services/error_codes.hpp>
+#include <test/utility.hpp>
+#include <gtest/gtest.h>
+
+using cmdstan::test::convert_model_path;
+
+TEST(interface, unwritable_file) {
+  std::string model = convert_model_path(
+      std::vector{"src", "test", "test-models", "test_model"});
+  std::string output
+      = convert_model_path(std::vector{"test", "output_unwritable.csv"});
+
+  cmdstan::test::temporary_unwritable_file guard(output);
+
+  std::string command
+      = model + " sample num_warmup=1 num_samples=1 output file=" + output;
+
+  cmdstan::test::run_command_output out = cmdstan::test::run_command(command);
+  EXPECT_IN_STRING("Permission denied", out.output);
+  EXPECT_TRUE(out.hasError);
+}

--- a/src/test/interface/save_metric_json_test.cpp
+++ b/src/test/interface/save_metric_json_test.cpp
@@ -13,7 +13,6 @@ using cmdstan::test::run_command_output;
 class CmdStan : public testing::Test {
  public:
   void SetUp() {
-    dev_null = {"/dev", "null"};
     multi_normal_model = {"src", "test", "test-models", "multi_normal_model"};
     simplex_model = {"src", "test", "test-models", "simplex_model"};
     output_csv = {"test", "output.csv"};
@@ -27,7 +26,6 @@ class CmdStan : public testing::Test {
   }
 
   std::vector<std::string> default_file;
-  std::vector<std::string> dev_null;
   std::vector<std::string> multi_normal_model;
   std::vector<std::string> output_csv;
   std::vector<std::string> output_metric;

--- a/src/test/utility.hpp
+++ b/src/test/utility.hpp
@@ -343,8 +343,11 @@ void make_writable(const std::string &filename) {
 }  // namespace internal
 
 struct temporary_unwritable_file {
-  std::string filename;
-  temporary_unwritable_file(const std::string &filename) : filename(filename) {
+ public:
+  const std::string filename;
+
+  explicit temporary_unwritable_file(std::string filename)
+      : filename(filename) {
     {
       // this will create the file if it does not exist
       std::ofstream ofs(filename);
@@ -353,6 +356,7 @@ struct temporary_unwritable_file {
     EXPECT_TRUE(file_exists(filename));
     internal::make_unwritable(filename);
   }
+
   ~temporary_unwritable_file() noexcept(false) {
     internal::make_writable(filename);
     EXPECT_EQ(remove(filename.c_str()), 0);

--- a/src/test/utility.hpp
+++ b/src/test/utility.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 #include <sys/stat.h>
+#include <sys/types.h>
 
 #define EXPECT_IN_STRING(needle, haystack)                  \
   EXPECT_TRUE(boost::algorithm::contains(haystack, needle)) \
@@ -317,6 +318,47 @@ bool is_valid_JSON(std::string &text) {
   rapidjson::Document document;
   return !document.Parse<0>(text.c_str()).HasParseError();
 }
+
+namespace internal {
+
+// TODO: can be replaced with std::filesystem when we have better compiler
+// support for C++17 (currently missing from our minimum clang version)
+#ifdef _WIN32
+#include <io.h>
+void make_unwritable_file(const std::string &filename) {
+  _chmod(filename.c_str(), _S_IREAD);
+}
+void make_writable(const std::string &filename) {
+  _chmod(filename.c_str(), _S_IWRITE);
+}
+#else
+void make_unwritable(const std::string &filename) {
+  chmod(filename.c_str(), 0444);
+}
+void make_writable(const std::string &filename) {
+  chmod(filename.c_str(), 0644);
+}
+#endif
+
+}  // namespace internal
+
+struct temporary_unwritable_file {
+  std::string filename;
+  temporary_unwritable_file(const std::string &filename) : filename(filename) {
+    {
+      // this will create the file if it does not exist
+      std::ofstream ofs(filename);
+      ofs.close();
+    }
+    EXPECT_TRUE(file_exists(filename));
+    internal::make_unwritable(filename);
+  }
+  ~temporary_unwritable_file() noexcept(false) {
+    internal::make_writable(filename);
+    EXPECT_EQ(remove(filename.c_str()), 0);
+    EXPECT_FALSE(file_exists(filename));
+  }
+};
 
 }  // namespace test
 }  // namespace cmdstan

--- a/src/test/utility.hpp
+++ b/src/test/utility.hpp
@@ -325,7 +325,7 @@ namespace internal {
 // support for C++17 (currently missing from our minimum clang version)
 #ifdef _WIN32
 #include <io.h>
-void make_unwritable_file(const std::string &filename) {
+void make_unwritable(const std::string &filename) {
   _chmod(filename.c_str(), _S_IREAD);
 }
 void make_writable(const std::string &filename) {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Attempts to improve the situation in cases like #1310

#### Intended Effect:

#### How to Verify:
I don't know a good way of simulating out-of-disk-space directly. You can test on other situations, like unwritable files or
similar. In those cases, you should see:

```sh
$ ls -lha # note there is no `w` bit for test_outputs/
-rwxrwxr-x 1 brian brian 2.6M Mar 12 16:27 bernoulli
-rw-rw-r-- 1 brian brian   50 Jun  6  2024 bernoulli.data.json
dr-xr-xr-x 2 brian brian 4.0K Mar 12 16:25 test_outputs
$ ./bernoulli sample data file=bernoulli.data.json output file=test_outputs/foo.csv
basic_ios::clear: iostream error: Permission denied
```

The "Permission denied" is new in this PR.

#### Side Effects:

CmdStan now halts in more erroneous situations, such as the above where the output is not writable; in the current code, it happily runs and just produces no outputs.

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
