### PR TITLE
Remove make logic to download stanc3 on mips64el

### DIFF
--- a/make/stanc
+++ b/make/stanc
@@ -21,9 +21,7 @@ else ifeq ($(OS),Darwin)
  STANC_XATTR := $(shell xattr bin/mac-stanc 2>/dev/null)
 else ifeq ($(OS),Linux)
  OS_TAG := linux
- ifeq ($(shell uname -m),mips64)
-  ARCH_TAG := -mips64el
- else ifeq ($(shell uname -m),ppc64le)
+ ifeq ($(shell uname -m),ppc64le)
   ARCH_TAG := -ppc64el
  else ifeq ($(shell uname -m),s390x)
   ARCH_TAG := -s390x


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This is no longer being built in our CI

https://discourse.mc-stan.org/t/if-you-use-cmdstan-on-non-x86-non-arm64-linux-speak-up-here/37655/5

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
