### PR TITLE
[wip] Migration to new jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,397 +1,154 @@
-@Library('StanUtils')
-import org.stan.Utils
+properties([
+  disableConcurrentBuilds(abortPrevious: !params.downstream),
+  buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '30')),
+  parameters([
+    string(defaultValue: '', name: 'stan_pr',
+           description: "Stan PR to test against. Will check out this PR in the downstream Stan repo."),
+    string(defaultValue: '', name: 'math_pr',
+           description: "Math PR to test against. Will check out this PR in the downstream Math repo."),
+    string(defaultValue: 'nightly', name: 'stanc3_bin_url',
+            description: 'Custom stanc3 binary url'),
+    booleanParam(defaultValue: false, name: 'downsteam', description: 'Run downstream tests from stan (was previously downstream_hotfix [master]/downstream_tests [develop])'),
+    booleanParam(defaultValue: false, name: 'run_all', description: 'Pretend all files changes'),
+  ])
+])
 
-def utils = new org.stan.Utils()
-def skipRemainingStages = false
+def commit
+def runRemainingStages = false
+def WIN_CXX = 'g++'
+def MPI_CXX = 'mpicxx.openmpi'
+def MAC_CXX = 'clang++'
+def WINSETENV = '''
+  SET "PATH=%RTOOLS%\\x86_64-w64-mingw32.static.posix\\bin;%RTOOLS%;%RTOOLS%\\usr\\bin;%CONDA%;%PATH%"
+'''
 
-def setupCXX(CXX = env.CXX) {
-    unstash 'CmdStanSetup'
+catchError {
+  withEnv([
+    'GIT_AUTHOR_NAME=Stan Jenkins',
+    'GIT_AUTHOR_EMAIL=mc.stanislaw@gmail.com',
+    'GIT_COMMITTER_NAME=Stan Jenkins',
+    'GIT_COMMITTER_EMAIL=mc.stanislaw@gmail.com'
+  ]) {
+    runPod(image: "stanorg/ci:gpu", cpus: 2) {
+      commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+      runRemainingStages = params.downstream || params.run_all || filesChanged('src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile')
 
-    stanc3_bin_url_str = params.stanc3_bin_url != "nightly" ? "\nSTANC3_TEST_BIN_URL=${params.stanc3_bin_url}\n" : ""
-    writeFile(file: "make/local", text: "CXX=${CXX} \n${stanc3_bin_url_str} \nCXXFLAGS+=-Wp,-D_GLIBCXX_ASSERTIONS\n")
-}
-
-def runTests(String prefix = "") {
-    "${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface"
-}
-
-def runWinTests(String prefix = "") {
-    withEnv(["PATH+TBB=${WORKSPACE}\\stan\\lib\\stan_math\\lib\\tbb"]) {
-        bat """
-            SET \"PATH=${env.RTOOLS40_HOME};%PATH%\"
-            SET \"PATH=${env.RTOOLS40_HOME}\\usr\\bin;${LLVM7}\\bin;%PATH%\" //
-            SET \"PATH=${env.RTOOLS40_HOME}\\mingw64\\bin;%PATH%\"
-            SET \"PATH=C:\\PROGRA~1\\R\\R-4.1.2\\bin;%PATH%\"
-            SET \"PATH=C:\\PROGRA~1\\Microsoft^ MPI\\Bin;%PATH%\"
-            SET \"MPI_HOME=C:\\PROGRA~1\\Microsoft^ MPI\\Bin\"
-            SET \"PATH=C:\\Users\\jenkins\\Anaconda3;%PATH%\"
-            python ${prefix}runCmdStanTests.py -j${env.PARALLEL} src/test/interface
+      stage('clang-format') {
+        def dirty = sh returnStatus: true, script: """
+          clang-format --version
+          git ls-files 'src/*.hpp' 'src/*.cpp' | xargs -n20 -P\$PARALLEL clang-format -i
+          git diff --exit-code
         """
+        if (dirty) {
+          def branch = env.CHANGE_BRANCH ?: env.BRANCH_NAME
+          def repo = env.CHANGE_FORK ?: "stan-dev"
+          if (!("/" in repo))
+            repo += "/cmdstan.git"
+          echo "Exiting build because clang-format found changes."
+          emailext (
+              subject: "[StanJenkins] Autoformattted: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
+              body: """
+Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' has been autoformatted and the
+changes committed to your branch, if permissions allowed.  Please pull these
+changes before continuing.
+
+See https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms for setting
+up the autoformatter locally.  (Check console output at ${env.BUILD_URL})
+""",
+              recipientProviders: [[$class: 'RequesterRecipientProvider']],
+              to: env.CHANGE_AUTHOR_EMAIL)
+          sh '''
+            git add -u src
+            git commit -m "[Jenkins] auto-formatting by `clang-format --version`"
+          '''
+          gitPush(gitScm: scmGit(
+              userRemoteConfigs: [[credentialsId: "stan-github", name: 'dest', url: "https://github.com/$repo"]],
+              branches: [[name: "refs/heads/$branch"]]),
+              targetBranch: branch,
+              targetRepo: 'dest')
+          echo "Those changes are now found on stan-dev/cmdstan under $repo branch $branch"
+          echo "Please 'git pull' before continuing to develop."
+          error "clang-format changes"
+        }
+      }
     }
+
+    def scmFull = scmGit(
+      branches: scm.branches,
+      userRemoteConfigs: scm.userRemoteConfigs,
+      extensions: scm.extensions + [cleanBeforeCheckout(),
+        submodule(recursiveSubmodules: true, shallow: true, depth: 2)])
+
+    def prepTests = { extra ->
+      checkout scmFull
+      checkoutPR("stan", params.stan_pr)
+      checkoutPR("stan/lib/stan_math", params.math_pr)
+
+      def local = "CXXFLAGS+=-Wp,-D_GLIBCXX_ASSERTIONS -Werror -Wno-unused-command-line-argument\n"
+      if (params.stanc3_bin_url != "nightly") {
+        local += "STANC3_TEST_BIN_URL=${params.stanc3_bin_url}\n"
+      }
+      writeFile(file: "make/local", text: local + extra)
+    }
+
+    if (runRemainingStages) {
+      parallel windows: {
+        node('windows') {
+          stage('Windows interface tests') {
+            prepTests("CXX=${WIN_CXX}")
+            withEnv(["PATH+TBB=${WORKSPACE}\\stan\\lib\\stan_math\\lib\\tbb"]) {
+              bat """$WINSETENV
+                  python runCmdStanTests.py -j%PARALLEL% src/test/interface
+              """
+            }
+          }
+        }
+      }, linux: {
+        runPod(image: "stanorg/ci:gpu", checkout: false) {
+          stage('Linux interface tests with MPI') {
+            prepTests("""CXX=${MPI_CXX}
+STAN_MPI=true
+CXX_TYPE=gcc""")
+            sh "make build-mpi > build-mpi.log 2>&1"
+            sh './runCmdStanTests.py -j$PARALLEL src/test/interface'
+          }
+        }
+      }, mac: {
+        node('macos') {
+          stage('Mac interface tests') {
+            prepTests("CXX=${MAC_CXX}")
+            sh 'python3 ./runCmdStanTests.py -j$PARALLEL src/test/interface'
+          }
+        }
+      }, upstream: {
+        if (params.downstream || env.CHANGE_TARGET) {
+          stage('Upstream CmdStan Performance tests') {
+            build(
+                job: "CCM/Stan/performance-tests-cmdstan/master",
+                parameters: [
+                    booleanParam(name: 'downstream', value: true),
+                    string(name: 'cmdstan_pr', value: env.BRANCH_NAME),
+                    string(name: 'stan_pr', value: params.stan_pr),
+                    string(name: 'math_pr', value: params.math_pr),
+                    string(name: 'stanc3_bin_url', value: params.stanc3_bin_url),
+                ],
+                wait: true)
+          }
+        }
+      }
+      /* TODO recordIssues? */
+    }
+
+    if (env.BRANCH_NAME == 'develop') {
+      podTemplate(inheritFrom: 'jnlp') {
+        node(POD_LABEL) {
+          stage('Update performance tests submodule') {
+            updateSubmodule('performance-tests-cmdstan', 'master', 'cmdstan', commit)
+          }
+        }
+      }
+    }
+  }
 }
 
-def deleteDirWin() {
-    bat "attrib -r -s /s /d"
-    deleteDir()
-}
-
-Boolean isPR() { env.CHANGE_URL != null }
-String fork() { env.CHANGE_FORK ?: "stan-dev" }
-String branchName() { isPR() ? env.CHANGE_BRANCH :env.BRANCH_NAME }
-
-
-pipeline {
-    agent none
-    options {
-        skipDefaultCheckout()
-        disableConcurrentBuilds(abortPrevious: env.BRANCH_NAME != "downstream_tests" && env.BRANCH_NAME != "downstream_hotfix")
-    }
-    parameters {
-        string(defaultValue: '', name: 'stan_pr',
-               description: "Stan PR to test against. Will check out this PR in the downstream Stan repo.")
-        string(defaultValue: '', name: 'math_pr',
-               description: "Math PR to test against. Will check out this PR in the downstream Math repo.")
-        string(defaultValue: 'nightly', name: 'stanc3_bin_url',
-                  description: 'Custom stanc3 binary url')
-    }
-    environment {
-        MAC_CXX = 'clang++'
-        LINUX_CXX = 'clang++-6.0'
-        WIN_CXX = 'g++'
-        PARALLEL = 4
-        MPICXX = 'mpicxx.openmpi'
-        GIT_AUTHOR_NAME = 'Stan Jenkins'
-        GIT_AUTHOR_EMAIL = 'mc.stanislaw@gmail.com'
-        GIT_COMMITTER_NAME = 'Stan Jenkins'
-        GIT_COMMITTER_EMAIL = 'mc.stanislaw@gmail.com'
-    }
-    stages {
-        stage('Clean & Setup') {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                }
-            }
-            steps {
-                retry(3) { checkout scm }
-                sh 'git clean -xffd'
-                sh 'make stan-revert'
-                script {
-                    utils.checkout_pr("stan", "stan", params.stan_pr)
-                    utils.checkout_pr("math", "stan/lib/stan_math", params.math_pr)
-                }
-
-                stash 'CmdStanSetup'
-            }
-            post { always { deleteDir() }}
-        }
-        stage('Verify changes') {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                }
-            }
-            steps {
-                script {
-                    retry(3) { checkout scm }
-                    sh 'git clean -xffd'
-
-                    def paths = ['src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile'].join(" ")
-                    skipRemainingStages = utils.verifyChanges(paths)
-                }
-            }
-            post {
-                always {
-                    deleteDir()
-                }
-            }
-        }
-        stage("Clang-format") {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                }
-            }
-            steps {
-                retry(3) { checkout scm }
-                withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                    usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                    sh """#!/bin/bash
-                        set -x
-                        git checkout -b ${branchName()}
-                        clang-format --version
-                        find src -name '*.hpp' -o -name '*.cpp' | xargs -n20 -P${env.PARALLEL} clang-format -i
-                        if [[ `git diff` != "" ]]; then
-                            git add src
-                            git commit -m "[Jenkins] auto-formatting by `clang-format --version`"
-                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/cmdstan.git ${branchName()}
-                            echo "Exiting build because clang-format found changes."
-                            echo "Those changes are now found on stan-dev/cmdstan under branch ${branchName()}"
-                            echo "Please 'git pull' before continuing to develop."
-                            exit 1
-                        fi
-                    """
-                }
-            }
-            post {
-                always { deleteDir() }
-                failure {
-                    script {
-                        emailext (
-                            subject: "[StanJenkins] Autoformattted: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
-                            body: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' " +
-                                "has been autoformatted and the changes committed " +
-                                "to your branch, if permissions allowed." +
-                                "Please pull these changes before continuing." +
-                                "\n\n" +
-                                "See https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms" +
-                                " for setting up the autoformatter locally.\n"+
-                            "(Check console output at ${env.BUILD_URL})",
-                            recipientProviders: [[$class: 'RequesterRecipientProvider']],
-                            to: "${env.CHANGE_AUTHOR_EMAIL}"
-                        )
-                    }
-                }
-            }
-        }
-        stage('Parallel tests') {
-            when {
-                expression {
-                    !skipRemainingStages
-                }
-            }
-            parallel {
-                stage('Windows interface tests') {
-                    agent { label 'windows' }
-                    steps {
-                        setupCXX(WIN_CXX)
-                        runWinTests()
-                    }
-                    post {
-                        always {
-
-                            recordIssues(
-                                id: "Windows",
-                                name: "Windows interface tests",
-                                enabledForFailure: true,
-                                aggregatingResults : false,
-                                filters: [
-                                    excludeFile('/lib/.*'),
-                                    excludeFile('tbb/*'),
-                                    excludeFile('stan/lib/stan_math/lib/*'),
-                                    excludeMessage(".*'sprintf' is deprecated.*")
-                                ],
-                                tools: [
-                                    gcc4(id: "Windows_gcc4", name: "Windows interface tests@GCC4"),
-                                    clang(id: "Windows_clang", name: "Windows interface tests@CLANG")
-                                ],
-                                qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-                                healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH'
-                            )
-
-                            deleteDirWin()
-                        }
-                    }
-                }
-
-                stage('Linux interface tests with MPI') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:gpu'
-                            label 'linux'
-                        }
-                    }
-                    steps {
-                        setupCXX(MPICXX)
-                        sh "echo STAN_MPI=true >> make/local"
-                        sh "echo CXX_TYPE=gcc >> make/local"
-                        sh "make build-mpi > build-mpi.log 2>&1"
-                        sh runTests("./")
-                    }
-                    post {
-                        always {
-
-                            recordIssues(
-                                id: "Linux_mpi",
-                                name: "Linux interface tests with MPI",
-                                enabledForFailure: true,
-                                aggregatingResults : false,
-                                filters: [
-                                    excludeFile('/lib/.*'),
-                                    excludeFile('tbb/*'),
-                                    excludeFile('stan/lib/stan_math/lib/*'),
-                                    excludeMessage(".*'sprintf' is deprecated.*")
-                                ],
-                                tools: [
-                                    gcc4(id: "Linux_mpi_gcc4", name: "Linux interface tests with MPI@GCC4"),
-                                    clang(id: "Linux_mpi_clang", name: "Linux interface tests with MPI@CLANG")
-                                ],
-                                qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-                                healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH'
-                            )
-
-                            deleteDir()
-                        }
-                    }
-                }
-
-                stage('Mac interface tests') {
-                    agent { label 'osx' }
-                    steps {
-                        setupCXX(MAC_CXX)
-                        sh runTests("python3 ./")
-                    }
-                    post {
-                        always {
-
-                            recordIssues(
-                                id: "Mac",
-                                name: "Mac interface tests",
-                                enabledForFailure: true,
-                                aggregatingResults : false,
-                                filters: [
-                                    excludeFile('/lib/.*'),
-                                    excludeFile('tbb/*'),
-                                    excludeFile('stan/lib/stan_math/lib/*'),
-                                    excludeMessage(".*'sprintf' is deprecated.*")
-                                ],
-                                tools: [
-                                    gcc4(id: "Mac_gcc4", name: "Mac interface tests@GCC4"),
-                                    clang(id: "Mac_clang", name: "Mac interface tests@CLANG")
-                                ],
-                                qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-                                healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH'
-                            )
-
-                            deleteDir()
-                        }
-                    }
-                }
-
-                stage('Upstream CmdStan Performance tests') {
-                    when {
-                            expression {
-                                env.BRANCH_NAME ==~ /PR-\d+/ ||
-                                env.BRANCH_NAME == "downstream_tests" ||
-                                env.BRANCH_NAME == "downstream_hotfix"
-                            }
-                        }
-                    steps {
-                        script{
-                            build(
-                                job: "Stan/CmdStan Performance Tests/downstream_tests",
-                                parameters: [
-                                    string(name: 'cmdstan_pr', value: env.BRANCH_NAME),
-                                    string(name: 'stan_pr', value: params.stan_pr),
-                                    string(name: 'math_pr', value: params.math_pr),
-                                    string(name: 'stanc3_bin_url', value: params.stanc3_bin_url)
-                                ],
-                                wait:true
-                            )
-                        }
-                    }
-                }
-
-            }
-        }
-        stage('Update downstream branches') {
-            parallel {
-                stage('Update downstream_hotfix - master') {
-                    agent {
-                        docker {
-                            image 'ellerbrock/alpine-bash-git'
-                            label 'linux'
-                            args '--entrypoint='
-                        }
-                    }
-                    when {
-                        beforeAgent true
-                        branch 'master'
-                    }
-                    steps {
-                        script {
-                            retry(3) {
-                                checkout([
-                                    $class: 'GitSCM',
-                                    branches: [[name: '*/master'], [name: '*/downstream_hotfix']],
-                                    userRemoteConfigs: scm.userRemoteConfigs
-                                ])
-                             }
-                            withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                                usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                                sh """#!/bin/bash
-                                    set -x
-
-                                    git checkout downstream_hotfix
-                                    git reset --hard origin/master
-                                    git status
-                                    git push -f https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_hotfix
-                                """
-                            }
-                        }
-                    }
-                    post {
-                        always {
-                            deleteDir()
-                        }
-                    }
-                }
-                stage('Update downstream_tests - develop') {
-                    agent {
-                        docker {
-                            image 'ellerbrock/alpine-bash-git'
-                            label 'linux'
-                            args '--entrypoint='
-                        }
-                    }
-                    when {
-                        beforeAgent true
-                        branch 'develop'
-                    }
-                    steps {
-                        script {
-                            retry(3) {
-                                checkout([
-                                    $class: 'GitSCM',
-                                    branches: [[name: '*/develop'], [name: '*/downstream_tests']],
-                                    userRemoteConfigs: scm.userRemoteConfigs
-                                ])
-                             }
-                            withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                                usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                                sh """#!/bin/bash
-                                    set -x
-
-                                    git checkout downstream_tests
-                                    git reset --hard origin/develop
-                                    git status
-                                    git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/cmdstan.git downstream_tests
-                                """
-                            }
-                        }
-                    }
-                    post {
-                        always {
-                            deleteDir()
-                        }
-                    }
-                }
-            }
-        }
-    }
-    post {
-        success {
-           script {
-               if (env.BRANCH_NAME == "develop") {
-                   build job: "Stan/CmdStan Performance Tests/master", wait:false
-               }
-               utils.mailBuildResults("SUCCESSFUL")
-           }
-        }
-        unstable { script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com") } }
-        failure { script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com") } }
-    }
-}
+emailFailure()

--- a/src/test/interface/diagnose_test.cpp
+++ b/src/test/interface/diagnose_test.cpp
@@ -74,9 +74,10 @@ TEST(CommandDiagnose, mix) {
   std::string command = "bin" + path_separator + "diagnose";
   std::string csv_file = "src" + path_separator + "test" + path_separator
                          + "interface" + path_separator + "example_output"
-                         + path_separator + "mix_output.*";
+                         + path_separator + "mix_output.";
 
-  auto out = run_command(command + " " + csv_file);
+  auto out
+      = run_command(command + " " + csv_file + "1.csv " + csv_file + "2.csv");
   ASSERT_FALSE(out.hasError) << "\"" << out.command << "\" quit with an error";
 
   compare_to_stored_output(out.output,
@@ -89,9 +90,10 @@ TEST(CommandDiagnose, divergences) {
   std::string command = "bin" + path_separator + "diagnose";
   std::string csv_file = "src" + path_separator + "test" + path_separator
                          + "interface" + path_separator + "example_output"
-                         + path_separator + "div_output*.csv";
+                         + path_separator + "div_output_";
 
-  auto out = run_command(command + " " + csv_file);
+  auto out
+      = run_command(command + " " + csv_file + "1.csv " + csv_file + "2.csv");
   ASSERT_FALSE(out.hasError) << "\"" << out.command << "\" quit with an error";
 
   compare_to_stored_output(out.output,


### PR DESCRIPTION
Migration to new jenkins system, significant cleanup of jenkinsfile.  Mostly maintains previous behaviors and tests, with some minor changes in arguments and parallelism.  Changes to note:

- Removes use of globs in a couple test cases that don't work on windows with the default shell.
- `recordIssues` was removed in favor of more `-Werror` flags. We could look at restoring this, but it has a lot of overhead and unnecessary things in jenkins.
- The separate fake downstream_ branches were replaced with a parameter and direct reference to the relevant branches.

Remaining things I may add:

- Replace use of (aging) `stanorg/ci:gpu` image with local `Dockerfile` (done already in stan and math)
- more consistent email result targets, including `stan-buildbot` list?