### PR TITLE
Remove broken STAN_CPP_OPTIMS output from model info

### DIFF
--- a/src/cmdstan/write_stan_flags.hpp
+++ b/src/cmdstan/write_stan_flags.hpp
@@ -27,11 +27,6 @@ void write_stan_flags(stan::callbacks::writer &writer) {
 #else
   writer("STAN_NO_RANGE_CHECKS=false");
 #endif
-#ifdef STAN_CPP_OPTIMS
-  writer("STAN_CPP_OPTIMS=true");
-#else
-  writer("STAN_CPP_OPTIMS=false");
-#endif
 }
 
 }  // namespace cmdstan


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Closes #1326 by removing this line of output from `model info`. It was never set to the correct value, 
nor is it a particularly meaningful thing to have included IMO due to the variability of the CXXFLAGs even
if you knew if this variable was set.

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
