### PR TITLE
fix standalone gqs rng seed use

### DIFF
--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -392,7 +392,6 @@ int command(int argc, const char *argv[]) {
       fitted_params_vec.emplace_back(
           fitted_params.samples.block(0, col_offset, num_rows, num_cols));
     }
-    // `id` offsets the RNG per chain, as it does for the sampler methods
     return_code = stan::services::standalone_generate(
         model, num_chains, fitted_params_vec, random_seed, interrupt, logger,
         sample_writers, id);

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -392,9 +392,10 @@ int command(int argc, const char *argv[]) {
       fitted_params_vec.emplace_back(
           fitted_params.samples.block(0, col_offset, num_rows, num_cols));
     }
+    // `id` offsets the RNG per chain, as it does for the sampler methods
     return_code = stan::services::standalone_generate(
         model, num_chains, fitted_params_vec, random_seed, interrupt, logger,
-        sample_writers);
+        sample_writers, id);
     // ---- generate_quantities end ---- //
   } else if (user_method->arg("laplace")) {
     // ---- laplace start ---- //

--- a/src/test/interface/generated_quantities_test.cpp
+++ b/src/test/interface/generated_quantities_test.cpp
@@ -112,6 +112,43 @@ TEST_F(CmdStan, generate_quantities_same_in_out_multi_path_diff) {
   ASSERT_TRUE(out.hasError);
 }
 
+// `id` must offset the RNG, as it does for the sample method: two runs that
+// differ only in `id` must not produce identical generated quantities.  This
+// is the launch pattern CmdStanR and CmdStanPy use for parallel chains.
+TEST_F(CmdStan, generate_quantities_chain_id_rng) {
+  std::vector<std::string> out_id_1
+      = {"src", "test", "test-models", "gq_id_1.csv"};
+  std::vector<std::string> out_id_2
+      = {"src", "test", "test-models", "gq_id_2.csv"};
+  auto run_gq = [&](const std::vector<std::string> &out_path, int id) {
+    std::stringstream ss;
+    ss << convert_model_path(bern_gq_model)
+       << " data file=" << convert_model_path(bern_data)
+       << " output file=" << convert_model_path(out_path)
+       << " random seed=12345 id=" << id
+       << " method=generate_quantities fitted_params="
+       << convert_model_path(bern_fitted_params);
+    run_command_output out = run_command(ss.str());
+    EXPECT_FALSE(out.hasError) << out.output;
+  };
+  auto csv_body = [](const std::string &path) {
+    std::ifstream in(path.c_str());
+    std::stringstream out;
+    std::string line;
+    while (std::getline(in, line)) {
+      if (!line.empty() && line[0] != '#')
+        out << line << "\n";
+    }
+    return out.str();
+  };
+  run_gq(out_id_1, 1);
+  run_gq(out_id_2, 2);
+  std::string body_1 = csv_body(convert_model_path(out_id_1));
+  std::string body_2 = csv_body(convert_model_path(out_id_2));
+  ASSERT_FALSE(body_1.empty());
+  EXPECT_NE(body_1, body_2);
+}
+
 TEST_F(CmdStan, generate_quantities_non_scalar_good) {
   std::stringstream ss;
   ss << convert_model_path(gq_non_scalar_model)


### PR DESCRIPTION
cmdstan part of fixing https://github.com/stan-dev/stan/issues/3401

This PR does not compile without https://github.com/stan-dev/stan/issues/3401 merged!

Making the fix and PR text were assisted by Claude

#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

https://github.com/stan-dev/stan/pull/3402 adds the chain-id parameter to
`stan::services::standalone_generate`. This PR forwards CmdStan's existing
`id` argument in `src/cmdstan/command.hpp`.

#### Intended Effect:

`id=` offsets the RNG for `generate_quantities` exactly as it does for
`sample`, so parallel GQ chains launched as separate processes no longer
share a random number stream.

#### How to Verify:

`./runCmdStanTests.py src/test/interface/generated_quantities_test.cpp`

New test `generate_quantities_chain_id_rng`: two runs of `bern_gq_model`
on the same `fitted_params`, differing only in `id`, must not produce
identical CSV bodies. It fails on develop and passes with this PR plus
https://github.com/stan-dev/stan/pull/3402.

#### Side Effects:

Output of multi-process standalone generated quantities runs changes (to correct behavior)

#### Documentation:

Existing documentation matches the desired behavior.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Aki Vehtari

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
