### PR TITLE
Use clang PCH template instantiation when available

### DIFF
--- a/make/program
+++ b/make/program
@@ -23,11 +23,17 @@ $(patsubst %.hpp.gch,%.d,$(PRECOMPILED_MODEL_HEADER)) : $(STAN)src/stan/model/mo
 	@mkdir -p $(dir $@)
 	$(COMPILE.cpp) $(DEPFLAGS) $<
 
+ifeq ($(CXX_TYPE),clang)
+ifeq ($(shell expr $(CXX_MAJOR) \>= 11),1)
+CXXFLAGS_PCH += -fpch-instantiate-templates
+endif
+endif
+
 $(PRECOMPILED_MODEL_HEADER) : $(STAN)src/stan/model/model_header.hpp
 	@echo ''
 	@echo '--- Compiling pre-compiled header. This might take a few seconds. ---'
 	@mkdir -p $(dir $@)
-	$(COMPILE.cpp) $< $(OUTPUT_OPTION)
+	$(COMPILE.cpp) $(CXXFLAGS_PCH) $< $(OUTPUT_OPTION)
 
 ifeq ($(CXX_TYPE),clang)
 CXXFLAGS_PROGRAM += -include-pch $(PRECOMPILED_MODEL_HEADER)


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

From clang 11+ the `-fpch-instantiate-templates` flag is available, which instantiates any template usages present in the header being pre-compiled so that they aren't instantiated repeatedly on each subsequent usage.

#### Intended Effect:

Reduce model compilation time. For me (m1 mac), this reduces the `bernoulli` model compilation time from ~4secs to ~2secs

#### How to Verify:

Compile stan model using clang +=11

#### Side Effects:

N/A

#### Documentation:

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
