### PR TITLE
Optimize tests: don't assume number of algorithmic parameters in output

### DIFF
--- a/src/test/interface/optimization_output_test.cpp
+++ b/src/test/interface/optimization_output_test.cpp
@@ -59,10 +59,12 @@ TEST_F(CmdStan, optimize_default) {
   EXPECT_TRUE(boost::contains(config[jacobian_idx], "= false (Default)"));
 
   ASSERT_NEAR(0, values[0], 0.00001);
-  EXPECT_FLOAT_EQ(1, values[1]);
-  EXPECT_FLOAT_EQ(100, values[2]);
-  EXPECT_FLOAT_EQ(10000, values[3]);
-  EXPECT_FLOAT_EQ(1000000, values[4]);
+  auto outputs = values.size();
+
+  EXPECT_FLOAT_EQ(1, values[outputs - 4]);
+  EXPECT_FLOAT_EQ(100, values[outputs - 3]);
+  EXPECT_FLOAT_EQ(10000, values[outputs - 2]);
+  EXPECT_FLOAT_EQ(1000000, values[outputs - 1]);
 }
 
 TEST_F(CmdStan, optimize_bfgs) {
@@ -85,10 +87,12 @@ TEST_F(CmdStan, optimize_bfgs) {
   EXPECT_FALSE(boost::contains(config[algo_idx], "lbfgs"));
 
   ASSERT_NEAR(0, values[0], 0.00001);
-  EXPECT_FLOAT_EQ(1, values[1]);
-  EXPECT_FLOAT_EQ(100, values[2]);
-  EXPECT_FLOAT_EQ(10000, values[3]);
-  EXPECT_FLOAT_EQ(1000000, values[4]);
+  auto outputs = values.size();
+
+  EXPECT_FLOAT_EQ(1, values[outputs - 4]);
+  EXPECT_FLOAT_EQ(100, values[outputs - 3]);
+  EXPECT_FLOAT_EQ(10000, values[outputs - 2]);
+  EXPECT_FLOAT_EQ(1000000, values[outputs - 1]);
 }
 
 TEST_F(CmdStan, optimize_lbfgs) {
@@ -110,10 +114,12 @@ TEST_F(CmdStan, optimize_lbfgs) {
   EXPECT_TRUE(boost::contains(config[algo_idx], "lbfgs"));
 
   ASSERT_NEAR(0, values[0], 0.00001);
-  EXPECT_FLOAT_EQ(1, values[1]);
-  EXPECT_FLOAT_EQ(100, values[2]);
-  EXPECT_FLOAT_EQ(10000, values[3]);
-  EXPECT_FLOAT_EQ(1000000, values[4]);
+  auto outputs = values.size();
+
+  EXPECT_FLOAT_EQ(1, values[outputs - 4]);
+  EXPECT_FLOAT_EQ(100, values[outputs - 3]);
+  EXPECT_FLOAT_EQ(10000, values[outputs - 2]);
+  EXPECT_FLOAT_EQ(1000000, values[outputs - 1]);
 }
 
 TEST_F(CmdStan, optimize_newton) {
@@ -135,10 +141,12 @@ TEST_F(CmdStan, optimize_newton) {
   EXPECT_TRUE(boost::contains(config[algo_idx], "newton"));
 
   ASSERT_NEAR(0, values[0], 0.00001);
-  EXPECT_FLOAT_EQ(1, values[1]);
-  EXPECT_FLOAT_EQ(100, values[2]);
-  EXPECT_FLOAT_EQ(10000, values[3]);
-  EXPECT_FLOAT_EQ(1000000, values[4]);
+  auto outputs = values.size();
+
+  EXPECT_FLOAT_EQ(1, values[outputs - 4]);
+  EXPECT_FLOAT_EQ(100, values[outputs - 3]);
+  EXPECT_FLOAT_EQ(10000, values[outputs - 2]);
+  EXPECT_FLOAT_EQ(1000000, values[outputs - 1]);
 }
 
 TEST_F(CmdStan, optimize_jacobian_adjust) {
@@ -158,8 +166,9 @@ TEST_F(CmdStan, optimize_jacobian_adjust) {
   EXPECT_NE(jacobian_idx, -1);
   EXPECT_TRUE(boost::contains(config1[jacobian_idx], "= false (Default)"));
 
+  auto outputs = values1.size();
   ASSERT_NEAR(0, values1[0], 0.00001);
-  ASSERT_NEAR(3, values1[1], 0.01);
+  ASSERT_NEAR(3, values1[outputs - 1], 0.01);
 
   ss.str(std::string());
   ss << convert_model_path(simple_jacobian_model) << " random seed=1234"
@@ -176,5 +185,5 @@ TEST_F(CmdStan, optimize_jacobian_adjust) {
   EXPECT_NE(jacobian_idx, -1);
   EXPECT_TRUE(boost::contains(config2[jacobian_idx], "= true"));
 
-  ASSERT_NEAR(3.3, values2[1], 0.01);
+  ASSERT_NEAR(3.3, values2[outputs - 1], 0.01);
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

For https://github.com/stan-dev/stan/pull/3379, this updates the tests of optimization output to allow for
more than one algorithm column in output (currently only `lp__`).

It can be merged independently.

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
