### PR TITLE
Add quoting to `make/program` to help when spaces are in paths

### DIFF
--- a/make/program
+++ b/make/program
@@ -69,7 +69,7 @@ endif
 %.hpp : %.stan bin/stanc$(EXE)
 	@echo ''
 	@echo '--- Translating Stan model to C++ code ---'
-	$(WINE) bin/stanc$(EXE) $(STANCFLAGS) --o=$(subst  \,/,$@) $(subst  \,/,$<)
+	$(WINE) bin/stanc$(EXE) $(STANCFLAGS) --o="$(subst  \,/,$@)" "$(subst  \,/,$<)"
 
 %.d: %.hpp
 
@@ -80,12 +80,12 @@ endif
 %.o : %.hpp $(USER_HEADER)
 	@echo ''
 	@echo '--- Compiling C++ code ---'
-	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)
+	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -x c++ -o "$(subst \,/,$*).o" "$(subst \,/,$<)"
 
 %$(EXE) : %.o $(CMDSTAN_MAIN_O) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS) $(PRECOMPILED_MODEL_HEADER)
 	@echo ''
 	@echo '--- Linking model ---'
-	$(LINK.cpp) $(subst \,/,$*.o) $(CMDSTAN_MAIN_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS) $(subst \,/,$(OUTPUT_OPTION))
+	$(LINK.cpp) "$(subst \,/,$*.o)" $(CMDSTAN_MAIN_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS) -o "$(subst \,/,$@)"
 
 ifeq ($(OS),Windows_NT)
 ifneq (,$(TBB_TARGETS))


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

By quoting strings derived from the user input to the makefiles, we can fix the build of models that live in a path with spaces. 

C.f. https://github.com/roualdes/bridgestan/pull/341 for similar in bridgestan; note that in particular, you still need to properly quote these strings when invoking `make` to benefit!

#### Intended Effect:

#### How to Verify:

```
mkdir "test path"
echo 'model {}' > "test path/model.stan"
make "test path/model"
```

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
