### PR TITLE
Add ESS/s back to stansummary

### DIFF
--- a/src/cmdstan/stansummary_helper.hpp
+++ b/src/cmdstan/stansummary_helper.hpp
@@ -366,28 +366,29 @@ stan::mcmc::chainset parse_csv_files(const std::vector<std::string> &filenames,
  */
 std::vector<std::string> get_header(
     const std::vector<std::string> &percentiles) {
-  // Mean, MCSE,  StdDev, MAD, ... percentiles ..., ESS_bulk, ESS_tail, R_hat
-  std::vector<std::string> header(percentiles.size() + 7);
-  header.at(0) = "Mean";
-  header.at(1) = "MCSE";
-  header.at(2) = "StdDev";
-  header.at(3) = "MAD";
-  for (size_t i = 0; i < percentiles.size(); ++i) {
-    header[i + 4] = percentiles[i] + '%';
+  // Mean, MCSE,  StdDev, MAD, ... percentiles ...,
+  // ESS_bulk, ESS_tail, ESS_bulk/s, R_hat
+  std::vector<std::string> header;
+  header.emplace_back("Mean");
+  header.emplace_back("MCSE");
+  header.emplace_back("StdDev");
+  header.emplace_back("MAD");
+  for (auto per : percentiles) {
+    header.push_back(per + '%');
   }
-  size_t offset = 4 + percentiles.size();
-  header.at(offset) = "ESS_bulk";
-  header.at(offset + 1) = "ESS_tail";
-  header.at(offset + 2) = "R_hat";
+  header.emplace_back("ESS_bulk");
+  header.emplace_back("ESS_tail");
+  header.emplace_back("ESS_bulk/s");
+  header.emplace_back("R_hat");
   return header;
 }
 
 /**
  * Compute statistics for span of output columns
- *  Mean, MCSE,  StdDev, MAD, ... percentiles ..., ESS_bulk, ESS_tail, R_hat
+ *  Mean, MCSE,  StdDev, MAD, ... percentiles ...,
+ * ESS_bulk, ESS_tail, ESS_bulk/s, R_hat
  *
  * @param in set of samples from one or more chains
- * @param in vector of warmup times  (required for N_eff/S)
  * @param in vector of sampling times (required for N_eff/S)
  * @param in vector of probabilities
  * @param in vector of model param column incides in chains object
@@ -404,6 +405,8 @@ void get_stats(const stan::mcmc::chainset &chains,
     throw std::domain_error("get_stats: size mismatch");
   }
 
+  double total_sampling_time = sampling_times.sum();
+
   // Model parameters
   int i = 0;
   for (int i_chains : cols) {
@@ -415,14 +418,15 @@ void get_stats(const stan::mcmc::chainset &chains,
     for (int j = 0; j < quantiles.size(); j++)
       params(i, 4 + j) = quantiles(j);
 
+    auto offset = 4 + quantiles.size();
     auto [ess_bulk, ess_tail] = chains.split_rank_normalized_ess(i_chains);
 
-    params(i, quantiles.size() + 4) = ess_bulk;
-    params(i, quantiles.size() + 5) = ess_tail;
+    params(i, offset++) = ess_bulk;
+    params(i, offset++) = ess_tail;
+    params(i, offset++) = ess_bulk / total_sampling_time;
 
     auto [rhat_bulk, rhat_tail] = chains.split_rank_normalized_rhat(i_chains);
-    params(i, quantiles.size() + 6)
-        = rhat_bulk > rhat_tail ? rhat_bulk : rhat_tail;
+    params(i, offset++) = rhat_bulk > rhat_tail ? rhat_bulk : rhat_tail;
     i++;
   }
 }

--- a/src/test/interface/stansummary_test.cpp
+++ b/src/test/interface/stansummary_test.cpp
@@ -583,7 +583,8 @@ TEST(CommandStansummary, check_csv_output_sig_figs) {
   std::string energy
       = "\"energy__\",7.8,0.051,1,0.75,6.8,7.5,9.9,4.9e+02,4.9e+02,2.1e+04,1";
   std::string theta
-      = "\"theta\",0.26,0.0061,0.12,0.12,0.08,0.25,0.47,3.6e+02,4e+02,1.6e+04,1";
+      = "\"theta\",0.26,0.0061,0.12,0.12,0.08,0.25,0.47,3.6e+02,4e+02,1.6e+04,"
+        "1";
 
   std::string path_separator;
   path_separator.push_back(get_path_separator());

--- a/src/test/interface/stansummary_test.cpp
+++ b/src/test/interface/stansummary_test.cpp
@@ -137,9 +137,10 @@ TEST(CommandStansummary, matrix_index_2d) {
 TEST(CommandStansummary, header_tests) {
   std::string expect
       = "      Mean  MCSE StdDev     MAD      10%       50%        90%"
-        "    ESS_bulk     ESS_tail         R_hat\n";
+        "    ESS_bulk     ESS_tail    ESS_bulk/s          R_hat\n";
   std::string expect_csv
-      = "name,Mean,MCSE,StdDev,MAD,10%,50%,90%,ESS_bulk,ESS_tail,R_hat\n";
+      = "name,Mean,MCSE,StdDev,MAD,10%,50%,90%,ESS_bulk,ESS_tail,ESS_bulk/"
+        "s,R_hat\n";
   std::vector<std::string> pcts;
   pcts.push_back("10");
   pcts.push_back("50");
@@ -150,14 +151,15 @@ TEST(CommandStansummary, header_tests) {
   EXPECT_FLOAT_EQ(probs[2], 0.9);
 
   std::vector<std::string> header = get_header(pcts);
-  EXPECT_EQ(header.size(), pcts.size() + 7);
+  EXPECT_EQ(header.size(), pcts.size() + 8);
   EXPECT_EQ(header[0], "Mean");
   EXPECT_EQ(header[2], "StdDev");
   EXPECT_EQ(header[3], "MAD");
   EXPECT_EQ(header[5], "50%");
   EXPECT_EQ(header[7], "ESS_bulk");
   EXPECT_EQ(header[8], "ESS_tail");
-  EXPECT_EQ(header[9], "R_hat");
+  EXPECT_EQ(header[9], "ESS_bulk/s");
+  EXPECT_EQ(header[10], "R_hat");
 
   Eigen::VectorXi column_widths(header.size());
   for (size_t i = 0, w = 5; i < header.size(); ++i, ++w) {
@@ -239,7 +241,7 @@ TEST(CommandStansummary, param_tests) {
   size_t num_model_params = chains.num_params() - model_params_offset;
   EXPECT_EQ(num_model_params, 1);
 
-  Eigen::MatrixXd model_params(num_model_params, 10);
+  Eigen::MatrixXd model_params(num_model_params, 11);
   std::vector<int> model_param_idxes(num_model_params);
   std::iota(model_param_idxes.begin(), model_param_idxes.end(),
             model_params_offset);
@@ -248,7 +250,7 @@ TEST(CommandStansummary, param_tests) {
   double mean_theta = model_params(0, 0);
   EXPECT_TRUE(mean_theta > 0.25);
   EXPECT_TRUE(mean_theta < 0.27);
-  double rhat_theta = model_params(0, 9);
+  double rhat_theta = model_params(0, 10);
   EXPECT_TRUE(rhat_theta > 0.999);
   EXPECT_TRUE(rhat_theta < 1.01);
 }
@@ -426,16 +428,16 @@ TEST(CommandStansummary, bad_include_param_args) {
 TEST(CommandStansummary, check_console_output) {
   std::string lp
       = "lp__            -7.3  3.7e-02     0.77   0.30   -9.0  -7.0  -6.8      "
-        " 519       503    1.0";
+        " 519       503       22578    1.0";
   std::string theta
       = "theta           0.26  6.1e-03     0.12   0.12  0.080  0.25  0.47      "
-        " 362       396    1.0";
+        " 362       396       15718    1.0";
   std::string accept_stat
       = "accept_stat__   0.90  4.6e-03  1.5e-01  0.064   0.57  0.96   1.0      "
-        "1284       941   1.00";
+        "1284       941       55805   1.00";
   std::string energy
       = "energy__         7.8  5.1e-02  1.0e+00   0.75    6.8   7.5   9.9      "
-        " 490       486    1.0";
+        " 490       486       21299    1.0";
 
   std::string path_separator;
   path_separator.push_back(get_path_separator());
@@ -480,16 +482,17 @@ TEST(CommandStansummary, check_console_output) {
 
 TEST(CommandStansummary, check_csv_output) {
   std::string csv_header
-      = "name,Mean,MCSE,StdDev,MAD,5%,50%,95%,ESS_bulk,ESS_tail,R_hat";
+      = "name,Mean,MCSE,StdDev,MAD,5%,50%,95%,ESS_bulk,ESS_tail,ESS_bulk/"
+        "s,R_hat";
   std::string lp
       = "\"lp__\",-7.2719,0.0365168,0.768874,0.303688,-8.98426,-6.97009,-6."
-        "75007,519.29,503.309,1.00141";
+        "75007,519.29,503.309,22577.8,1.00141";
   std::string energy
       = "\"energy__\",7.78428,0.0508815,1.0314,0.745859,6.80565,7.46758,9.8864,"
-        "489.874,486.438,1.00495";
+        "489.874,486.438,21298.9,1.00495";
   std::string theta
       = "\"theta\",0.256552,0.00610844,0.119654,0.120965,0.0802982,0.24996,0."
-        "47034,361.506,395.736,1.00186";
+        "47034,361.506,395.736,15717.6,1.00186";
 
   std::string path_separator;
   path_separator.push_back(get_path_separator());
@@ -532,9 +535,11 @@ TEST(CommandStansummary, check_csv_output) {
 }
 
 TEST(CommandStansummary, check_csv_output_no_percentiles) {
-  std::string csv_header = "name,Mean,MCSE,StdDev,MAD,ESS_bulk,ESS_tail,R_hat";
+  std::string csv_header
+      = "name,Mean,MCSE,StdDev,MAD,ESS_bulk,ESS_tail,ESS_bulk/s,R_hat";
   std::string lp
-      = "\"lp__\",-7.2719,0.0365168,0.768874,0.303688,519.29,503.309,1.00141";
+      = "\"lp__\",-7.2719,0.0365168,0.768874,0.303688,519.29,503.309,22577.8,1."
+        "00141";
 
   std::string path_separator;
   path_separator.push_back(get_path_separator());
@@ -571,12 +576,14 @@ TEST(CommandStansummary, check_csv_output_no_percentiles) {
 
 TEST(CommandStansummary, check_csv_output_sig_figs) {
   std::string csv_header
-      = "name,Mean,MCSE,StdDev,MAD,5%,50%,95%,ESS_bulk,ESS_tail,R_hat";
-  std::string lp = "\"lp__\",-7.3,0.037,0.77,0.3,-9,-7,-6.8,5.2e+02,5e+02,1";
+      = "name,Mean,MCSE,StdDev,MAD,5%,50%,95%,ESS_bulk,ESS_tail,ESS_bulk/"
+        "s,R_hat";
+  std::string lp
+      = "\"lp__\",-7.3,0.037,0.77,0.3,-9,-7,-6.8,5.2e+02,5e+02,2.3e+04,1";
   std::string energy
-      = "\"energy__\",7.8,0.051,1,0.75,6.8,7.5,9.9,4.9e+02,4.9e+02,1";
+      = "\"energy__\",7.8,0.051,1,0.75,6.8,7.5,9.9,4.9e+02,4.9e+02,2.1e+04,1";
   std::string theta
-      = "\"theta\",0.26,0.0061,0.12,0.12,0.08,0.25,0.47,3.6e+02,4e+02,1";
+      = "\"theta\",0.26,0.0061,0.12,0.12,0.08,0.25,0.47,3.6e+02,4e+02,1.6e+04,1";
 
   std::string path_separator;
   path_separator.push_back(get_path_separator());
@@ -621,20 +628,21 @@ TEST(CommandStansummary, check_csv_output_sig_figs) {
 
 TEST(CommandStansummary, check_csv_output_include_param) {
   std::string csv_header
-      = "name,Mean,MCSE,StdDev,MAD,5%,50%,95%,ESS_bulk,ESS_tail,R_hat";
+      = "name,Mean,MCSE,StdDev,MAD,5%,50%,95%,ESS_bulk,ESS_tail,ESS_bulk/"
+        "s,R_hat";
   std::string lp
       = "\"lp__\",-15.5617,0.97319,6.05585,6.3817,-25.3182,-15.7598,-5.47732,"
-        "41.1897,113.537,1.00153";
+        "41.1897,113.537,396.283,1.00153";
   std::string energy
       = "\"energy__\",20.5888,1.01449,6.43127,6.6161,10.2809,20.8278,30.9921,"
-        "42.5605,140.171,1.00069";
+        "42.5605,140.171,409.472,1.00069";
   // note: skipping theta 1-5
   std::string theta6
       = "\"theta[6]\",5.001,0.365016,5.76072,5.37947,-4.95375,5.22746,14.1688,"
-        "230.645,464.978,1.00054";
+        "230.645,464.978,2219.02,1.00054";
   std::string theta7
       = "\"theta[7]\",8.54125,0.650098,6.22195,5.35785,-0.814388,8.09342,19."
-        "2622,92.3075,241.177,1.00244";
+        "2622,92.3075,241.177,888.084,1.00244";
   // note: skipping theta 8
   std::string message = "# Inference for Stan model: eight_schools_cp_model";
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Removed in #1290, this adds it back based on ESS_bulk

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
