### PR TITLE
Replace Boost `algorithm` and `posix_time` usages with standard library

### DIFF
--- a/src/cmdstan/arguments/arg_seed.hpp
+++ b/src/cmdstan/arguments/arg_seed.hpp
@@ -2,7 +2,7 @@
 #define CMDSTAN_ARGUMENTS_ARG_SEED_HPP
 
 #include <cmdstan/arguments/singleton_argument.hpp>
-#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <chrono>
 #include <string>
 
 namespace cmdstan {
@@ -19,10 +19,9 @@ class arg_seed : public long_long_int_argument {
     _default = "-1";
     _default_value = -1;
     _value = _default_value;
-    _random_value
-        = (boost::posix_time::microsec_clock::universal_time()
-           - boost::posix_time::ptime(boost::posix_time::min_date_time))
-              .total_milliseconds();
+    _random_value = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::system_clock::now().time_since_epoch())
+                        .count();
   }
 
   bool is_valid(long long int value) {

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -25,7 +25,7 @@
 #include <stan/callbacks/unique_stream_writer.hpp>
 #include <stan/callbacks/writer.hpp>
 #include <stan/io/dump.hpp>
-#include <stan/io/ends_with.hpp>
+#include <stan/io/string_utils.hpp>
 #include <stan/io/stan_csv_reader.hpp>
 #include <stan/io/json/json_data.hpp>
 #include <stan/model/model_base.hpp>

--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -14,7 +14,6 @@
 #include <stan/model/log_prob_grad.hpp>
 #include <stan/model/model_base.hpp>
 #include <stan/services/sample/standalone_gqs.hpp>
-#include <boost/algorithm/string.hpp>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -224,7 +223,7 @@ context_vector get_vec_var_context(const std::string &file, size_t num_chains,
   if (has_commas && !missing_files.empty()) {
     std::stringstream msg;
     msg << "Cannot open some of the requested files: [";
-    msg << boost::algorithm::join(missing_files, ", ");
+    msg << stan::io::join(missing_files, ", ");
     msg << "]" << std::endl;
     throw std::invalid_argument(msg.str());
   }
@@ -235,7 +234,7 @@ context_vector get_vec_var_context(const std::string &file, size_t num_chains,
   if (stream.rdstate() & std::ifstream::failbit) {
     std::stringstream msg;
     msg << "Cannot open some of the requested files: [";
-    msg << boost::algorithm::join(missing_files, ", ");
+    msg << stan::io::join(missing_files, ", ");
     msg << "]" << std::endl;
     msg << "Also failed to find base file " << file << std::endl;
     msg << "When cmdstan is given a file 'name' and there are "
@@ -311,7 +310,7 @@ void parse_stan_csv(const std::string &fname,
   // compute offset, size of parameters block
   col_offset = 0;
   for (auto col_name : fitted_params.header) {
-    if (boost::algorithm::ends_with(col_name, "__")) {
+    if (stan::io::ends_with(col_name, "__")) {
       col_offset++;
     } else {
       break;
@@ -435,17 +434,13 @@ Eigen::VectorXd get_laplace_mode_csv(const std::string &fname,
   std::ifstream in = file::safe_open(fname);
   while (in.peek() == '#') {
     std::getline(in, line);
-    if (boost::contains(line, "method = optimize"))
+    if (stan::io::contains(line, "method = optimize"))
       is_optimization = true;
   }
   std::getline(in, line);
-  std::vector<std::string> names;
-  boost::algorithm::split(names, line, boost::is_any_of(","),
-                          boost::token_compress_on);
+  std::vector<std::string> names = stan::io::split(line, ",", true);
   std::getline(in, line);
-  std::vector<std::string> values;
-  boost::algorithm::split(values, line, boost::is_any_of(","),
-                          boost::token_compress_on);
+  std::vector<std::string> values = stan::io::split(line, ",", true);
   in.close();
   // validate
   if (!is_optimization) {
@@ -455,7 +450,7 @@ Eigen::VectorXd get_laplace_mode_csv(const std::string &fname,
   // columns: algorithm outputs ending in "__", params, txparms, and gq vars
   size_t col_offset = 0;
   for (auto name : names) {
-    if (boost::algorithm::ends_with(name, "__")) {
+    if (stan::io::ends_with(name, "__")) {
       col_offset++;
     } else {
       break;

--- a/src/cmdstan/command_helper.hpp
+++ b/src/cmdstan/command_helper.hpp
@@ -7,6 +7,7 @@
 #include <stan/callbacks/json_writer.hpp>
 #include <stan/callbacks/writer.hpp>
 #include <stan/io/dump.hpp>
+#include <stan/io/ends_with.hpp>
 #include <stan/io/empty_var_context.hpp>
 #include <stan/io/json/json_data.hpp>
 #include <stan/io/stan_csv_reader.hpp>
@@ -310,7 +311,7 @@ void parse_stan_csv(const std::string &fname,
   // compute offset, size of parameters block
   col_offset = 0;
   for (auto col_name : fitted_params.header) {
-    if (stan::io::ends_with(col_name, "__")) {
+    if (stan::io::ends_with("__", col_name)) {
       col_offset++;
     } else {
       break;
@@ -450,7 +451,7 @@ Eigen::VectorXd get_laplace_mode_csv(const std::string &fname,
   // columns: algorithm outputs ending in "__", params, txparms, and gq vars
   size_t col_offset = 0;
   for (auto name : names) {
-    if (stan::io::ends_with(name, "__")) {
+    if (stan::io::ends_with("__", name)) {
       col_offset++;
     } else {
       break;

--- a/src/cmdstan/file.hpp
+++ b/src/cmdstan/file.hpp
@@ -1,7 +1,8 @@
 #ifndef CMDSTAN_FILE_HPP
 #define CMDSTAN_FILE_HPP
 
-#include <boost/algorithm/string.hpp>
+#include <stan/io/string_utils.hpp>
+#include <algorithm>
 #include <string>
 #include <fstream>
 #include <sstream>
@@ -106,10 +107,7 @@ std::pair<std::string, std::string> get_basename_suffix(
 }
 
 std::vector<std::string> split_on_comma(const std::string &input) {
-  std::vector<std::string> result;
-  boost::algorithm::split(result, input, boost::is_any_of(","),
-                          boost::token_compress_on);
-  return result;
+  return stan::io::split(input, ",", true);
 }
 
 /**
@@ -202,8 +200,8 @@ void validate_output_filename(const std::string &fname) {
   std::string sep = std::string(1, cmdstan::file::PATH_SEPARATOR);
   if (!fname.empty()
       && (fname[fname.size() - 1] == PATH_SEPARATOR
-          || boost::algorithm::ends_with(fname, "..")
-          || boost::algorithm::ends_with(fname, sep + "."))) {
+          || stan::io::ends_with(fname, "..")
+          || stan::io::ends_with(fname, sep + "."))) {
     std::stringstream msg;
     msg << "Ill-formed output filename " << fname << std::endl;
     throw std::invalid_argument(msg.str());

--- a/src/cmdstan/file.hpp
+++ b/src/cmdstan/file.hpp
@@ -2,6 +2,7 @@
 #define CMDSTAN_FILE_HPP
 
 #include <stan/io/string_utils.hpp>
+#include <stan/io/ends_with.hpp>
 #include <algorithm>
 #include <string>
 #include <fstream>
@@ -200,8 +201,8 @@ void validate_output_filename(const std::string &fname) {
   std::string sep = std::string(1, cmdstan::file::PATH_SEPARATOR);
   if (!fname.empty()
       && (fname[fname.size() - 1] == PATH_SEPARATOR
-          || stan::io::ends_with(fname, "..")
-          || stan::io::ends_with(fname, sep + "."))) {
+          || stan::io::ends_with("..", fname)
+          || stan::io::ends_with(sep + ".", fname))) {
     std::stringstream msg;
     msg << "Ill-formed output filename " << fname << std::endl;
     throw std::invalid_argument(msg.str());

--- a/src/cmdstan/stansummary.cpp
+++ b/src/cmdstan/stansummary.cpp
@@ -1,13 +1,13 @@
 #include <cmdstan/return_codes.hpp>
 #include <cmdstan/stansummary_helper.hpp>
 #include <stan/io/string_utils.hpp>
+#include <stan/io/ends_with.hpp>
 #include <algorithm>
 #include <fstream>
 #include <iomanip>
 #include <ios>
 #include <iostream>
 #include <vector>
-#include <boost/algorithm/string.hpp>
 #include <CLI11/CLI11.hpp>
 
 using cmdstan::return_codes;
@@ -147,7 +147,7 @@ Options:
     for (int i = 0; i < chains.num_params(); ++i) {
       if (chains.param_name(i).length() > max_name_length)
         max_name_length = chains.param_name(i).length();
-      if (stan::io::ends_with(chains.param_name(i), "__"))
+      if (stan::io::ends_with("__", chains.param_name(i)))
         num_sampler_params++;
     }
     // don't count name 'lp__'

--- a/src/cmdstan/stansummary.cpp
+++ b/src/cmdstan/stansummary.cpp
@@ -1,6 +1,6 @@
 #include <cmdstan/return_codes.hpp>
 #include <cmdstan/stansummary_helper.hpp>
-#include <stan/io/ends_with.hpp>
+#include <stan/io/string_utils.hpp>
 #include <algorithm>
 #include <fstream>
 #include <iomanip>
@@ -97,10 +97,9 @@ Options:
   }
   std::vector<std::string> percentiles;
   Eigen::VectorXd probs;
-  boost::algorithm::trim(percentiles_spec);
+  stan::io::trim(percentiles_spec);
   if (!percentiles_spec.empty()) {
-    boost::algorithm::split(percentiles, percentiles_spec,
-                            boost::is_any_of(", "), boost::token_compress_on);
+    percentiles = stan::io::split(percentiles_spec, ", ", true);
     try {
       probs = percentiles_to_probs(percentiles);
     } catch (const std::invalid_argument &e) {
@@ -148,7 +147,7 @@ Options:
     for (int i = 0; i < chains.num_params(); ++i) {
       if (chains.param_name(i).length() > max_name_length)
         max_name_length = chains.param_name(i).length();
-      if (stan::io::ends_with("__", chains.param_name(i)))
+      if (stan::io::ends_with(chains.param_name(i), "__"))
         num_sampler_params++;
     }
     // don't count name 'lp__'

--- a/src/cmdstan/stansummary_helper.hpp
+++ b/src/cmdstan/stansummary_helper.hpp
@@ -11,7 +11,6 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <boost/algorithm/string.hpp>
 
 /**
  * Determine size, and number of decimals required

--- a/src/test/interface/arguments/argument_parser_test.cpp
+++ b/src/test/interface/arguments/argument_parser_test.cpp
@@ -6,7 +6,7 @@
 #include <cmdstan/arguments/argument_parser.hpp>
 #include <stan/callbacks/writer.hpp>
 #include <stan/callbacks/stream_writer.hpp>
-#include <boost/algorithm/string.hpp>
+#include <stan/io/string_utils.hpp>
 #include <stan/services/error_codes.hpp>
 #include <gtest/gtest.h>
 
@@ -48,11 +48,10 @@ class CmdStanArgumentsArgumentParser : public testing::Test {
    * double arguments, but it could be easily extended.
    */
   void check_suggestion(std::string suggestion) {
-    boost::trim(suggestion);
-    boost::replace_first(suggestion, "<double>",
+    stan::io::trim(suggestion);
+    stan::io::replace_first(suggestion, "<double>",
                          "1e-20");  // replace type with value
-    std::vector<std::string> args;
-    boost::split(args, suggestion, boost::is_any_of(" "));
+    std::vector<std::string> args = stan::io::split(suggestion, " ");
     args.insert(args.begin(), "mymodel");  // add model name
 
     // convert to char** for parse_args

--- a/src/test/interface/arguments/argument_parser_test.cpp
+++ b/src/test/interface/arguments/argument_parser_test.cpp
@@ -50,7 +50,7 @@ class CmdStanArgumentsArgumentParser : public testing::Test {
   void check_suggestion(std::string suggestion) {
     stan::io::trim(suggestion);
     stan::io::replace_first(suggestion, "<double>",
-                         "1e-20");  // replace type with value
+                            "1e-20");  // replace type with value
     std::vector<std::string> args = stan::io::split(suggestion, " ");
     args.insert(args.begin(), "mymodel");  // add model name
 

--- a/src/test/interface/arguments/singleton_argument_test.cpp
+++ b/src/test/interface/arguments/singleton_argument_test.cpp
@@ -1,8 +1,9 @@
 #include <cmdstan/arguments/singleton_argument.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <boost/lexical_cast.hpp>
 #include <gtest/gtest.h>
+#include <string>
+#include <type_traits>
 
 template <typename T>
 T argument_value() {
@@ -11,7 +12,11 @@ T argument_value() {
 
 template <typename T>
 std::string argument_string() {
-  return boost::lexical_cast<std::string>(argument_value<T>());
+  if constexpr (std::is_same_v<T, std::string>) {
+    return argument_value<T>();
+  } else {
+    return std::to_string(argument_value<T>());
+  }
 }
 
 template <>

--- a/src/test/interface/command_test.cpp
+++ b/src/test/interface/command_test.cpp
@@ -2,7 +2,7 @@
 #include <cmdstan/return_codes.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 #include <stan/services/error_codes.hpp>
-#include <boost/algorithm/string.hpp>
+#include <stan/io/string_utils.hpp>
 #include <boost/math/policies/error_handling.hpp>
 #include <gtest/gtest.h>
 #include <stdexcept>
@@ -350,12 +350,11 @@ TEST(StanUiCommand, random_seed_default) {
         + " output refresh=0 file=test/output.csv";
   std::string cmd_output = run_command(command).output;
   EXPECT_EQ(1, count_matches("y values:", cmd_output));
-  std::vector<std::string> lines;
-  split(lines, cmd_output, boost::is_any_of("\n"));
+  std::vector<std::string> lines = stan::io::split(cmd_output, "\n");
   std::string random1;
   for (std::vector<std::string>::iterator it = lines.begin(); it != lines.end();
        ++it) {
-    if (boost::starts_with(*it, "y values:")) {
+    if (stan::io::starts_with(*it, "y values:")) {
       random1.assign(*it, 9, std::string::npos);
       EXPECT_EQ(1, count_matches("[", random1));
       EXPECT_EQ(1, count_matches("]", random1));
@@ -364,11 +363,11 @@ TEST(StanUiCommand, random_seed_default) {
   }
   cmd_output = run_command(command).output;
   EXPECT_EQ(1, count_matches("y values:", cmd_output));
-  split(lines, cmd_output, boost::is_any_of("\n"));
+  lines = stan::io::split(cmd_output, "\n");
   std::string random2;
   for (std::vector<std::string>::iterator it = lines.begin(); it != lines.end();
        ++it) {
-    if (boost::starts_with(*it, "y values:")) {
+    if (stan::io::starts_with(*it, "y values:")) {
       random2.assign(*it, 9, std::string::npos);
       EXPECT_EQ(1, count_matches("[", random2));
       EXPECT_EQ(1, count_matches("]", random2));
@@ -392,12 +391,11 @@ TEST(StanUiCommand, random_seed_specified_same) {
         + " output refresh=0 file=test/output.csv";
   std::string cmd_output = run_command(command).output;
   EXPECT_EQ(1, count_matches("y values:", cmd_output));
-  std::vector<std::string> lines;
-  split(lines, cmd_output, boost::is_any_of("\n"));
+  std::vector<std::string> lines = stan::io::split(cmd_output, "\n");
   std::string random1;
   for (std::vector<std::string>::iterator it = lines.begin(); it != lines.end();
        ++it) {
-    if (boost::starts_with(*it, "y values:")) {
+    if (stan::io::starts_with(*it, "y values:")) {
       random1.assign(*it, 9, std::string::npos);
       EXPECT_EQ(1, count_matches("[", random1));
       EXPECT_EQ(1, count_matches("]", random1));
@@ -406,11 +404,11 @@ TEST(StanUiCommand, random_seed_specified_same) {
   }
   cmd_output = run_command(command).output;
   EXPECT_EQ(1, count_matches("y values:", cmd_output));
-  split(lines, cmd_output, boost::is_any_of("\n"));
+  lines = stan::io::split(cmd_output, "\n");
   std::string random2;
   for (std::vector<std::string>::iterator it = lines.begin(); it != lines.end();
        ++it) {
-    if (boost::starts_with(*it, "y values:")) {
+    if (stan::io::starts_with(*it, "y values:")) {
       random2.assign(*it, 9, std::string::npos);
       EXPECT_EQ(1, count_matches("[", random2));
       EXPECT_EQ(1, count_matches("]", random2));
@@ -434,12 +432,11 @@ TEST(StanUiCommand, random_seed_specified_different) {
         + " output refresh=0 file=test/output.csv";
   std::string cmd_output = run_command(command).output;
   EXPECT_EQ(1, count_matches("y values:", cmd_output));
-  std::vector<std::string> lines;
-  split(lines, cmd_output, boost::is_any_of("\n"));
+  std::vector<std::string> lines = stan::io::split(cmd_output, "\n");
   std::string random1;
   for (std::vector<std::string>::iterator it = lines.begin(); it != lines.end();
        ++it) {
-    if (boost::starts_with(*it, "y values:")) {
+    if (stan::io::starts_with(*it, "y values:")) {
       random1.assign(*it, 9, std::string::npos);
       EXPECT_EQ(1, count_matches("[", random1));
       EXPECT_EQ(1, count_matches("]", random1));
@@ -453,11 +450,11 @@ TEST(StanUiCommand, random_seed_specified_different) {
             + " output refresh=0 file=test/output.csv";
   cmd_output = run_command(command).output;
   EXPECT_EQ(1, count_matches("y values:", cmd_output));
-  split(lines, cmd_output, boost::is_any_of("\n"));
+  lines = stan::io::split(cmd_output, "\n");
   std::string random2;
   for (std::vector<std::string>::iterator it = lines.begin(); it != lines.end();
        ++it) {
-    if (boost::starts_with(*it, "y values:")) {
+    if (stan::io::starts_with(*it, "y values:")) {
       random2.assign(*it, 9, std::string::npos);
       EXPECT_EQ(1, count_matches("[", random2));
       EXPECT_EQ(1, count_matches("]", random2));

--- a/src/test/interface/datetime_test.cpp
+++ b/src/test/interface/datetime_test.cpp
@@ -50,10 +50,10 @@ TEST(interface, csv_header_consistency) {
     size_t equal = lhs.find("=");
     if (equal != std::string::npos) {
       name = lhs.substr(0, equal);
-      boost::trim(name);
+      stan::io::trim(name);
       if (name.compare("start_datetime") == 0) {
         value = lhs.substr(equal + 1, lhs.size());
-        boost::trim(value);
+        stan::io::trim(value);
         break;
       }
     }

--- a/src/test/interface/file_test.cpp
+++ b/src/test/interface/file_test.cpp
@@ -8,7 +8,6 @@
 #include <cmdstan/arguments/argument_parser.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 #include <test/utility.hpp>
-#include <boost/algorithm/string.hpp>
 #include <iostream>
 #include <stdexcept>
 #include <string>

--- a/src/test/interface/fixed_param_sampler_test.cpp
+++ b/src/test/interface/fixed_param_sampler_test.cpp
@@ -4,7 +4,6 @@
 #include <stan/mcmc/fixed_param_sampler.hpp>
 #include <gtest/gtest.h>
 #include <fstream>
-#include <boost/algorithm/string.hpp>
 
 using cmdstan::test::convert_model_path;
 using cmdstan::test::run_command;

--- a/src/test/interface/log_prob_test.cpp
+++ b/src/test/interface/log_prob_test.cpp
@@ -1,4 +1,5 @@
 #include <test/utility.hpp>
+#include <stan/io/string_utils.hpp>
 #include <gtest/gtest.h>
 #include <string>
 
@@ -71,9 +72,7 @@ TEST_F(CmdStan, log_prob_uparams_rdump) {
   std::vector<std::string> header;
   std::vector<double> values;
   parse_sample(convert_model_path(test_output), config, header, values);
-  std::vector<std::string> names;
-  boost::split(names, header[0], boost::is_any_of(","),
-               boost::token_compress_on);
+  std::vector<std::string> names = stan::io::split(header[0], ",", true);
   ASSERT_EQ(values.size() % names.size(), 0);
   ASSERT_EQ(names[0].compare(0, 2, std::string("lp")), 0);
   ASSERT_EQ(names[1].compare(0, 2, std::string("g_")), 0);
@@ -95,9 +94,7 @@ TEST_F(CmdStan, log_prob_uparams_multi_rdump) {
   std::vector<std::string> header;
   std::vector<double> values;
   parse_sample(convert_model_path(test_output), config, header, values);
-  std::vector<std::string> names;
-  boost::split(names, header[0], boost::is_any_of(","),
-               boost::token_compress_on);
+  std::vector<std::string> names = stan::io::split(header[0], ",", true);
   ASSERT_EQ(values.size() % names.size(), 0);
 
   // log_p values calculated externally
@@ -119,9 +116,7 @@ TEST_F(CmdStan, log_prob_cparams_rdump) {
   std::vector<std::string> header;
   std::vector<double> values;
   parse_sample(convert_model_path(test_output), config, header, values);
-  std::vector<std::string> names;
-  boost::split(names, header[0], boost::is_any_of(","),
-               boost::token_compress_on);
+  std::vector<std::string> names = stan::io::split(header[0], ",", true);
   ASSERT_TRUE(values.size() % names.size() == 0);
 
   ASSERT_FLOAT_EQ(values[0], -26.1950918);
@@ -141,9 +136,7 @@ TEST_F(CmdStan, log_prob_uparams_json) {
   std::vector<std::string> header;
   std::vector<double> values;
   parse_sample(convert_model_path(test_output), config, header, values);
-  std::vector<std::string> names;
-  boost::split(names, header[0], boost::is_any_of(","),
-               boost::token_compress_on);
+  std::vector<std::string> names = stan::io::split(header[0], ",", true);
   ASSERT_EQ(values.size() % names.size(), 0);
 
   ASSERT_FLOAT_EQ(values[0], -26.1950918);
@@ -163,9 +156,7 @@ TEST_F(CmdStan, log_prob_uparams_multi_json) {
   std::vector<std::string> header;
   std::vector<double> values;
   parse_sample(convert_model_path(test_output), config, header, values);
-  std::vector<std::string> names;
-  boost::split(names, header[0], boost::is_any_of(","),
-               boost::token_compress_on);
+  std::vector<std::string> names = stan::io::split(header[0], ",", true);
   ASSERT_EQ(values.size() % names.size(), 0);
 
   // log_p values calculated externally
@@ -187,9 +178,7 @@ TEST_F(CmdStan, log_prob_cparams_json) {
   std::vector<std::string> header;
   std::vector<double> values;
   parse_sample(convert_model_path(test_output), config, header, values);
-  std::vector<std::string> names;
-  boost::split(names, header[0], boost::is_any_of(","),
-               boost::token_compress_on);
+  std::vector<std::string> names = stan::io::split(header[0], ",", true);
   ASSERT_EQ(values.size() % names.size(), 0);
   ASSERT_FLOAT_EQ(values[0], -26.1950918);
 }
@@ -210,9 +199,7 @@ TEST_F(CmdStan, log_prob_cparams_csv) {
   std::vector<std::string> header;
   std::vector<double> values;
   parse_sample(convert_model_path(test_output), config, header, values);
-  std::vector<std::string> names;
-  boost::split(names, header[0], boost::is_any_of(","),
-               boost::token_compress_on);
+  std::vector<std::string> names = stan::io::split(header[0], ",", true);
   ASSERT_EQ(values.size() % names.size(), 0);
   ASSERT_EQ(names[0].compare(0, 2, std::string("lp")), 0);
   ASSERT_EQ(names[1].compare(std::string("g_theta")), 0);
@@ -255,9 +242,7 @@ TEST_F(CmdStan, log_prob_constrained_simplex) {
   std::vector<std::string> header;
   std::vector<double> values;
   parse_sample(convert_model_path(test_output), config, header, values);
-  std::vector<std::string> names;
-  boost::split(names, header[0], boost::is_any_of(","),
-               boost::token_compress_on);
+  std::vector<std::string> names = stan::io::split(header[0], ",", true);
   // param is 3-array of 3-simplex, unconstrained params size == 6 + lp__
   ASSERT_EQ(names.size(), 7);
   ASSERT_EQ(values.size() % names.size(), 0);

--- a/src/test/interface/optimization_output_test.cpp
+++ b/src/test/interface/optimization_output_test.cpp
@@ -1,6 +1,5 @@
 #include <test/utility.hpp>
 #include <stan/mcmc/chains.hpp>
-#include <boost/algorithm/string.hpp>
 #include <gtest/gtest.h>
 #include <fstream>
 

--- a/src/test/interface/optimization_output_test.cpp
+++ b/src/test/interface/optimization_output_test.cpp
@@ -52,11 +52,11 @@ TEST_F(CmdStan, optimize_default) {
 
   int algo_idx = idx_first_match(config, algorithm);
   EXPECT_NE(algo_idx, -1);
-  EXPECT_TRUE(boost::contains(config[algo_idx], "(Default)"));
+  EXPECT_TRUE(stan::io::contains(config[algo_idx], "(Default)"));
 
   int jacobian_idx = idx_first_match(config, jacobian);
   EXPECT_NE(jacobian_idx, -1);
-  EXPECT_TRUE(boost::contains(config[jacobian_idx], "= false (Default)"));
+  EXPECT_TRUE(stan::io::contains(config[jacobian_idx], "= false (Default)"));
 
   ASSERT_NEAR(0, values[0], 0.00001);
   auto outputs = values.size();
@@ -83,8 +83,8 @@ TEST_F(CmdStan, optimize_bfgs) {
 
   int algo_idx = idx_first_match(config, algorithm);
   EXPECT_NE(algo_idx, -1);
-  EXPECT_TRUE(boost::contains(config[algo_idx], "bfgs"));
-  EXPECT_FALSE(boost::contains(config[algo_idx], "lbfgs"));
+  EXPECT_TRUE(stan::io::contains(config[algo_idx], "bfgs"));
+  EXPECT_FALSE(stan::io::contains(config[algo_idx], "lbfgs"));
 
   ASSERT_NEAR(0, values[0], 0.00001);
   auto outputs = values.size();
@@ -111,7 +111,7 @@ TEST_F(CmdStan, optimize_lbfgs) {
 
   int algo_idx = idx_first_match(config, algorithm);
   EXPECT_NE(algo_idx, -1);
-  EXPECT_TRUE(boost::contains(config[algo_idx], "lbfgs"));
+  EXPECT_TRUE(stan::io::contains(config[algo_idx], "lbfgs"));
 
   ASSERT_NEAR(0, values[0], 0.00001);
   auto outputs = values.size();
@@ -138,7 +138,7 @@ TEST_F(CmdStan, optimize_newton) {
 
   int algo_idx = idx_first_match(config, algorithm);
   EXPECT_NE(algo_idx, -1);
-  EXPECT_TRUE(boost::contains(config[algo_idx], "newton"));
+  EXPECT_TRUE(stan::io::contains(config[algo_idx], "newton"));
 
   ASSERT_NEAR(0, values[0], 0.00001);
   auto outputs = values.size();
@@ -164,7 +164,7 @@ TEST_F(CmdStan, optimize_jacobian_adjust) {
 
   int jacobian_idx = idx_first_match(config1, jacobian);
   EXPECT_NE(jacobian_idx, -1);
-  EXPECT_TRUE(boost::contains(config1[jacobian_idx], "= false (Default)"));
+  EXPECT_TRUE(stan::io::contains(config1[jacobian_idx], "= false (Default)"));
 
   auto outputs = values1.size();
   ASSERT_NEAR(0, values1[0], 0.00001);
@@ -183,7 +183,7 @@ TEST_F(CmdStan, optimize_jacobian_adjust) {
 
   jacobian_idx = idx_first_match(config2, jacobian);
   EXPECT_NE(jacobian_idx, -1);
-  EXPECT_TRUE(boost::contains(config2[jacobian_idx], "= true"));
+  EXPECT_TRUE(stan::io::contains(config2[jacobian_idx], "= true"));
 
   ASSERT_NEAR(3.3, values2[outputs - 1], 0.01);
 }

--- a/src/test/interface/pathfinder_test.cpp
+++ b/src/test/interface/pathfinder_test.cpp
@@ -1,6 +1,7 @@
 #include <test/utility.hpp>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <algorithm>
 
 using cmdstan::test::convert_model_path;
 using cmdstan::test::count_matches;

--- a/src/test/interface/stansummary_test.cpp
+++ b/src/test/interface/stansummary_test.cpp
@@ -1,9 +1,9 @@
 #include <cmdstan/stansummary_helper.hpp>
 #include <test/utility.hpp>
 #include <stan/io/string_utils.hpp>
+#include <stan/io/ends_with.hpp>
 #include <fstream>
 #include <sstream>
-#include <boost/algorithm/string.hpp>
 #include <gtest/gtest.h>
 #include <CLI11/CLI11.hpp>
 
@@ -232,7 +232,7 @@ TEST(CommandStansummary, param_tests) {
   for (int i = 0; i < chains.num_params(); ++i) {
     if (chains.param_name(i).length() > max_name_length)
       max_name_length = chains.param_name(i).length();
-    if (stan::io::ends_with(chains.param_name(i), "__"))
+    if (stan::io::ends_with("__", chains.param_name(i)))
       num_sampler_params++;
   }
   EXPECT_EQ(num_sampler_params, 6);

--- a/src/test/interface/stansummary_test.cpp
+++ b/src/test/interface/stansummary_test.cpp
@@ -1,6 +1,6 @@
 #include <cmdstan/stansummary_helper.hpp>
 #include <test/utility.hpp>
-#include <stan/io/ends_with.hpp>
+#include <stan/io/string_utils.hpp>
 #include <fstream>
 #include <sstream>
 #include <boost/algorithm/string.hpp>
@@ -232,7 +232,7 @@ TEST(CommandStansummary, param_tests) {
   for (int i = 0; i < chains.num_params(); ++i) {
     if (chains.param_name(i).length() > max_name_length)
       max_name_length = chains.param_name(i).length();
-    if (stan::io::ends_with("__", chains.param_name(i)))
+    if (stan::io::ends_with(chains.param_name(i), "__"))
       num_sampler_params++;
   }
   EXPECT_EQ(num_sampler_params, 6);
@@ -284,7 +284,7 @@ TEST(CommandStansummary, no_args) {
   path_separator.push_back(get_path_separator());
   std::string command = "bin" + path_separator + "stansummary";
   run_command_output out = run_command(command);
-  EXPECT_TRUE(boost::algorithm::contains(out.output, expected_message));
+  EXPECT_TRUE(stan::io::contains(out.output, expected_message));
   ASSERT_TRUE(out.hasError)
       << "\"" << out.command << "\" failed to quit with an error";
 }
@@ -297,7 +297,7 @@ TEST(CommandStansummary, bad_input_files) {
   std::string csv_file = "src" + path_separator + "test" + path_separator
                          + "interface" + path_separator + "no_such_file";
   run_command_output out = run_command(command + " " + csv_file);
-  EXPECT_TRUE(boost::algorithm::contains(out.output, expected_message));
+  EXPECT_TRUE(stan::io::contains(out.output, expected_message));
   ASSERT_TRUE(out.hasError)
       << "\"" << out.command << "\" failed to quit with an error";
 }
@@ -315,7 +315,7 @@ TEST(CommandStansummary, bad_csv_file_arg) {
 
   run_command_output out
       = run_command(command + " " + arg_csv_file + " " + csv_file);
-  EXPECT_TRUE(boost::algorithm::contains(out.output, expected_message));
+  EXPECT_TRUE(stan::io::contains(out.output, expected_message));
   ASSERT_TRUE(out.hasError)
       << "\"" << out.command << "\" failed to quit with an error";
 }
@@ -332,14 +332,14 @@ TEST(CommandStansummary, bad_sig_figs_arg) {
 
   run_command_output out
       = run_command(command + " " + arg_sig_figs + " " + csv_file);
-  EXPECT_TRUE(boost::algorithm::contains(out.output, expected_message));
+  EXPECT_TRUE(stan::io::contains(out.output, expected_message));
   ASSERT_TRUE(out.hasError)
       << "\"" << out.command << "\" failed to quit with an error";
 
   arg_sig_figs = "--sig_figs 101";
   expected_message = "--sig_figs: Value 101 not in range";
   out = run_command(command + " " + arg_sig_figs + " " + csv_file);
-  EXPECT_TRUE(boost::algorithm::contains(out.output, expected_message));
+  EXPECT_TRUE(stan::io::contains(out.output, expected_message));
   ASSERT_TRUE(out.hasError)
       << "\"" << out.command << "\" failed to quit with an error";
 }
@@ -356,20 +356,20 @@ TEST(CommandStansummary, bad_autocorr_arg) {
 
   run_command_output out
       = run_command(command + " " + arg_autocorr + " " + csv_file);
-  EXPECT_TRUE(boost::algorithm::contains(out.output, expected_message));
+  EXPECT_TRUE(stan::io::contains(out.output, expected_message));
   ASSERT_TRUE(out.hasError)
       << "\"" << out.command << "\" failed to quit with an error";
 
   arg_autocorr = "--autocorr 0";
   out = run_command(command + " " + arg_autocorr + " " + csv_file);
-  EXPECT_TRUE(boost::algorithm::contains(out.output, expected_message));
+  EXPECT_TRUE(stan::io::contains(out.output, expected_message));
   ASSERT_TRUE(out.hasError)
       << "\"" << out.command << "\" failed to quit with an error";
 
   expected_message = "not a valid chain id";
   arg_autocorr = "--autocorr 2";
   out = run_command(command + " " + arg_autocorr + " " + csv_file);
-  EXPECT_TRUE(boost::algorithm::contains(out.output, expected_message));
+  EXPECT_TRUE(stan::io::contains(out.output, expected_message));
   ASSERT_TRUE(out.hasError)
       << "\"" << out.command << "\" failed to quit with an error";
 }
@@ -386,19 +386,19 @@ TEST(CommandStansummary, bad_percentiles_arg) {
   std::string arg_percentiles = "--percentiles -1";
   run_command_output out
       = run_command(command + " " + arg_percentiles + " " + csv_file);
-  EXPECT_TRUE(boost::algorithm::contains(out.output, expected_message));
+  EXPECT_TRUE(stan::io::contains(out.output, expected_message));
   ASSERT_TRUE(out.hasError)
       << "\"" << out.command << "\" failed to quit with an error";
 
   arg_percentiles = "--percentiles \"101\"";
   out = run_command(command + " " + arg_percentiles + " " + csv_file);
-  EXPECT_TRUE(boost::algorithm::contains(out.output, expected_message));
+  EXPECT_TRUE(stan::io::contains(out.output, expected_message));
   ASSERT_TRUE(out.hasError)
       << "\"" << out.command << "\" failed to quit with an error";
 
   arg_percentiles = "--percentiles \"2,30,5\"";
   out = run_command(command + " " + arg_percentiles + " " + csv_file);
-  EXPECT_TRUE(boost::algorithm::contains(out.output, expected_message));
+  EXPECT_TRUE(stan::io::contains(out.output, expected_message));
   ASSERT_TRUE(out.hasError)
       << "\"" << out.command << "\" failed to quit with an error";
 
@@ -420,7 +420,7 @@ TEST(CommandStansummary, bad_include_param_args) {
 
   run_command_output out
       = run_command(command + " " + arg_include_param + " " + csv_file);
-  EXPECT_TRUE(boost::algorithm::contains(out.output, expected_message));
+  EXPECT_TRUE(stan::io::contains(out.output, expected_message));
   ASSERT_TRUE(out.hasError)
       << "\"" << out.command << "\" failed to quit with an error";
 }

--- a/src/test/utility.hpp
+++ b/src/test/utility.hpp
@@ -1,7 +1,7 @@
 #ifndef TEST__MODELS__UTILITY_HPP
 #define TEST__MODELS__UTILITY_HPP
 
-#include <boost/algorithm/string.hpp>
+#include <stan/io/string_utils.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <rapidjson/document.h>
 #include <gtest/gtest.h>
@@ -15,7 +15,7 @@
 #include <sys/types.h>
 
 #define EXPECT_IN_STRING(needle, haystack)                  \
-  EXPECT_TRUE(boost::algorithm::contains(haystack, needle)) \
+  EXPECT_TRUE(stan::io::contains(haystack, needle)) \
       << "could not find '" << needle << "' in '" << haystack << "'";
 
 // TODO: a similar macro is defined in both Stan and Stan Math
@@ -238,11 +238,10 @@ std::vector<std::pair<std::string, std::string>> parse_command_output(
   size_t equal_pos = command_output.find("=", start);
 
   while (equal_pos != string::npos) {
-    using boost::trim;
     option = command_output.substr(start, equal_pos - start);
     value = command_output.substr(equal_pos + 1, end - equal_pos - 1);
-    trim(option);
-    trim(value);
+    stan::io::trim(option);
+    stan::io::trim(value);
     output.push_back(pair<string, string>(option, value));
     start = end + 1;
     end = command_output.find("\n", start);
@@ -297,7 +296,7 @@ int idx_first_match(const std::vector<std::string> &lines,
                     std::string &substring) {
   int idx = -1;
   for (int n = 0; n < lines.size(); ++n) {
-    if (boost::contains(lines[n], substring)) {
+    if (stan::io::contains(lines[n], substring)) {
       idx = n;
       break;
     }

--- a/src/test/utility.hpp
+++ b/src/test/utility.hpp
@@ -14,7 +14,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#define EXPECT_IN_STRING(needle, haystack)                  \
+#define EXPECT_IN_STRING(needle, haystack)          \
   EXPECT_TRUE(stan::io::contains(haystack, needle)) \
       << "could not find '" << needle << "' in '" << haystack << "'";
 
@@ -189,7 +189,7 @@ run_command_output run_command(std::string command) {
   return run_command_output(
       command, output,
       std::chrono::duration_cast<std::chrono::milliseconds>(time_end
-                                                              - time_start)
+                                                            - time_start)
           .count(),
       err_code);
 }

--- a/src/test/utility.hpp
+++ b/src/test/utility.hpp
@@ -2,10 +2,10 @@
 #define TEST__MODELS__UTILITY_HPP
 
 #include <stan/io/string_utils.hpp>
-#include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <rapidjson/document.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <stdexcept>
 #include <fstream>
 #include <iostream>
@@ -155,8 +155,6 @@ std::ostream &operator<<(std::ostream &os, const run_command_output &out) {
  * @return the system output of the command
  */
 run_command_output run_command(std::string command) {
-  using boost::posix_time::microsec_clock;
-  using boost::posix_time::ptime;
   FILE *in;
   std::string command_plus = command + " 2>&1";  // put stderr to stdout
   in = popen(command_plus.c_str(), "r");
@@ -172,10 +170,10 @@ run_command_output run_command(std::string command) {
   std::string output;
   char buf[1024];
   size_t count;
-  ptime time_start(microsec_clock::universal_time());  // start timer
+  auto time_start = std::chrono::system_clock::now();
   while ((count = fread(&buf, 1, 1024, in)) > 0)
     output += std::string(&buf[0], &buf[count]);
-  ptime time_end(microsec_clock::universal_time());  // end timer
+  auto time_end = std::chrono::system_clock::now();
 
   // bits 15-8 is err code, bit 7 if core dump, bits 6-0 is signal number
   int err_code = pclose(in);
@@ -189,7 +187,11 @@ run_command_output run_command(std::string command) {
     throw std::runtime_error(err_msg.c_str());
   }
   return run_command_output(
-      command, output, (time_end - time_start).total_milliseconds(), err_code);
+      command, output,
+      std::chrono::duration_cast<std::chrono::milliseconds>(time_end
+                                                              - time_start)
+          .count(),
+      err_code);
 }
 
 /**


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Replaces the `boost/algorithm/string` usages with the string utilities added to the Stan library and replaces `boost::posix_time` with `std::chrono`.

#### Intended Effect:

Reduce boost dependency footprint

#### How to Verify:

Tests and models all run as usual

#### Side Effects:

N/A

#### Documentation:

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
