### PR TITLE
Stop passing raw stream to log_prob_grad helper

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -786,7 +786,7 @@ int command(int argc, const char *argv[]) {
           }
         }
       }  // end static HMC
-    }  // ---- sample end ---- //
+    }    // ---- sample end ---- //
   } else if (user_method->arg("variational")) {
     // ---- variational start ---- //
     list_argument *algo = dynamic_cast<list_argument *>(

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -449,8 +449,7 @@ int command(int argc, const char *argv[]) {
       }
     }
     try {
-      services_log_prob_grad(model, jacobian, params_r_ind, sig_figs,
-                             sample_writers[0].get_stream());
+      services_log_prob_grad(model, jacobian, params_r_ind, sample_writers[0]);
       return_code = return_codes::OK;
     } catch (const std::exception &e) {
       msg << "Error during log_prob calculation:" << std::endl;
@@ -787,7 +786,7 @@ int command(int argc, const char *argv[]) {
           }
         }
       }  // end static HMC
-    }    // ---- sample end ---- //
+    }  // ---- sample end ---- //
   } else if (user_method->arg("variational")) {
     // ---- variational start ---- //
     list_argument *algo = dynamic_cast<list_argument *>(

--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -4,7 +4,6 @@
 #include <cmdstan/arguments/argument_parser.hpp>
 #include <cmdstan/arguments/arg_sample.hpp>
 #include <cmdstan/file.hpp>
-#include <stan/callbacks/unique_stream_writer.hpp>
 #include <stan/callbacks/json_writer.hpp>
 #include <stan/callbacks/writer.hpp>
 #include <stan/io/dump.hpp>
@@ -580,18 +579,14 @@ std::vector<std::vector<double>> get_uparams_r(
  */
 void services_log_prob_grad(const stan::model::model_base &model, bool jacobian,
                             std::vector<std::vector<double>> &params_set,
-                            int sig_figs, std::ostream &output_stream) {
-  // header row
-  output_stream << std::setprecision(sig_figs) << "lp__,";
-  std::vector<std::string> p_names;
+                            stan::callbacks::writer &output) {
+  // header
+  std::vector<std::string> p_names{"lp__"};
   model.unconstrained_param_names(p_names, false, false);
-  for (size_t i = 0; i < p_names.size(); ++i) {
-    output_stream << "g_" << p_names[i];
-    if (i == p_names.size() - 1)
-      output_stream << "\n";
-    else
-      output_stream << ",";
-  }
+  std::transform(p_names.begin() + 1, p_names.end(), p_names.begin() + 1,
+                 [](std::string s) { return "g_" + s; });
+  output(p_names);
+
   // data row(s)
   std::vector<int> dummy_params_i;
   double lp;
@@ -604,10 +599,9 @@ void services_log_prob_grad(const stan::model::model_base &model, bool jacobian,
       lp = stan::model::log_prob_grad<true, false>(model, params,
                                                    dummy_params_i, gradients);
     }
-    output_stream << lp << ",";
-    std::copy(gradients.begin(), gradients.end() - 1,
-              std::ostream_iterator<double>(output_stream, ","));
-    output_stream << gradients.back() << "\n";
+    // unfortunate: var.grad clears the vector, so need to insert lp afterwards
+    gradients.insert(gradients.begin(), lp);
+    output(gradients);
   }
 }
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Small change, noticed that this helper isn't using `writer`s.

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
