### PR TITLE
Jenkins: use stanorg/ci:v1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ if (!params.downstream) {
 
 properties(props)
 
+def image = 'stanorg/ci:v1'
 def commit
 def runRemainingStages = false
 def WIN_CXX = 'g++'
@@ -35,7 +36,7 @@ catchError {
     'GIT_COMMITTER_NAME=Stan Jenkins',
     'GIT_COMMITTER_EMAIL=mc.stanislaw@gmail.com'
   ]) {
-    runPod(image: "stanorg/ci:gpu", cpus: 2) {
+    runPod(image: image, cpus: 2) {
       commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
       runRemainingStages = params.downstream || params.run_all || filesChanged('src/cmdstan', 'src/test', 'lib', 'examples', 'make', 'stan', 'install-tbb.bat', 'makefile', 'runCmdStanTests.py', 'test-all.sh', 'Jenkinsfile')
 
@@ -110,7 +111,7 @@ up the autoformatter locally.  (Check console output at ${env.BUILD_URL})
           }
         }
       }, linux: {
-        runPod(image: "stanorg/ci:gpu", checkout: false) {
+        runPod(image: image, checkout: false) {
           stage('Linux interface tests with MPI') {
             prepTests("""CXX=${MPI_CXX}
 STAN_MPI=true
@@ -155,7 +156,7 @@ CXX_TYPE=gcc""")
       }
     }
     if (env.TAG_NAME || params.build_tarballs) {
-      runPod(image: "stanorg/ci:gpu", checkout: false) {
+      runPod(image: image, checkout: false) {
         def download_stanc = { args ->
           def platform = args.platform ?: 'linux';
           if (params.stanc3_bin_url != 'nightly') {


### PR DESCRIPTION
This is the same image now used by the other repositories for C++ compilation.

#### Submisison Checklist

- [x] Run tests: `./runCmdStanTests.py src/test`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
