### PR TITLE
Add AI contribution policy

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,3 +8,4 @@ Here are links to create issues for related Stan projects.
 |-----------|------------|-------|
 | [Math](https://github.com/stan-dev/math/issues/new) <br /> [Stan](https://github.com/stan-dev/stan/issues/new) | [CmdStan](https://github.com/stan-dev/cmdstan/issues/new) <br /> [RStan](https://github.com/stan-dev/rstan/issues/new) <br /> [PyStan](https://github.com/stan-dev/pystan/issues/new) | [shinyStan](https://github.com/stan-dev/shinystan/issues) |
 
+All contributions must follow the [Stan AI Contribution Policy](https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy).


### PR DESCRIPTION
#### Submisison Checklist

- ~[ ] Run tests: `./runCmdStanTests.py src/test`~
- [x] Declare copyright holder and open-source license: see below

#### Summary:
This PR adds a reference to the Stan AI Contribution Policy (see Stan-wiki: https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy) to the CONTRIBUTING.md so contributors are aware of it before submitting PRs.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Aalto university

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
